### PR TITLE
Move Pulsar start/stop logic to test_helper

### DIFF
--- a/test/integration/connection_test.exs
+++ b/test/integration/connection_test.exs
@@ -10,13 +10,7 @@ defmodule Pulsar.Integration.ConnectionTest do
   @consumer_callback Pulsar.Test.Support.DummyConsumer
 
   setup_all do
-    :ok = System.start_pulsar()
-
     :ok = System.create_topic(@topic)
-
-    on_exit(fn ->
-      :ok = System.stop_pulsar()
-    end)
   end
 
   setup do

--- a/test/integration/consumer_test.exs
+++ b/test/integration/consumer_test.exs
@@ -19,14 +19,6 @@ defmodule Pulsar.Integration.ConsumerTest do
     {"key4", "Message 1 for key4 - #{:os.system_time(:millisecond)}"}
   ]
 
-  setup_all do
-    :ok = System.start_pulsar()
-
-    on_exit(fn ->
-      :ok = System.stop_pulsar()
-    end)
-  end
-
   setup do
     broker = System.broker()
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,11 @@
+alias Pulsar.Test.Support.System
+
 Application.ensure_all_started(:telemetry_test)
+
+:ok = System.start_pulsar()
+
 ExUnit.start()
+
+ExUnit.after_suite(fn _result ->
+  :ok = System.stop_pulsar()
+end)


### PR DESCRIPTION
By starting (and stopping) the pulsar cluster before (and after) the entire test suite we can avoid adding that overhead in every integration test file.