### PR TITLE
ci: configure dependabot to bump gha dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
     rebase-strategy: "auto"
     commit-message:
       prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "efcasado"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
### Description

Enable Dependabot's [github-actions ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions).