### PR TITLE
feat: consumer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ config :pulsar,
   ],
   consumers: [
     my_consumer: [
-        conn: :foo,
         callback: MyApp.MyConsumer,
         subscription_name: "my-app-my-consumer-subscription",
         subscription_type: "Exclusive",

--- a/lib/pulsar/application.ex
+++ b/lib/pulsar/application.ex
@@ -13,17 +13,20 @@ defmodule Pulsar.Application do
         # Registry for broker processes
         {Registry, keys: :unique, name: Pulsar.BrokerRegistry},
 
+        # Registry for consumer group processes
+        {Registry, keys: :unique, name: Pulsar.ConsumerGroupRegistry},
+
         # DynamicSupervisor for broker processes
         {DynamicSupervisor, strategy: :one_for_one, name: Pulsar.BrokerSupervisor},
 
-        # DynamicSupervisor for consumer processes (started via API)
+        # DynamicSupervisor for consumer group processes (started via API)
         {DynamicSupervisor, strategy: :one_for_one, name: Pulsar.ConsumerSupervisor},
 
         # Bootstrap broker (if configured)
         bootstrap_broker_spec(bootstrap_host),
 
-        # Consumer processes based on configuration
-        consumer_supervisor_spec(consumers)
+        # Consumer group processes based on configuration
+        consumer_group_supervisor_spec(consumers)
       ]
       |> List.flatten()
       |> Enum.reject(&is_nil/1)
@@ -50,35 +53,39 @@ defmodule Pulsar.Application do
     }
   end
 
-  defp consumer_supervisor_spec([]), do: nil
+  defp consumer_group_supervisor_spec([]), do: nil
 
-  defp consumer_supervisor_spec(consumers) do
-    consumer_children =
+  defp consumer_group_supervisor_spec(consumers) do
+    consumer_group_children =
       consumers
       |> Enum.map(fn {consumer_name, consumer_opts} ->
         topic = Keyword.fetch!(consumer_opts, :topic)
         subscription_name = Keyword.fetch!(consumer_opts, :subscription_name)
         subscription_type = Keyword.fetch!(consumer_opts, :subscription_type)
         callback_module = Keyword.fetch!(consumer_opts, :callback)
+        consumer_count = Keyword.get(consumer_opts, :consumer_count, 1)
+        init_args = Keyword.get(consumer_opts, :init_args, [])
+
+        consumer_group_opts = [
+          topic: topic,
+          subscription_name: subscription_name,
+          subscription_type: subscription_type,
+          callback_module: callback_module,
+          consumer_count: consumer_count,
+          init_args: init_args
+        ]
 
         %{
-          id: {:consumer, consumer_name},
-          start:
-            {Pulsar.Consumer, :start_link,
-             [
-               topic,
-               subscription_name,
-               subscription_type,
-               callback_module
-             ]},
+          id: {:consumer_group, consumer_name},
+          start: {Pulsar.ConsumerGroup, :start_link, [consumer_group_opts]},
           restart: :permanent,
-          type: :worker
+          type: :supervisor
         }
       end)
 
     %{
-      id: :consumer_supervisor,
-      start: {Supervisor, :start_link, [consumer_children, [strategy: :one_for_one]]},
+      id: :consumer_group_supervisor,
+      start: {Supervisor, :start_link, [consumer_group_children, [strategy: :one_for_one]]},
       restart: :permanent,
       type: :supervisor
     }

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -588,6 +588,18 @@ defmodule Pulsar.Broker do
     {:keep_state, new_broker}
   end
 
+  defp handle_command(%Binary.CommandError{request_id: request_id} = error, broker) do
+    reply = {:error, {error.error, error.message}}
+    new_broker = reply_to_request(broker, request_id, reply)
+    {:keep_state, new_broker}
+  end
+
+  defp handle_command(%Binary.CommandSuccess{request_id: request_id} = success, broker) do
+    reply = {:ok, success}
+    new_broker = reply_to_request(broker, request_id, reply)
+    {:keep_state, new_broker}
+  end
+
   defp handle_command(%Binary.CommandMessage{consumer_id: consumer_id} = command, broker) do
     case Map.get(broker.consumers, consumer_id) do
       nil ->

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -128,11 +128,11 @@ defmodule Pulsar.Consumer do
     else
       {:error, :no_brokers_available} ->
         Logger.error("No brokers available for service discovery")
-        {:stop, :no_brokers_available}
+        {:error, :no_brokers_available}
 
       {:error, reason} ->
         Logger.error("Consumer initialization failed: #{inspect(reason)}")
-        {:stop, {:initialization_failed, reason}}
+        {:error, {:initialization_failed, reason}}
     end
   end
 

--- a/lib/pulsar/consumer_group.ex
+++ b/lib/pulsar/consumer_group.ex
@@ -1,0 +1,206 @@
+defmodule Pulsar.ConsumerGroup do
+  @moduledoc """
+  Consumer Group supervisor that manages multiple consumer instances for a single subscription.
+
+  A consumer group represents a logical grouping of consumer processes that share the same:
+  - Topic
+  - Subscription name  
+  - Subscription type
+  - Callback module
+
+  The consumer group acts as a supervisor for these consumer instances, providing:
+  - Fault isolation per consumer group
+  - Simplified management (start/stop the group as a unit)
+  - Independent restart strategies per group
+  - Easy scaling (add/remove consumers from a group)
+
+  ## Examples
+
+      # Start a consumer group with multiple consumers
+      {:ok, group_pid} = Pulsar.ConsumerGroup.start_link(
+        topic: "my-topic",
+        subscription_name: "my-subscription", 
+        subscription_type: :Shared,
+        callback_module: MyApp.MessageHandler,
+        consumer_count: 3
+      )
+
+      # Get information about the consumer group
+      info = Pulsar.ConsumerGroup.get_info(group_pid)
+
+      # Stop the entire consumer group
+      Pulsar.ConsumerGroup.stop(group_pid)
+  """
+
+  use Supervisor
+  require Logger
+
+  defstruct [
+    :topic,
+    :subscription_name,
+    :subscription_type,
+    :callback_module,
+    :consumer_count,
+    :init_args,
+    :group_id
+  ]
+
+  @type t :: %__MODULE__{
+          topic: String.t(),
+          subscription_name: String.t(),
+          subscription_type: atom(),
+          callback_module: module(),
+          consumer_count: pos_integer(),
+          init_args: term(),
+          group_id: String.t()
+        }
+
+  ## Public API
+
+  @doc """
+  Starts a consumer group supervisor.
+
+  ## Options
+
+  - `:topic` - The topic to subscribe to (required)
+  - `:subscription_name` - Name of the subscription (required)
+  - `:subscription_type` - Type of subscription (required, e.g., :Exclusive, :Shared)
+  - `:callback_module` - Module that implements `Pulsar.Consumer.Callback` behaviour (required)
+  - `:consumer_count` - Number of consumer processes to start (default: 1)
+  - `:init_args` - Arguments passed to callback module's init/1 function (default: [])
+  - `:name` - Name for the supervisor process (optional)
+
+  Returns `{:ok, pid()}` on success, `{:error, reason}` on failure.
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    # Extract required parameters
+    topic = Keyword.fetch!(opts, :topic)
+    subscription_name = Keyword.fetch!(opts, :subscription_name)
+    subscription_type = Keyword.fetch!(opts, :subscription_type)
+    callback_module = Keyword.fetch!(opts, :callback_module)
+
+    # Extract optional parameters
+    consumer_count = Keyword.get(opts, :consumer_count, 1)
+    init_args = Keyword.get(opts, :init_args, [])
+    name = Keyword.get(opts, :name)
+
+    # Generate unique group ID
+    group_id = generate_group_id(topic, subscription_name)
+
+    config = %__MODULE__{
+      topic: topic,
+      subscription_name: subscription_name,
+      subscription_type: subscription_type,
+      callback_module: callback_module,
+      consumer_count: consumer_count,
+      init_args: init_args,
+      group_id: group_id
+    }
+
+    supervisor_opts = if name, do: [name: name], else: []
+    Supervisor.start_link(__MODULE__, config, supervisor_opts)
+  end
+
+  @doc """
+  Gets information about a consumer group.
+
+  Returns a map with details about the consumer group including:
+  - Consumer group configuration
+  - List of consumer PIDs
+  - Consumer count
+  """
+  @spec get_info(pid()) :: map()
+  def get_info(group_pid) do
+    children = Supervisor.which_children(group_pid)
+    consumer_pids = Enum.map(children, fn {_id, pid, _type, _modules} -> pid end)
+
+    %{
+      group_pid: group_pid,
+      consumer_pids: consumer_pids,
+      consumer_count: length(consumer_pids),
+      active_consumers: length(Enum.filter(consumer_pids, &Process.alive?/1))
+    }
+  end
+
+  @doc """
+  Lists all consumer PIDs in the group.
+  """
+  @spec list_consumers(pid()) :: [pid()]
+  def list_consumers(group_pid) do
+    group_pid
+    |> Supervisor.which_children()
+    |> Enum.map(fn {_id, pid, _type, _modules} -> pid end)
+  end
+
+  @doc """
+  Gets the count of consumers in the group.
+  """
+  @spec consumer_count(pid()) :: non_neg_integer()
+  def consumer_count(group_pid) do
+    group_pid
+    |> Supervisor.count_children()
+    |> Map.get(:active, 0)
+  end
+
+  @doc """
+  Stops a consumer group and all its consumers.
+  """
+  @spec stop(pid()) :: :ok
+  def stop(group_pid) do
+    Process.exit(group_pid, :shutdown)
+    :ok
+  end
+
+  ## Supervisor Callbacks
+
+  @impl Supervisor
+  def init(config) do
+    %__MODULE__{
+      topic: topic,
+      subscription_name: subscription_name,
+      subscription_type: subscription_type,
+      callback_module: callback_module,
+      consumer_count: consumer_count,
+      init_args: init_args,
+      group_id: group_id
+    } = config
+
+    Logger.info("Starting consumer group #{group_id} with #{consumer_count} consumers")
+
+    # Create child specifications for each consumer
+    children =
+      for i <- 1..consumer_count do
+        consumer_id = "#{group_id}-consumer-#{i}"
+
+        %{
+          id: consumer_id,
+          start: {
+            Pulsar.Consumer,
+            :start_link,
+            [topic, subscription_name, subscription_type, callback_module, [init_args: init_args]]
+          },
+          restart: :transient,
+          type: :worker
+        }
+      end
+
+    # Use :one_for_one strategy - if one consumer fails, only restart that consumer
+    opts = [strategy: :one_for_one]
+
+    Supervisor.init(children, opts)
+  end
+
+  ## Public Utility Functions
+
+  @doc """
+  Generates a unique group ID based on topic and subscription name.
+
+  Used internally and by the main Pulsar module for consistency.
+  """
+  @spec generate_group_id(String.t(), String.t()) :: String.t()
+  def generate_group_id(topic, subscription_name) do
+    timestamp = System.unique_integer([:positive])
+    "#{topic}-#{subscription_name}-#{timestamp}"
+  end
+end

--- a/test/integration/consumer_test.exs
+++ b/test/integration/consumer_test.exs
@@ -38,13 +38,16 @@ defmodule Pulsar.Integration.ConsumerTest do
 
   describe "Consumer Integration" do
     test "produce and consume messages" do
-      {:ok, consumer_pid} =
+      {:ok, group_pid} =
         Pulsar.start_consumer(
           @test_topic,
           @test_subscription <> "-e2e",
           :Shared,
           Pulsar.DummyConsumer
         )
+
+      # Get the individual consumer PID from the group
+      [consumer_pid] = Pulsar.ConsumerGroup.list_consumers(group_pid)
 
       Process.sleep(3000)
       TestHelper.produce_messages(@test_topic, @messages)
@@ -57,7 +60,7 @@ defmodule Pulsar.Integration.ConsumerTest do
     end
 
     test "Key_Shared subscription with multiple consumers" do
-      {:ok, consumer_pids} =
+      {:ok, group_pid} =
         Pulsar.start_consumer(
           @test_topic,
           @test_subscription <> "-key-shared",
@@ -66,6 +69,7 @@ defmodule Pulsar.Integration.ConsumerTest do
           consumer_count: 2
         )
 
+      consumer_pids = Pulsar.ConsumerGroup.list_consumers(group_pid)
       assert length(consumer_pids) == 2
       [consumer1_pid, consumer2_pid] = consumer_pids
 
@@ -113,7 +117,7 @@ defmodule Pulsar.Integration.ConsumerTest do
     end
 
     test "Shared subscription with multiple consumers (round-robin)" do
-      {:ok, consumer_pids} =
+      {:ok, group_pid} =
         Pulsar.start_consumer(
           @test_topic,
           @test_subscription <> "-shared",
@@ -122,6 +126,7 @@ defmodule Pulsar.Integration.ConsumerTest do
           consumer_count: 2
         )
 
+      consumer_pids = Pulsar.ConsumerGroup.list_consumers(group_pid)
       assert length(consumer_pids) == 2
       [consumer1_pid, consumer2_pid] = consumer_pids
 
@@ -145,7 +150,7 @@ defmodule Pulsar.Integration.ConsumerTest do
     end
 
     test "Failover subscription with multiple consumers" do
-      {:ok, consumer_pids} =
+      {:ok, group_pid} =
         Pulsar.start_consumer(
           @test_topic,
           @test_subscription <> "-failover",
@@ -154,6 +159,7 @@ defmodule Pulsar.Integration.ConsumerTest do
           consumer_count: 2
         )
 
+      consumer_pids = Pulsar.ConsumerGroup.list_consumers(group_pid)
       assert length(consumer_pids) == 2
       [consumer1_pid, consumer2_pid] = consumer_pids
 
@@ -187,7 +193,7 @@ defmodule Pulsar.Integration.ConsumerTest do
       # In Exclusive mode, only one consumer should be allowed to subscribe
       # The second consumer should fail to start because exclusive subscription
       # only allows one consumer at a time
-      {:ok, consumer_pids} =
+      {:ok, group_pid} =
         Pulsar.start_consumer(
           @test_topic,
           @test_subscription <> "-exclusive",
@@ -196,6 +202,7 @@ defmodule Pulsar.Integration.ConsumerTest do
           consumer_count: 2
         )
 
+      consumer_pids = Pulsar.ConsumerGroup.list_consumers(group_pid)
       assert length(consumer_pids) == 2
       [consumer1_pid, _consumer2_pid] = consumer_pids
 


### PR DESCRIPTION
### Description

Introduce **consumer groups**, which allow us to start all instances of the same consumer under their own supervisor, as opposed to used a "global" supervisor for all consumers.

Besides providing a cleaner architecture, this also opens up new opportunities - such as defining different restart strategies for the different consumers. For example, depending on the subscription type.