### PR TITLE
ci: migrate releases to release-please

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [2.8.18](https://github.com/efcasado/pulsar-elixir/compare/v2.8.17...v2.8.18) (2026-05-30)
 
 ## [2.8.17](https://github.com/efcasado/pulsar-elixir/compare/v2.8.16...v2.8.17) (2026-05-21)


### PR DESCRIPTION
### Description

Add a header to the changelog file so that `release-please` can use it as a marker to correctly place future changelog updates.