### PR TITLE
deps: bump erlang and elixir versions to 29 and 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
         path: |
           priv/plts
         key: |
-          plt-${{ runner.os }}-${{ hashFiles('**/mise.toml') }}-${{ hashFiles('**/mix.lock') }}
+          plt-${{ runner.os }}-${{ hashFiles('.mise.toml') }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          plt-${{ runner.os }}-${{ hashFiles('**/mise.toml') }}-
+          plt-${{ runner.os }}-${{ hashFiles('.mise.toml') }}-
 
     - name: Get Mix dependencies
       run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         echo "127.0.0.1 broker1 broker2" | sudo tee -a /etc/hosts
 
     - name: Run ${{ matrix.suite }} tests
-      run: mix coveralls.github test/integration/${{ matrix.suite }}
+      run: mix coveralls.github test/integration/${{ matrix.suite }} --parallel
 
     - name: Publish Test Report
       uses: dorny/test-reporter@v2.2.0
@@ -138,3 +138,15 @@ jobs:
         name: Test Results - ${{ matrix.suite }}
         path: test/reports/junit.xml
         reporter: java-junit
+
+  finish-coverage:
+    name: Finish Coverage
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Close coveralls parallel build
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
-elixir = "1.18.4"
-erlang = "28.1"
+elixir = "1.20"
+erlang = "29.0"
 protoc = "25.1"
 
 [env]

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -908,7 +908,7 @@ defmodule Pulsar.Broker do
 
   defp parse_data(data, buffer, pending_bytes, broker, commands) when pending_bytes > 0 do
     case data do
-      <<missing_chunk::bytes-size(pending_bytes), rest::binary>> ->
+      <<missing_chunk::bytes-size(^pending_bytes), rest::binary>> ->
         command = Pulsar.Protocol.decode(buffer <> missing_chunk)
         parse_data(rest, <<>>, 0, broker, [command | commands])
 

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -1104,7 +1104,7 @@ defmodule Pulsar.Consumer do
 
     payload_size = single_metadata.payload_size
 
-    <<payload::bytes-size(payload_size), rest::binary>> = data
+    <<payload::bytes-size(^payload_size), rest::binary>> = data
 
     # Build individual message as {metadata, payload} tuple
     message = {single_metadata, payload}

--- a/lib/pulsar/consumer/chunked_message_context.ex
+++ b/lib/pulsar/consumer/chunked_message_context.ex
@@ -7,8 +7,6 @@ defmodule Pulsar.Consumer.ChunkedMessageContext do
   chunks in any order, assembling the complete payload once all chunks are received.
   """
 
-  require Logger
-
   defstruct [
     :uuid,
     :chunks,

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -815,7 +815,7 @@ defmodule Pulsar.Producer do
         offset = chunk_id * chunk_size
         remaining = payload_size - offset
         current_chunk_size = min(remaining, chunk_size)
-        <<_skip::binary-size(offset), chunk_data::binary-size(current_chunk_size), _rest::binary>> = payload
+        <<_skip::binary-size(^offset), chunk_data::binary-size(^current_chunk_size), _rest::binary>> = payload
 
         chunk_metadata = %{
           uuid: uuid,

--- a/mix.exs
+++ b/mix.exs
@@ -14,14 +14,6 @@ defmodule Pulsar.MixProject do
         plt_add_apps: [:mix, :ex_unit]
       ],
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test,
-        "coveralls.cobertura": :test,
-        "coveralls.github": :test
-      ],
       aliases: aliases(),
       name: "Pulsar",
       description: description(),
@@ -38,6 +30,19 @@ defmodule Pulsar.MixProject do
         groups_for_extras: [
           Guides: ~r/docs\/.*/
         ]
+      ]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test,
+        "coveralls.cobertura": :test,
+        "coveralls.github": :test
       ]
     ]
   end

--- a/test/integration/client/common_test.exs
+++ b/test/integration/client/common_test.exs
@@ -3,8 +3,6 @@ defmodule Pulsar.Integration.Client.CommonTest do
 
   alias Pulsar.Test.Support.System
 
-  require Logger
-
   @moduletag :integration
 
   test "can spawn multiple clients at once" do

--- a/test/integration/client/reliability_test.exs
+++ b/test/integration/client/reliability_test.exs
@@ -5,8 +5,6 @@ defmodule Pulsar.Integration.Client.ReliabilityTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :reliability_test_client
   @topic "persistent://public/default/reliability-test-topic"

--- a/test/integration/client/service_discovery_test.exs
+++ b/test/integration/client/service_discovery_test.exs
@@ -7,8 +7,6 @@ defmodule Pulsar.Integration.Client.ServiceDiscoveryTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :service_discovery_test_client
   @topic "persistent://public/default/service-discovery-test-topic"

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -5,8 +5,6 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :dead_letter_policy_test_client
   @topic "persistent://public/default/dlq-test-topic"

--- a/test/integration/producer/access_modes_test.exs
+++ b/test/integration/producer/access_modes_test.exs
@@ -6,8 +6,6 @@ defmodule Pulsar.Integration.AccessModesTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :access_modes_test_client
   @shared_topic "persistent://public/default/producer-shared-test"

--- a/test/integration/producer/common_test.exs
+++ b/test/integration/producer/common_test.exs
@@ -6,8 +6,6 @@ defmodule Pulsar.Integration.Producer.CommonTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :producer_common_test_client
   @topic "persistent://public/default/producer-common-test"

--- a/test/integration/producer/compression_test.exs
+++ b/test/integration/producer/compression_test.exs
@@ -5,8 +5,6 @@ defmodule Pulsar.Integration.Producer.CompressionTest do
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
 
-  require Logger
-
   @moduletag :integration
   @client :producer_compression_test_client
   @topic "persistent://public/default/producer-compression-test"


### PR DESCRIPTION
### Description

Bump Erlang and Elixir versions to `29` and `1.20` respectively.