### PR TITLE
Partition auto-discovery

### DIFF
--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -37,8 +37,9 @@ defmodule Pulsar do
           │       │   └── C2
           │       ├── ConsumerGroup partition-1
           │       │   └── C3
-          │       └── ConsumerGroup partition-2
-          │           └── C4
+          │       ├── ConsumerGroup partition-2
+          │       │   └── C4
+          │       └── PartitionDiscovery (polls for newly added partitions)
           │
           └── ProducerSupervisor
               ├── ProducerGroup: my-topic
@@ -49,8 +50,9 @@ defmodule Pulsar do
                   │   └── P2
                   ├── ProducerGroup partition-1
                   │   └── P3
-                  └── ProducerGroup partition-2
-                      └── P4
+                  ├── ProducerGroup partition-2
+                  │   └── P4
+                  └── PartitionDiscovery (polls for newly added partitions)
 
   ### Consumer/Producer Architecture
 
@@ -321,6 +323,9 @@ defmodule Pulsar do
     - `:flow_threshold` - Flow permits threshold for refill (default: 50)
     - `:flow_refill` - Flow permits refill amount (default: 50)
     - `:initial_position` - Initial position for subscription (`:latest` or `:earliest`, defaults to `:latest`)
+    - `:partition_discovery_interval_ms` - For partitioned topics, how often to poll
+      for newly added partitions, in milliseconds (default: 60000). Set to `false`
+      to disable auto-discovery. Discovery is grow-only.
     - Other options passed to ConsumerGroup supervisor
 
   ## Return Values
@@ -502,20 +507,20 @@ defmodule Pulsar do
   def get_consumers(group_pid, opts \\ [])
 
   def get_consumers(group_pid, _opts) when is_pid(group_pid) do
-    case Supervisor.which_children(group_pid) do
-      [] ->
+    children = Supervisor.which_children(group_pid)
+
+    cond do
+      children == [] ->
         []
 
-      [{_id, _child_pid, :worker, [Pulsar.Consumer]} | _] ->
-        # This is a ConsumerGroup - children are Consumer processes
-        Pulsar.ConsumerGroup.get_consumers(group_pid)
-
-      [{_id, _child_pid, :supervisor, _modules} | _] ->
-        # This is a PartitionedConsumer - children are ConsumerGroup supervisors
+      # PartitionedConsumer - has ConsumerGroup supervisors as children
+      # (alongside a partition discovery worker).
+      partitioned?(children) ->
         Pulsar.PartitionedConsumer.get_consumers(group_pid)
 
-      _ ->
-        {:error, :unknown_supervisor_type}
+      # ConsumerGroup - children are Consumer worker processes.
+      true ->
+        Pulsar.ConsumerGroup.get_consumers(group_pid)
     end
   end
 
@@ -549,6 +554,9 @@ defmodule Pulsar do
       - `:Exclusive` - Only one producer can publish. Other producers get errors immediately.
       - `:WaitForExclusive` - Wait for exclusive access if another producer is connected
       - `:ExclusiveWithFencing` - Immediately remove any existing producer
+    - `:partition_discovery_interval_ms` - For partitioned topics, how often to poll
+      for newly added partitions, in milliseconds (default: 60000). Set to `false`
+      to disable auto-discovery. Discovery is grow-only.
     - Other options passed to individual producer processes
 
   ## Producer Naming and Registry
@@ -716,17 +724,19 @@ defmodule Pulsar do
   def get_producers(group_pid, opts \\ [])
 
   def get_producers(group_pid, _opts) when is_pid(group_pid) do
-    # Check which type of supervisor this is based on child type
-    case Supervisor.which_children(group_pid) do
-      [] ->
+    children = Supervisor.which_children(group_pid)
+
+    cond do
+      children == [] ->
         []
 
-      [{_id, _, :supervisor, _} | _] ->
-        # PartitionedProducer (children are ProducerGroups - supervisors)
+      # PartitionedProducer - has ProducerGroup supervisors as children
+      # (alongside a partition discovery worker).
+      partitioned?(children) ->
         Pulsar.PartitionedProducer.get_producers(group_pid)
 
-      [{_id, _, :worker, _} | _] ->
-        # ProducerGroup (children are Producer workers)
+      # ProducerGroup - children are Producer worker processes.
+      true ->
         Pulsar.ProducerGroup.get_producers(group_pid)
     end
   end
@@ -932,10 +942,19 @@ defmodule Pulsar do
   end
 
   defp send_to_producer(producer_pid, message, opts) do
-    case Supervisor.which_children(producer_pid) do
-      [{_id, _, :supervisor, _} | _] -> Pulsar.PartitionedProducer.send_message(producer_pid, message, opts)
-      _ -> Pulsar.ProducerGroup.send_message(producer_pid, message, opts)
+    if producer_pid |> Supervisor.which_children() |> partitioned?() do
+      Pulsar.PartitionedProducer.send_message(producer_pid, message, opts)
+    else
+      Pulsar.ProducerGroup.send_message(producer_pid, message, opts)
     end
+  end
+
+  # A partitioned consumer/producer supervises one group supervisor per
+  # partition; a plain group supervises worker processes. The presence of any
+  # `:supervisor` child therefore distinguishes the two, regardless of the
+  # partition discovery worker that also runs under the partitioned supervisor.
+  defp partitioned?(children) do
+    Enum.any?(children, fn {_id, _pid, type, _modules} -> type == :supervisor end)
   end
 
   @spec check_partitioned_topic(String.t(), atom()) :: {:ok, integer()} | {:error, term()}
@@ -959,14 +978,9 @@ defmodule Pulsar do
   @spec do_check_partitioned_topic(String.t(), atom()) ::
           {:ok, integer()} | {:error, term()}
   defp do_check_partitioned_topic(topic, client) do
-    broker = Pulsar.Client.random_broker(client)
-
-    case Pulsar.Broker.partitioned_topic_metadata(broker, topic) do
-      {:ok, %{response: :Success, partitions: partitions}} ->
+    case Pulsar.ServiceDiscovery.partition_count(topic, client: client) do
+      {:ok, partitions} ->
         {:ok, partitions}
-
-      {:ok, %{response: :Failed, error: error}} ->
-        {:error, {:partition_metadata_check_failed, error}}
 
       {:error, reason} ->
         Logger.warning("Error checking partitioned topic metadata for #{topic}: #{inspect(reason)}")

--- a/lib/pulsar/partition_discovery.ex
+++ b/lib/pulsar/partition_discovery.ex
@@ -1,0 +1,138 @@
+defmodule Pulsar.PartitionDiscovery do
+  @moduledoc """
+  Periodically polls a partitioned topic's metadata and grows a partitioned
+  consumer/producer supervisor when new partitions are added to the topic.
+
+  Pulsar only ever increases a topic's partition count, so discovery is
+  grow-only: any partition indices that are missing from the supervisor are
+  added, existing partitions are left untouched, and a reported count that is
+  not larger than the current one (including a transient lookup error) is
+  ignored.
+
+  This runs as a `:worker` child of the `Pulsar.PartitionedConsumer` /
+  `Pulsar.PartitionedProducer` supervisor it manages, and adds new partition
+  children to that same supervisor via `Supervisor.start_child/2`.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @default_interval_ms 60_000
+
+  @doc "The default poll interval, in milliseconds, when none is configured."
+  @spec default_interval_ms() :: pos_integer()
+  def default_interval_ms, do: @default_interval_ms
+
+  @doc """
+  Returns the child spec(s) for a discovery poller attached to `supervisor`.
+
+  Returns a single-element list when discovery is enabled, or an empty list when
+  it is disabled, so the supervisor never starts a poller process it doesn't
+  need.
+
+  `opts`:
+    * `:topic` - base partitioned topic name (required)
+    * `:client` - client name (required)
+    * `:build_child_spec` - 1-arity fun mapping a partition index to the child
+      spec for that partition's consumer/producer group (required)
+    * `:interval_ms` - poll interval in milliseconds (required), or `false` to
+      disable discovery.
+  """
+  @spec child_specs(pid(), keyword()) :: [Supervisor.child_spec()]
+  def child_specs(supervisor, opts) do
+    if enabled?(Keyword.fetch!(opts, :interval_ms)) do
+      [
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [supervisor, opts]},
+          restart: :permanent,
+          type: :worker
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  def start_link(supervisor, opts) do
+    GenServer.start_link(__MODULE__, {supervisor, opts})
+  end
+
+  @impl true
+  def init({supervisor, opts}) do
+    interval = Keyword.fetch!(opts, :interval_ms)
+
+    state = %{
+      supervisor: supervisor,
+      topic: Keyword.fetch!(opts, :topic),
+      client: Keyword.fetch!(opts, :client),
+      interval: interval,
+      build_child_spec: Keyword.fetch!(opts, :build_child_spec)
+    }
+
+    schedule(interval)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:discover, state) do
+    discover(state)
+    schedule(state.interval)
+    {:noreply, state}
+  end
+
+  defp discover(state) do
+    case Pulsar.ServiceDiscovery.partition_count(state.topic, client: state.client) do
+      {:ok, desired} ->
+        grow(state, desired)
+
+      {:error, reason} ->
+        Logger.warning("Partition discovery for #{state.topic} skipped: #{inspect(reason)}")
+    end
+  end
+
+  defp grow(state, desired) when desired > 0 do
+    existing = existing_partition_indices(state.supervisor)
+    missing = Enum.reject(0..(desired - 1), &MapSet.member?(existing, &1))
+    add_partitions(state, missing)
+  end
+
+  defp grow(_state, _desired), do: :ok
+
+  defp add_partitions(_state, []), do: :ok
+
+  defp add_partitions(state, missing) do
+    Logger.info("Partition discovery: adding partition(s) #{inspect(missing)} for #{state.topic}")
+
+    Enum.each(missing, fn index ->
+      case Supervisor.start_child(state.supervisor, state.build_child_spec.(index)) do
+        {:ok, _pid} ->
+          :ok
+
+        {:ok, _pid, _info} ->
+          :ok
+
+        {:error, {:already_started, _pid}} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.error("Partition discovery: failed to start partition #{index} for #{state.topic}: #{inspect(reason)}")
+      end
+    end)
+  end
+
+  defp existing_partition_indices(supervisor) do
+    supervisor
+    |> Supervisor.which_children()
+    |> Enum.filter(fn {_id, _pid, type, _modules} -> type == :supervisor end)
+    |> MapSet.new(fn {id, _pid, _type, _modules} -> Pulsar.PartitionTopic.index(id) end)
+  end
+
+  defp schedule(interval), do: Process.send_after(self(), :discover, interval)
+
+  defp enabled?(false), do: false
+  defp enabled?(interval) when is_integer(interval) and interval > 0, do: true
+  defp enabled?(_interval), do: false
+end

--- a/lib/pulsar/partition_topic.ex
+++ b/lib/pulsar/partition_topic.ex
@@ -1,0 +1,35 @@
+defmodule Pulsar.PartitionTopic do
+  @moduledoc """
+  The naming convention for the individual partitions of a partitioned topic:
+  `"<base>-partition-<index>"`.
+
+  This is also used for the per-partition consumer/producer group names, which
+  follow the same suffix convention.
+  """
+
+  @separator "-partition-"
+
+  @doc """
+  Builds the partition name for `base` (a topic or group name) at `index`.
+
+      iex> Pulsar.PartitionTopic.name("persistent://public/default/t", 3)
+      "persistent://public/default/t-partition-3"
+  """
+  @spec name(String.t(), non_neg_integer()) :: String.t()
+  def name(base, index), do: "#{base}#{@separator}#{index}"
+
+  @doc """
+  Extracts the numeric partition index from a partition topic/group name.
+
+      iex> Pulsar.PartitionTopic.index("persistent://public/default/t-partition-3")
+      3
+  """
+  @spec index(String.t() | atom()) :: non_neg_integer()
+  def index(partition_name) do
+    partition_name
+    |> to_string()
+    |> String.split(@separator)
+    |> List.last()
+    |> String.to_integer()
+  end
+end

--- a/lib/pulsar/partitioned_consumer.ex
+++ b/lib/pulsar/partitioned_consumer.ex
@@ -60,7 +60,8 @@ defmodule Pulsar.PartitionedConsumer do
   def get_partition_groups(supervisor_pid) do
     supervisor_pid
     |> Supervisor.which_children()
-    |> Enum.map(fn {partition_topic, group_pid, :supervisor, _modules} ->
+    |> Enum.filter(fn {_id, _pid, type, _modules} -> type == :supervisor end)
+    |> Enum.map(fn {partition_topic, group_pid, _type, _modules} ->
       {partition_topic, group_pid}
     end)
   end
@@ -82,33 +83,52 @@ defmodule Pulsar.PartitionedConsumer do
   def init({name, topic, partitions, subscription_name, subscription_type, callback_module, opts}) do
     Logger.info("Starting partitioned consumer for topic #{topic} with #{partitions} partitions")
 
-    children =
-      0
-      |> Range.new(partitions - 1)
-      |> Enum.map(fn partition_index ->
-        partition_topic = "#{topic}-partition-#{partition_index}"
-        partition_group_name = "#{name}-partition-#{partition_index}"
+    build_child_spec = fn partition_index ->
+      partition_child_spec(
+        partition_index,
+        name,
+        topic,
+        subscription_name,
+        subscription_type,
+        callback_module,
+        opts
+      )
+    end
 
-        # Create ConsumerGroup spec for this partition
-        %{
-          id: partition_topic,
-          start: {
-            Pulsar.ConsumerGroup,
-            :start_link,
-            [
-              partition_group_name,
-              partition_topic,
-              subscription_name,
-              subscription_type,
-              callback_module,
-              opts
-            ]
-          },
-          restart: :permanent,
-          type: :supervisor
-        }
-      end)
+    partition_children = Enum.map(0..(partitions - 1), build_child_spec)
 
-    Supervisor.init(children, strategy: :one_for_one)
+    discovery_children =
+      Pulsar.PartitionDiscovery.child_specs(self(),
+        topic: topic,
+        client: Keyword.get(opts, :client, @default_client),
+        interval_ms: Keyword.get(opts, :partition_discovery_interval_ms, Pulsar.PartitionDiscovery.default_interval_ms()),
+        build_child_spec: build_child_spec
+      )
+
+    Supervisor.init(partition_children ++ discovery_children, strategy: :one_for_one)
+  end
+
+  # Builds the ConsumerGroup child spec for a single partition.
+  defp partition_child_spec(partition_index, name, topic, subscription_name, subscription_type, callback_module, opts) do
+    partition_topic = Pulsar.PartitionTopic.name(topic, partition_index)
+    partition_group_name = Pulsar.PartitionTopic.name(name, partition_index)
+
+    %{
+      id: partition_topic,
+      start: {
+        Pulsar.ConsumerGroup,
+        :start_link,
+        [
+          partition_group_name,
+          partition_topic,
+          subscription_name,
+          subscription_type,
+          callback_module,
+          opts
+        ]
+      },
+      restart: :permanent,
+      type: :supervisor
+    }
   end
 end

--- a/lib/pulsar/partitioned_producer.ex
+++ b/lib/pulsar/partitioned_producer.ex
@@ -104,14 +104,26 @@ defmodule Pulsar.PartitionedProducer do
     partition_groups = get_partition_groups(supervisor_pid)
     num_partitions = length(partition_groups)
 
-    if num_partitions == 0 do
-      {:error, :no_producers_available}
-    else
-      partition_index = select_partition(opts, num_partitions)
-      # Sort by topic name to ensure consistent ordering, then get by index
-      {_topic, group_pid} = partition_groups |> Enum.sort() |> Enum.at(partition_index)
+    case route_partition(partition_groups, num_partitions, opts) do
+      {:ok, group_pid} -> Pulsar.ProducerGroup.send_message(group_pid, message, opts)
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-      Pulsar.ProducerGroup.send_message(group_pid, message, opts)
+  # Selects the target partition group for a message.
+  #
+  # Routing resolves the partition's actual index, parsed from its topic suffix,
+  # rather than its position in a sorted list. Sorting topic names
+  # lexicographically would misorder partitions once there are 10+
+  # (e.g. "...-partition-10" sorts before "...-partition-2").
+  defp route_partition(_partition_groups, 0, _opts), do: {:error, :no_producers_available}
+
+  defp route_partition(partition_groups, num_partitions, opts) do
+    partition_index = select_partition(opts, num_partitions)
+
+    case Enum.find(partition_groups, fn {topic, _pid} -> partition_index(topic) == partition_index end) do
+      {_topic, group_pid} -> {:ok, group_pid}
+      nil -> {:error, {:partition_not_found, partition_index}}
     end
   end
 
@@ -143,6 +155,15 @@ defmodule Pulsar.PartitionedProducer do
       end)
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # Extracts the numeric partition index from a partition topic name of the
+  # form "<base-topic>-partition-<index>".
+  defp partition_index(partition_topic) do
+    partition_topic
+    |> String.split("-partition-")
+    |> List.last()
+    |> String.to_integer()
   end
 
   defp select_partition(opts, num_partitions) do

--- a/lib/pulsar/partitioned_producer.ex
+++ b/lib/pulsar/partitioned_producer.ex
@@ -63,7 +63,8 @@ defmodule Pulsar.PartitionedProducer do
   def get_partition_groups(supervisor_pid) do
     supervisor_pid
     |> Supervisor.which_children()
-    |> Enum.map(fn {partition_topic, group_pid, :supervisor, _modules} ->
+    |> Enum.filter(fn {_id, _pid, type, _modules} -> type == :supervisor end)
+    |> Enum.map(fn {partition_topic, group_pid, _type, _modules} ->
       {partition_topic, group_pid}
     end)
   end
@@ -121,7 +122,7 @@ defmodule Pulsar.PartitionedProducer do
   defp route_partition(partition_groups, num_partitions, opts) do
     partition_index = select_partition(opts, num_partitions)
 
-    case Enum.find(partition_groups, fn {topic, _pid} -> partition_index(topic) == partition_index end) do
+    case Enum.find(partition_groups, fn {topic, _pid} -> Pulsar.PartitionTopic.index(topic) == partition_index end) do
       {_topic, group_pid} -> {:ok, group_pid}
       nil -> {:error, {:partition_not_found, partition_index}}
     end
@@ -131,39 +132,42 @@ defmodule Pulsar.PartitionedProducer do
   def init({name, topic, partitions, opts}) do
     Logger.info("Starting partitioned producer for topic #{topic} with #{partitions} partitions")
 
-    children =
-      0
-      |> Range.new(partitions - 1)
-      |> Enum.map(fn partition_index ->
-        partition_topic = "#{topic}-partition-#{partition_index}"
-        partition_group_name = "#{name}-partition-#{partition_index}"
+    build_child_spec = fn partition_index ->
+      partition_child_spec(partition_index, name, topic, opts)
+    end
 
-        %{
-          id: partition_topic,
-          start: {
-            Pulsar.ProducerGroup,
-            :start_link,
-            [
-              partition_group_name,
-              partition_topic,
-              opts
-            ]
-          },
-          restart: :permanent,
-          type: :supervisor
-        }
-      end)
+    partition_children = Enum.map(0..(partitions - 1), build_child_spec)
 
-    Supervisor.init(children, strategy: :one_for_one)
+    discovery_children =
+      Pulsar.PartitionDiscovery.child_specs(self(),
+        topic: topic,
+        client: Keyword.get(opts, :client, @default_client),
+        interval_ms: Keyword.get(opts, :partition_discovery_interval_ms, Pulsar.PartitionDiscovery.default_interval_ms()),
+        build_child_spec: build_child_spec
+      )
+
+    Supervisor.init(partition_children ++ discovery_children, strategy: :one_for_one)
   end
 
-  # Extracts the numeric partition index from a partition topic name of the
-  # form "<base-topic>-partition-<index>".
-  defp partition_index(partition_topic) do
-    partition_topic
-    |> String.split("-partition-")
-    |> List.last()
-    |> String.to_integer()
+  # Builds the ProducerGroup child spec for a single partition.
+  defp partition_child_spec(partition_index, name, topic, opts) do
+    partition_topic = Pulsar.PartitionTopic.name(topic, partition_index)
+    partition_group_name = Pulsar.PartitionTopic.name(name, partition_index)
+
+    %{
+      id: partition_topic,
+      start: {
+        Pulsar.ProducerGroup,
+        :start_link,
+        [
+          partition_group_name,
+          partition_topic,
+          opts
+        ]
+      },
+      restart: :permanent,
+      type: :supervisor
+    }
   end
 
   defp select_partition(opts, num_partitions) do

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -373,25 +373,8 @@ defmodule Pulsar.Reader do
   end
 
   defp wait_for_consumers_ready(consumer_group_pid, reader_ref) do
-    expected_count = count_consumers(consumer_group_pid)
+    expected_count = length(Pulsar.get_consumers(consumer_group_pid))
     collect_ready_messages(expected_count, [], 5_000, reader_ref)
-  end
-
-  defp count_consumers(consumer_group_pid) do
-    case Supervisor.which_children(consumer_group_pid) do
-      # PartitionedConsumer - children are ConsumerGroup supervisors
-      [{_id, _pid, :supervisor, [Pulsar.ConsumerGroup]} | _] = children ->
-        # Each ConsumerGroup has 1 consumer (we use consumer_count: 1 implicitly)
-        length(children)
-
-      # ConsumerGroup - children are Consumer workers
-      [{_id, _pid, :worker, [Consumer]} | _] = children ->
-        length(children)
-
-      # Empty or unknown structure, assume 1
-      _ ->
-        1
-    end
   end
 
   defp collect_ready_messages(0, pids, _timeout, _reader_ref), do: pids

--- a/lib/pulsar/service_discovery.ex
+++ b/lib/pulsar/service_discovery.ex
@@ -11,6 +11,42 @@ defmodule Pulsar.ServiceDiscovery do
 
   require Logger
 
+  @doc """
+  Returns the number of partitions for `topic`.
+
+  Performs a single `partitioned-topic-metadata` lookup against a random broker.
+  Returns `{:ok, partitions}` where `partitions` is `0` for a non-partitioned
+  topic, or `{:error, reason}` if the lookup failed.
+  """
+  @spec partition_count(String.t(), keyword()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def partition_count(topic, opts \\ []) do
+    client = Keyword.get(opts, :client, :default)
+
+    :telemetry.span(
+      [:pulsar, :service_discovery, :partition_count],
+      %{},
+      fn ->
+        result = do_partition_count(Pulsar.Client.random_broker(client), topic)
+
+        metadata = %{success: match?({:ok, _}, result), client: client}
+        {result, metadata}
+      end
+    )
+  end
+
+  defp do_partition_count(broker, topic) do
+    case Pulsar.Broker.partitioned_topic_metadata(broker, topic) do
+      {:ok, %{response: :Success, partitions: partitions}} ->
+        {:ok, partitions}
+
+      {:ok, %{response: :Failed, error: error}} ->
+        {:error, {:partition_metadata_check_failed, error}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @spec lookup_topic(String.t(), keyword()) :: {:ok, pid()} | {:error, any()}
   def lookup_topic(topic, opts \\ []) do
     client = Keyword.get(opts, :client, :default)

--- a/test/integration/consumer/partitioned_topic_test.exs
+++ b/test/integration/consumer/partitioned_topic_test.exs
@@ -8,6 +8,7 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
   @client :partition_topic_test_client
   @topic "persistent://public/default/partition-topic-test"
   @consumer_callback Pulsar.Test.Support.DummyConsumer
+  @discovery_interval_ms 200
   @messages [
     {"key1", "Message 1 for key1"},
     {"key2", "Message 1 for key2"},
@@ -73,6 +74,28 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
     assert consumed_messages == expected_count
   end
 
+  test "discovers partitions added to the topic" do
+    test_id = :erlang.unique_integer([:positive])
+    topic = "persistent://public/default/partition-discovery-consumer-#{test_id}"
+
+    System.create_topic(topic, 3)
+
+    opts = Keyword.put(subscription_options(1), :partition_discovery_interval_ms, @discovery_interval_ms)
+
+    {:ok, partitioned_consumer_pid} =
+      Pulsar.start_consumer(topic, "partition-discovery-#{test_id}", @consumer_callback, opts)
+
+    assert wait_for_partition_count(partitioned_consumer_pid, 3) == :ok
+
+    System.update_partitions(topic, 6)
+
+    # The discovery poller should pick up the new partitions and start a
+    # consumer group for each one, without restarting the existing groups.
+    assert wait_for_partition_count(partitioned_consumer_pid, 6) == :ok
+
+    :ok = Pulsar.stop_consumer(partitioned_consumer_pid)
+  end
+
   defp subscription_options(count) do
     [
       client: @client,
@@ -82,5 +105,11 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
       flow_threshold: 0,
       flow_refill: 1
     ]
+  end
+
+  defp wait_for_partition_count(partitioned_consumer_pid, expected) do
+    Utils.wait_for(fn ->
+      length(Pulsar.PartitionedConsumer.get_partition_groups(partitioned_consumer_pid)) == expected
+    end)
   end
 end

--- a/test/integration/producer/partitioned_topic_test.exs
+++ b/test/integration/producer/partitioned_topic_test.exs
@@ -8,6 +8,7 @@ defmodule Pulsar.Integration.Producer.PartitionedTopicTest do
   @moduletag :integration
   @client :partitioned_producer_test_client
   @topic "persistent://public/default/partitioned-producer-test"
+  @discovery_interval_ms 200
 
   setup_all do
     broker = System.broker()
@@ -157,6 +158,30 @@ defmodule Pulsar.Integration.Producer.PartitionedTopicTest do
     :ok = Pulsar.stop_consumer(consumer_pid)
   end
 
+  test "discovers partitions added to the topic" do
+    test_id = :erlang.unique_integer([:positive])
+    topic = "persistent://public/default/partition-discovery-producer-#{test_id}"
+
+    System.create_topic(topic, 3)
+
+    {:ok, producer_pid} =
+      Pulsar.start_producer(topic,
+        client: @client,
+        name: "partition-discovery-producer-#{test_id}",
+        partition_discovery_interval_ms: @discovery_interval_ms
+      )
+
+    assert wait_for_partition_count(producer_pid, 3) == :ok
+
+    System.update_partitions(topic, 6)
+
+    # The discovery poller should pick up the new partitions and start a
+    # producer group for each one, without restarting the existing groups.
+    assert wait_for_partition_count(producer_pid, 6) == :ok
+
+    :ok = Pulsar.stop_producer(producer_pid)
+  end
+
   defp wait_for_producers_ready(partitioned_producer_pid) do
     Utils.wait_for(fn ->
       producers = Pulsar.PartitionedProducer.get_producers(partitioned_producer_pid)
@@ -166,6 +191,12 @@ defmodule Pulsar.Integration.Producer.PartitionedTopicTest do
           state = :sys.get_state(producer)
           state.producer_name != nil
         end)
+    end)
+  end
+
+  defp wait_for_partition_count(partitioned_producer_pid, expected) do
+    Utils.wait_for(fn ->
+      length(Pulsar.PartitionedProducer.get_partition_groups(partitioned_producer_pid)) == expected
     end)
   end
 end

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -123,6 +123,24 @@ defmodule Pulsar.Test.Support.System do
     :ok
   end
 
+  def update_partitions(topic, n) do
+    broker = broker()
+
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "topics",
+      "update-partitioned-topic",
+      topic,
+      "--partitions",
+      "#{n}"
+    ]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
   def unload_topic(topic) do
     broker = broker()
     command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", "unload", topic]


### PR DESCRIPTION
### Description

The number of partitions in a Pulsar topic is dynamic. New partitions can be added to a partitioned topic using `pulsar-admin`'s `update-partition-topic` command (see [here](https://pulsar.apache.org/docs/4.2.x/admin-api-topics/#update)).

Before this change, the number of partitions was only checked once during the initialization of a (partitioned) consumer/producer group. Now, each (partitioned) consumer/producer group runs a periodic job to check for new partitions that may require spawning new consumers/producers within their group. By default, the period job runs once a minute. The value can be updated adjusting the `partition_discovery_interval_ms` setting, which can also be disabled setting its value to `false`.