### PR TITLE
fix: verbose logs when consumer in crash loop

### DIFF
--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -596,6 +596,10 @@ defmodule Pulsar.Consumer do
     )
   end
 
+  defp close_consumer(nil, _consumer_id) do
+    {:ok, :skipped}
+  end
+
   defp close_consumer(broker_pid, consumer_id) do
     close_consumer_command = %Binary.CommandCloseConsumer{
       consumer_id: consumer_id


### PR DESCRIPTION
### Description

Let the consumer process terminate gracefully even if there is no broker process. This removes some noise for the error logs, which makes finding the root cause of potential issue much easier.

Close #27.