### PR TITLE
Add support for pulsar 5.x and scalable topics

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,7 +4,7 @@ erlang = "29.0"
 protoc = "25.1"
 
 [env]
-PULSAR_PROTOCOL = "v4.2.1"
+PULSAR_PROTOCOL = "v5.0.0-M1"
 
 # Core development tasks
 [tasks.deps]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ config :pulsar,
   ]
 ```
 
+> [!TIP]
+> Consumers support both classic and scalable (Pulsar 5) topics, selected with the
+> `consumer_type` option. See the [Consumers guide](docs/consumers.md) for the difference
+> between classic, queue, and stream consumers.
+
 Sending a message using the configured producer can be done as follows:
 
 ```elixir
@@ -183,6 +188,9 @@ The full feature matrix for Apache Pulsar can be found [here](https://pulsar.apa
 | Consumer  | Seek                               | ✅        |
 | Consumer  | Subscription types                 | ✅        |
 | Consumer  | Subscription modes                 | ✅        |
+| Consumer  | Scalable topics (queue)            | ✅        |
+| Consumer  | Scalable topics (stream)           | ✅        |
+| Consumer  | Scalable topics (checkpoint)       | ❌        |
 | Consumer  | Retry letter topic                 | ❌        |
 | Consumer  | Dead letter topic                  | ✅        |
 | Consumer  | Compression                        | ✅        |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-broker: &broker
 
 services:
   zookeeper:
-    image: apachepulsar/pulsar:4.2.2
+    image: apachepulsar/pulsar:5.0.0-M1
     container_name: zookeeper
     restart: on-failure
     environment:
@@ -41,7 +41,7 @@ services:
       retries: 30
 
   pulsar-init:
-    image: apachepulsar/pulsar:4.2.2
+    image: apachepulsar/pulsar:5.0.0-M1
     container_name: pulsar-init
     command:
       - bash
@@ -58,7 +58,7 @@ services:
         condition: service_healthy
 
   bookie:
-    image: apachepulsar/pulsar:4.2.2
+    image: apachepulsar/pulsar:5.0.0-M1
     container_name: bookie
     restart: on-failure
     environment:
@@ -84,7 +84,7 @@ services:
 
   broker1:
     <<: *broker
-    image: apachepulsar/pulsar:4.2.2
+    image: apachepulsar/pulsar:5.0.0-M1
     container_name: broker1
     hostname: broker1
     environment:
@@ -102,7 +102,7 @@ services:
 
   broker2:
     <<: *broker
-    image: apachepulsar/pulsar:4.2.2
+    image: apachepulsar/pulsar:5.0.0-M1
     container_name: broker2
     hostname: broker2
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 x-broker: &broker
   restart: on-failure
   environment: &broker-environment
-    metadataStoreUrl: zk:zookeeper:2181
-    zookeeperServers: zookeeper:2181
+    metadataStoreUrl: oxia://oxia:6648/default
     clusterName: cluster-a
     managedLedgerDefaultEnsembleSize: 1
     managedLedgerDefaultWriteQuorum: 1
     managedLedgerDefaultAckQuorum: 1
     PULSAR_MEM: -Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
   depends_on:
-    zookeeper:
+    oxia:
       condition: service_healthy
     bookie:
       condition: service_started
@@ -20,22 +19,15 @@ x-broker: &broker
     retries: 5
 
 services:
-  zookeeper:
-    image: apachepulsar/pulsar:5.0.0-M1
-    container_name: zookeeper
+  oxia:
+    image: oxia/oxia:0.16.7
+    container_name: oxia
     restart: on-failure
-    environment:
-      metadataStoreUrl: zk:zookeeper:2181
-      PULSAR_MEM: -Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m
     command:
-      - bash
-      - -c
-      - |
-        bin/apply-config-from-env.py conf/zookeeper.conf && \
-        bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
-        exec bin/pulsar zookeeper
+      - oxia
+      - standalone
     healthcheck:
-      test: ["CMD", "bin/pulsar-zookeeper-ruok.sh"]
+      test: ["CMD", "oxia", "health", "--port=6648"]
       interval: 10s
       timeout: 5s
       retries: 30
@@ -49,12 +41,12 @@ services:
       - |
         bin/pulsar initialize-cluster-metadata \
         --cluster cluster-a \
-        --zookeeper zookeeper:2181 \
-        --configuration-store zookeeper:2181 \
+        --metadata-store oxia://oxia:6648/default \
+        --configuration-store oxia://oxia:6648/default \
         --web-service-url http://broker1:8080 \
         --broker-service-url pulsar://broker1:6650
     depends_on:
-      zookeeper:
+      oxia:
         condition: service_healthy
 
   bookie:
@@ -63,15 +55,14 @@ services:
     restart: on-failure
     environment:
       clusterName: cluster-a
-      zkServers: zookeeper:2181
-      metadataServiceUri: metadata-store:zk:zookeeper:2181
+      metadataServiceUri: metadata-store:oxia://oxia:6648/default
       advertisedAddress: bookie
       journalDirectories: /tmp/bookie/journal
       ledgerDirectories: /tmp/bookie/ledgers
       journalSyncData: "false"
       BOOKIE_MEM: -Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
     depends_on:
-      zookeeper:
+      oxia:
         condition: service_healthy
       pulsar-init:
         condition: service_completed_successfully

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -1,0 +1,173 @@
+# Consumers
+
+## What is a Consumer?
+
+A Consumer is a callback-based, long-running subscriber to a Pulsar topic. Unlike a
+[Reader](reader.md) — which pulls a finite stream of messages into the calling process — a
+Consumer holds a durable **subscription** on the broker, invokes your callback for every
+message, and is supervised so it reconnects and resumes from where it left off.
+
+Reach for a Consumer when you want continuous, supervised processing; reach for a Reader
+for one-off reads, replays, or stream pipelines.
+
+## Your first consumer
+
+A consumer is a module that uses `Pulsar.Consumer.Callback` and implements
+`handle_message/2`:
+
+```elixir
+defmodule MyConsumer do
+  use Pulsar.Consumer.Callback
+
+  def handle_message(message, state) do
+    IO.puts("Received: #{message.payload}")
+    {:ok, state}
+  end
+end
+```
+
+The return value tells the client what to do with the message:
+
+- `{:ok, state}` — acknowledge it
+- `{:error, reason, state}` — negatively acknowledge it (redeliver later, or route to the dead-letter topic)
+- `{:noreply, state}` — you will acknowledge manually with `Pulsar.Consumer.ack/2` / `nack/2`
+
+Start it from your application config:
+
+```elixir
+config :pulsar,
+  host: "pulsar://localhost:6650",
+  consumers: [
+    my_consumer: [
+      topic: "persistent://public/default/my-topic",
+      subscription_name: "my-subscription",
+      callback_module: MyConsumer
+    ]
+  ]
+```
+
+or dynamically:
+
+```elixir
+Pulsar.start_consumer("persistent://public/default/my-topic", "my-subscription", MyConsumer)
+```
+
+## Classic vs. scalable topics
+
+Pulsar has two families of topics, and this client consumes both.
+
+**Classic topics** are what most Pulsar users know: a topic is either non-partitioned (one
+stream) or **partitioned** into a fixed number of partitions you choose up front. More
+partitions means more parallelism, but changing the count later is disruptive.
+
+**Scalable topics** (new in Pulsar 5, addressed with the `topic://` scheme) are a single
+logical stream that the broker sizes to its actual load: internally it divides the key
+space into **segments** and splits or merges them as traffic rises and falls — no partition
+count to pick, no downtime to resize, and per-key ordering preserved across resizes.
+
+How you consume is selected by the `:consumer_type` option, *independently of how the topic
+is named*:
+
+| `:consumer_type` | Use with | Model |
+|---|---|---|
+| `:classic` (default) | regular & partitioned topics | one consumer group per topic/partition |
+| `:queue` | scalable topics | parallel work-queue over all segments |
+| `:stream` | scalable topics | ordered, controller-assigned segments |
+
+```elixir
+# classic (default)
+Pulsar.start_consumer(topic, sub, MyConsumer)
+
+# scalable, queue model
+Pulsar.start_consumer(topic, sub, MyConsumer, consumer_type: :queue)
+
+# scalable, stream model
+Pulsar.start_consumer(topic, sub, MyConsumer, consumer_type: :stream)
+```
+
+> #### Note {: .info}
+> `:consumer_type` — not the topic name — decides the model. A scalable topic needs
+> `consumer_type: :queue` or `:stream`; the default `:classic` will not consume it.
+
+## Queue consumers
+
+A **queue** consumer treats a scalable topic as a parallel work queue: it attaches to every
+segment and acknowledges messages individually, with optional dead-letter support — the
+scalable analogue of a `Shared` / `Key_Shared` subscription.
+
+To parallelize, start several consumers on the same subscription and pick a
+`subscription_type`; the broker spreads messages across them:
+
+```elixir
+Pulsar.start_consumer(topic, "workers", MyConsumer,
+  consumer_type: :queue,
+  subscription_type: :Key_Shared
+)
+```
+
+## Stream consumers
+
+A **stream** consumer is ordered. It registers with the broker's controller, which assigns
+it a subset of the topic's key-range segments. Run several stream consumers on the same
+subscription and the controller distributes the segments — and therefore the key ranges —
+across them: parallel consumption with per-key ordering preserved, even as segments split
+and merge.
+
+```elixir
+# run this on several nodes/processes with the same subscription
+Pulsar.start_consumer(topic, "orders", MyConsumer, consumer_type: :stream)
+```
+
+> #### Note {: .info}
+> `subscription_type` does not apply to stream consumers. Each segment is consumed by one
+> member at a time, and parallelism comes from running more consumers (the controller hands
+> each a slice of the key space), not from the subscription type.
+
+## Subscription types
+
+For `:classic` and `:queue` consumers, `:subscription_type` controls how the broker
+dispatches messages within a subscription:
+
+- `:Exclusive` — a single consumer
+- `:Failover` — one active consumer, the rest on standby
+- `:Shared` (default) — distributed across consumers
+- `:Key_Shared` — like `:Shared`, but each key always goes to the same consumer
+
+## Acknowledgement
+
+By default each message is acknowledged **individually**. For ordered consumption on an
+`:Exclusive` or `:Failover` subscription you can switch to **cumulative** acks, which
+acknowledge a message and everything before it in one step:
+
+```elixir
+Pulsar.start_consumer(topic, sub, MyConsumer,
+  subscription_type: :Exclusive,
+  ack_type: :Cumulative
+)
+```
+
+> #### Note {: .info}
+> Cumulative acks are only valid on `:Exclusive` / `:Failover` subscriptions; the broker
+> rejects them on `:Shared` / `:Key_Shared`.
+
+## Consuming a not-yet-migrated topic
+
+Because `:consumer_type` drives routing, you can point a `:queue` consumer at a regular
+`persistent://` topic that has not been migrated to a scalable topic yet — the broker
+presents it as a single legacy segment and the consumer drains it like any other. The same
+scalable consumer code keeps working across a topic's migration.
+
+## Configuration options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `:consumer_type` | atom | `:classic` | `:classic`, `:queue`, or `:stream` |
+| `:subscription_type` | atom | `:Shared` | `:Exclusive`, `:Failover`, `:Shared`, `:Key_Shared` (classic/queue only) |
+| `:ack_type` | atom | `:Individual` | `:Individual` or `:Cumulative` (Exclusive/Failover only) |
+| `:consumer_count` | integer | `1` | Consumers per group (classic/queue) |
+| `:initial_position` | atom | `:latest` | `:earliest` or `:latest` |
+| `:dead_letter_policy` | keyword | - | Dead-letter topic configuration |
+| `:client` | atom | `:default` | Name of the client to use |
+| `:name` | term | `"<topic>-<subscription>"` | Registered name for the consumer |
+
+There are more options (flow control, chunking, schema, …) — see `Pulsar.start_consumer/4`.

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -32,14 +32,19 @@ defmodule Pulsar do
           │   │   └── C1 (with DLQ policy)
           │   │       └── DLQ-P1 (linked process)
           │   │
-          │   └── PartitionedConsumer: my-partitioned-topic
-          │       ├── ConsumerGroup partition-0
-          │       │   └── C2
-          │       ├── ConsumerGroup partition-1
-          │       │   └── C3
-          │       ├── ConsumerGroup partition-2
+          │   ├── PartitionedConsumer: my-partitioned-topic
+          │   │   ├── ConsumerGroup partition-0
+          │   │   │   └── C2
+          │   │   ├── ConsumerGroup partition-1
+          │   │   │   └── C3
+          │   │   └── PartitionDiscovery (polls for newly added partitions)
+          │   │
+          │   └── ScalableConsumer: my-scalable-topic
+          │       ├── ConsumerGroup segment-0
           │       │   └── C4
-          │       └── PartitionDiscovery (polls for newly added partitions)
+          │       ├── ConsumerGroup segment-1
+          │       │   └── C5
+          │       └── ScalableWatcher (reconciles segments as the topology changes)
           │
           └── ProducerSupervisor
               ├── ProducerGroup: my-topic
@@ -58,11 +63,13 @@ defmodule Pulsar do
 
   Both consumers and producers are managed through supervised processes:
 
-  **Consumers:**
-  - **Regular topics**: Consumer groups with configurable process count
-  - **Partitioned topics**: PartitionedConsumer supervisor managing consumer groups per partition
+  **Consumers:** (selected with the `:consumer_type` option)
+  - **Classic topics** (`:classic`, default): a consumer group per topic, or a
+    PartitionedConsumer managing one group per partition
+  - **Scalable topics** (`:queue` / `:stream`): a ScalableConsumer with a ScalableWatcher
+    that fans out one consumer group per segment and reconciles them as the topology changes
   - The `start_consumer/4` function returns a single PID that can be registered with a name,
-    regardless of partitioning or process count
+    regardless of topic kind or process count
 
   **Producers:**
   - **Regular topics**: Producer groups with configurable process count

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -327,34 +327,41 @@ defmodule Pulsar do
     subscription_type = Keyword.get(opts, :subscription_type, :Shared)
     name = Keyword.get(opts, :name, topic <> "-" <> subscription_name)
 
-    if scalable_topic?(topic) do
-      # Scalable topic (PIP-460/466/468), addressed by the topic:// scheme. The
-      # `:scalable_type` option (in opts) selects the consumer model - `:queue`
-      # (default) or `:stream`; `subscription_type` is forwarded for `:queue`.
-      child_spec = %{
-        id: name,
-        start: {
-          Pulsar.ScalableConsumer,
-          :start_link,
-          [name, topic, subscription_name, callback_module, opts]
-        },
-        restart: :permanent,
-        type: :supervisor
-      }
+    # `:consumer_type` selects the consumer model, independent of the topic name:
+    #   :classic (default) - regular/partitioned consumer
+    #   :queue             - scalable topic, fan out over all segments
+    #   :stream            - scalable topic, ordered, controller-assigned segments
+    case Keyword.get(opts, :consumer_type, :classic) do
+      :classic ->
+        start_classic_consumer(
+          topic,
+          subscription_name,
+          subscription_type,
+          callback_module,
+          name,
+          consumer_supervisor,
+          client,
+          opts
+        )
 
-      DynamicSupervisor.start_child(consumer_supervisor, child_spec)
-    else
-      start_classic_consumer(
-        topic,
-        subscription_name,
-        subscription_type,
-        callback_module,
-        name,
-        consumer_supervisor,
-        client,
-        opts
-      )
+      consumer_type when consumer_type in [:queue, :stream] ->
+        start_scalable_consumer(topic, subscription_name, callback_module, name, consumer_supervisor, opts)
     end
+  end
+
+  defp start_scalable_consumer(topic, subscription_name, callback_module, name, consumer_supervisor, opts) do
+    child_spec = %{
+      id: name,
+      start: {
+        Pulsar.ScalableConsumer,
+        :start_link,
+        [name, topic, subscription_name, callback_module, opts]
+      },
+      restart: :permanent,
+      type: :supervisor
+    }
+
+    DynamicSupervisor.start_child(consumer_supervisor, child_spec)
   end
 
   defp start_classic_consumer(
@@ -944,8 +951,6 @@ defmodule Pulsar do
   defp scalable?(children) do
     Enum.any?(children, fn {id, _pid, _type, _modules} -> id == Pulsar.ScalableWatcher end)
   end
-
-  defp scalable_topic?(topic), do: String.starts_with?(topic, "topic://")
 
   @spec check_partitioned_topic(String.t(), atom()) :: {:ok, integer()} | {:error, term()}
   defp check_partitioned_topic(_topic, _client, attempts \\ 10, delay_ms \\ 500)

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -327,6 +327,46 @@ defmodule Pulsar do
     subscription_type = Keyword.get(opts, :subscription_type, :Shared)
     name = Keyword.get(opts, :name, topic <> "-" <> subscription_name)
 
+    if scalable_topic?(topic) do
+      # Scalable topic (PIP-460/466/468), addressed by the topic:// scheme. The
+      # `:scalable_type` option (in opts) selects the consumer model - `:queue`
+      # (default) or `:stream`; `subscription_type` is forwarded for `:queue`.
+      child_spec = %{
+        id: name,
+        start: {
+          Pulsar.ScalableConsumer,
+          :start_link,
+          [name, topic, subscription_name, callback_module, opts]
+        },
+        restart: :permanent,
+        type: :supervisor
+      }
+
+      DynamicSupervisor.start_child(consumer_supervisor, child_spec)
+    else
+      start_classic_consumer(
+        topic,
+        subscription_name,
+        subscription_type,
+        callback_module,
+        name,
+        consumer_supervisor,
+        client,
+        opts
+      )
+    end
+  end
+
+  defp start_classic_consumer(
+         topic,
+         subscription_name,
+         subscription_type,
+         callback_module,
+         name,
+         consumer_supervisor,
+         client,
+         opts
+       ) do
     case check_partitioned_topic(topic, client) do
       {:ok, 0} ->
         # Regular topic - create single consumer group
@@ -451,6 +491,11 @@ defmodule Pulsar do
     cond do
       children == [] ->
         []
+
+      # ScalableConsumer (queue or stream) - has a ScalableWatcher worker driving
+      # the per-segment consumer groups.
+      scalable?(children) ->
+        Pulsar.ScalableConsumer.get_consumers(group_pid)
 
       # PartitionedConsumer - has ConsumerGroup supervisors as children
       # (alongside a partition discovery worker).
@@ -895,6 +940,12 @@ defmodule Pulsar do
   defp partitioned?(children) do
     Enum.any?(children, fn {_id, _pid, type, _modules} -> type == :supervisor end)
   end
+
+  defp scalable?(children) do
+    Enum.any?(children, fn {id, _pid, _type, _modules} -> id == Pulsar.ScalableWatcher end)
+  end
+
+  defp scalable_topic?(topic), do: String.starts_with?(topic, "topic://")
 
   @spec check_partitioned_topic(String.t(), atom()) :: {:ok, integer()} | {:error, term()}
   defp check_partitioned_topic(_topic, _client, attempts \\ 10, delay_ms \\ 500)

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -442,7 +442,8 @@ defmodule Pulsar.Broker do
       client_version: Config.client_version(),
       protocol_version: Config.protocol_version(),
       auth_method_name: auth_method_name,
-      auth_data: auth_data
+      auth_data: auth_data,
+      feature_flags: %Binary.FeatureFlags{supports_scalable_topics: true}
     }
 
     case send_command_internal(connect_command, broker) do

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -303,8 +303,7 @@ defmodule Pulsar.Broker do
     # Fail all pending requests immediately to prevent timeouts
     broker = fail_all_pending_requests(broker, :connection_lost)
 
-    # Restart all consumers and producers by exiting their processes
-    # The supervision trees will automatically restart them
+    # Consumers and producers restart automatically via their supervision trees.
     restart_consumers_and_producers(broker)
 
     actions = [{{:timeout, :reconnect}, wait, nil}]

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -42,7 +42,13 @@ defmodule Pulsar.Broker do
     :actions,
     # Broker-specific state
     :consumers,
-    :producers
+    :producers,
+    # Scalable topic watchers: id -> {owner_pid, ref, close_command}. Routes
+    # pushed topology/assignment commands to the owning watcher (keyed by the
+    # wire id - session_id for a DAG watch, consumer_id for a STREAM/CHECKPOINT
+    # registration). `close_command`, if any, is sent to the broker when the
+    # owner exits.
+    :watchers
   ]
 
   @type t :: %__MODULE__{
@@ -60,7 +66,8 @@ defmodule Pulsar.Broker do
           requests: %{integer() => {GenServer.from(), integer()}},
           actions: list(),
           consumers: %{integer() => {pid(), reference()}},
-          producers: %{integer() => {pid(), reference()}}
+          producers: %{integer() => {pid(), reference()}},
+          watchers: %{integer() => {pid(), reference(), struct() | nil}}
         }
 
   ## Public API
@@ -110,6 +117,20 @@ defmodule Pulsar.Broker do
   @spec register_producer(GenServer.server(), integer(), pid()) :: :ok
   def register_producer(broker, producer_id, producer_pid) do
     :gen_statem.call(broker, {:register_producer, producer_id, producer_pid})
+  end
+
+  @doc """
+  Registers a scalable topic watcher and monitors `owner_pid`.
+
+  `id` is the wire id the broker routes pushed commands by (a `session_id` for a
+  DAG watch, a `consumer_id` for a STREAM/CHECKPOINT registration); matching
+  `CommandScalableTopicUpdate`/`CommandScalableTopicAssignmentUpdate` messages
+  are delivered to `owner_pid` as `{:broker_message, command}`. `close_command`,
+  if given, is sent to the broker when the owner exits.
+  """
+  @spec register_watcher(GenServer.server(), integer(), pid(), struct() | nil) :: :ok
+  def register_watcher(broker, id, owner_pid, close_command \\ nil) do
+    :gen_statem.call(broker, {:register_watcher, id, owner_pid, close_command})
   end
 
   @doc """
@@ -260,6 +281,7 @@ defmodule Pulsar.Broker do
       requests: %{},
       consumers: %{},
       producers: %{},
+      watchers: %{},
       prev_backoff: 0
     }
 
@@ -469,57 +491,33 @@ defmodule Pulsar.Broker do
     {:keep_state, new_broker, actions}
   end
 
+  def connected({:call, from}, {:register_watcher, id, owner_pid, close_command}, broker) do
+    monitor_ref = Process.monitor(owner_pid)
+
+    new_watchers = Map.put(broker.watchers, id, {owner_pid, monitor_ref, close_command})
+    new_broker = %{broker | watchers: new_watchers}
+
+    Logger.debug("Registered scalable watcher #{id} and monitoring process")
+    actions = [{:reply, from, :ok}]
+    {:keep_state, new_broker, actions}
+  end
+
   # Automatic cleanup when monitored processes exit
   def connected(:info, {:DOWN, monitor_ref, :process, pid, reason}, broker) do
-    # Find and remove the consumer/producer that died
+    # Find and remove the consumer/producer/watcher that died, and tell the
+    # broker it is gone (each owes a different close command, if any).
     {consumer_id, new_consumers} = remove_by_monitor_ref(broker.consumers, monitor_ref, pid)
     {producer_id, new_producers} = remove_by_monitor_ref(broker.producers, monitor_ref, pid)
+    {watcher_id, watcher_close, new_watchers} = remove_watcher_by_monitor_ref(broker.watchers, monitor_ref, pid)
 
-    broker_after_consumer =
-      if consumer_id do
-        Logger.info("Consumer #{consumer_id} exited: #{inspect(reason)}, sending CloseConsumer to server")
+    broker =
+      broker
+      |> close_after_exit(consumer_id, close_consumer_command(consumer_id), reason, "consumer")
+      |> close_after_exit(producer_id, close_producer_command(producer_id), reason, "producer")
+      |> close_after_exit(watcher_id, watcher_close, reason, "scalable watcher")
 
-        close_consumer_command = %Binary.CommandCloseConsumer{
-          consumer_id: consumer_id,
-          request_id: System.unique_integer([:positive, :monotonic])
-        }
+    new_broker = %{broker | consumers: new_consumers, producers: new_producers, watchers: new_watchers}
 
-        case send_command_internal(close_consumer_command, broker) do
-          {:ok, updated_broker} ->
-            updated_broker
-
-          {{:error, send_error}, updated_broker} ->
-            Logger.warning("Failed to send CloseConsumer for consumer #{consumer_id}: #{inspect(send_error)}")
-
-            updated_broker
-        end
-      else
-        broker
-      end
-
-    broker_after_producer =
-      if producer_id do
-        Logger.info("Producer #{producer_id} exited: #{inspect(reason)}, sending CloseProducer to server")
-
-        close_producer_command = %Binary.CommandCloseProducer{
-          producer_id: producer_id,
-          request_id: System.unique_integer([:positive, :monotonic])
-        }
-
-        case send_command_internal(close_producer_command, broker_after_consumer) do
-          {:ok, updated_broker} ->
-            updated_broker
-
-          {{:error, send_error}, updated_broker} ->
-            Logger.warning("Failed to send CloseProducer for producer #{producer_id}: #{inspect(send_error)}")
-
-            updated_broker
-        end
-      else
-        broker_after_consumer
-      end
-
-    new_broker = %{broker_after_producer | consumers: new_consumers, producers: new_producers}
     {:keep_state, new_broker}
   end
 
@@ -690,6 +688,11 @@ defmodule Pulsar.Broker do
     {:keep_state, new_broker}
   end
 
+  defp handle_command(%Binary.CommandScalableTopicSubscribeResponse{request_id: request_id} = command, broker) do
+    new_broker = reply_to_request(broker, request_id, {:ok, command})
+    {:keep_state, new_broker}
+  end
+
   defp handle_command(%Binary.CommandError{request_id: request_id} = error, broker) do
     reply = {:error, {error.error, error.message}}
     new_broker = reply_to_request(broker, request_id, reply)
@@ -713,6 +716,26 @@ defmodule Pulsar.Broker do
 
       {consumer_pid, _monitor_ref} ->
         send(consumer_pid, {:broker_message, {command, metadata, payload, broker_metadata}})
+        :keep_state_and_data
+    end
+  end
+
+  defp handle_command(%Binary.CommandScalableTopicUpdate{session_id: session_id} = command, broker) do
+    route_to_watcher(broker, session_id, command)
+  end
+
+  defp handle_command(%Binary.CommandScalableTopicAssignmentUpdate{consumer_id: consumer_id} = command, broker) do
+    route_to_watcher(broker, consumer_id, command)
+  end
+
+  defp handle_command(%Binary.CommandReachedEndOfTopic{consumer_id: consumer_id} = command, broker) do
+    case Map.get(broker.consumers, consumer_id) do
+      nil ->
+        Logger.debug("Reached end of topic for unknown consumer #{consumer_id}")
+        :keep_state_and_data
+
+      {consumer_pid, _monitor_ref} ->
+        send(consumer_pid, {:broker_message, command})
         :keep_state_and_data
     end
   end
@@ -1002,5 +1025,59 @@ defmodule Pulsar.Broker do
           {found_id, acc_map}
         end
     end)
+  end
+
+  # Like remove_by_monitor_ref/3 but for watcher entries, which also carry a
+  # close command. Returns {id, close_command, new_map}.
+  defp remove_watcher_by_monitor_ref(watchers, target_monitor_ref, target_pid) do
+    Enum.reduce(watchers, {nil, nil, watchers}, fn
+      {id, {pid, monitor_ref, close_command}}, {found_id, found_close, acc_map} ->
+        if monitor_ref == target_monitor_ref and pid == target_pid do
+          {id, close_command, Map.delete(acc_map, id)}
+        else
+          {found_id, found_close, acc_map}
+        end
+    end)
+  end
+
+  defp close_consumer_command(nil), do: nil
+
+  defp close_consumer_command(consumer_id) do
+    %Binary.CommandCloseConsumer{consumer_id: consumer_id, request_id: System.unique_integer([:positive, :monotonic])}
+  end
+
+  defp close_producer_command(nil), do: nil
+
+  defp close_producer_command(producer_id) do
+    %Binary.CommandCloseProducer{producer_id: producer_id, request_id: System.unique_integer([:positive, :monotonic])}
+  end
+
+  # Sends the close command (if any) owed for a monitored process that exited.
+  defp close_after_exit(broker, nil, _command, _reason, _label), do: broker
+  defp close_after_exit(broker, _id, nil, _reason, _label), do: broker
+
+  defp close_after_exit(broker, id, command, reason, label) do
+    Logger.info("#{label} #{id} exited: #{inspect(reason)}, sending #{inspect(command.__struct__)} to server")
+
+    case send_command_internal(command, broker) do
+      {:ok, updated_broker} ->
+        updated_broker
+
+      {{:error, send_error}, updated_broker} ->
+        Logger.warning("Failed to send close for #{label} #{id}: #{inspect(send_error)}")
+        updated_broker
+    end
+  end
+
+  defp route_to_watcher(broker, id, command) do
+    case Map.get(broker.watchers, id) do
+      nil ->
+        Logger.warning("Received #{inspect(command.__struct__)} for unknown scalable watcher #{id}")
+        :keep_state_and_data
+
+      {owner_pid, _monitor_ref, _close_command} ->
+        send(owner_pid, {:broker_message, command})
+        :keep_state_and_data
+    end
   end
 end

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -40,6 +40,7 @@ defmodule Pulsar.Consumer do
     :topic,
     :subscription_name,
     :subscription_type,
+    :ack_type,
     :consumer_id,
     :consumer_name,
     :callback_module,
@@ -140,6 +141,7 @@ defmodule Pulsar.Consumer do
     {refill_threshold, genserver_opts} = Keyword.pop(genserver_opts, :flow_threshold, 50)
     {refill_amount, genserver_opts} = Keyword.pop(genserver_opts, :flow_refill, 50)
     {initial_position, genserver_opts} = Keyword.pop(genserver_opts, :initial_position, :latest)
+    {ack_type, genserver_opts} = Keyword.pop(genserver_opts, :ack_type, :Individual)
     {durable, genserver_opts} = Keyword.pop(genserver_opts, :durable, true)
     {force_create_topic, genserver_opts} = Keyword.pop(genserver_opts, :force_create_topic, true)
     {read_compacted, genserver_opts} = Keyword.pop(genserver_opts, :read_compacted, false)
@@ -174,6 +176,7 @@ defmodule Pulsar.Consumer do
       topic: topic,
       subscription_name: subscription_name,
       subscription_type: subscription_type,
+      ack_type: ack_type,
       callback_module: callback_module,
       init_args: init_args,
       flow_initial: initial_permits,
@@ -340,6 +343,7 @@ defmodule Pulsar.Consumer do
       topic: topic,
       subscription_name: subscription_name,
       subscription_type: subscription_type,
+      ack_type: ack_type,
       callback_module: callback_module,
       init_args: init_args,
       flow_initial: initial_permits,
@@ -371,6 +375,7 @@ defmodule Pulsar.Consumer do
       topic: topic,
       subscription_name: subscription_name,
       subscription_type: subscription_type,
+      ack_type: ack_type,
       callback_module: callback_module,
       flow_initial: initial_permits,
       flow_threshold: refill_threshold,
@@ -727,6 +732,33 @@ defmodule Pulsar.Consumer do
     }
   end
 
+  # Cumulative ack targets a single message id ("everything up to and including
+  # this"); individual acks the given ids. Cumulative is only valid on
+  # Exclusive/Failover subscriptions - the broker rejects it otherwise.
+  #
+  # The target is the greatest id by Pulsar's ordering (ledger, entry, batch),
+  # not the last list element - chunked messages and batched manual acks can pass
+  # ids in any order.
+  defp build_ack(%__MODULE__{ack_type: :Cumulative} = state, message_ids) do
+    %Binary.CommandAck{
+      consumer_id: state.consumer_id,
+      ack_type: :Cumulative,
+      message_id: [highest_message_id(message_ids)]
+    }
+  end
+
+  defp build_ack(state, message_ids) do
+    %Binary.CommandAck{
+      consumer_id: state.consumer_id,
+      ack_type: :Individual,
+      message_id: message_ids
+    }
+  end
+
+  defp highest_message_id(message_ids) do
+    Enum.max_by(message_ids, &{&1.ledgerId, &1.entryId, &1.batch_index})
+  end
+
   defp process_single_message(state, %Pulsar.Message{} = message, callback_state, nacked_acc) do
     # Call callback for ALL messages (including incomplete chunks)
     result = state.callback_module.handle_message(message, callback_state)
@@ -738,13 +770,7 @@ defmodule Pulsar.Consumer do
     case result do
       {:ok, new_callback_state} ->
         # ACK all message IDs (for chunked messages, this ACKs all chunks)
-        ack_command = %Binary.CommandAck{
-          consumer_id: state.consumer_id,
-          ack_type: :Individual,
-          message_id: message_ids_list
-        }
-
-        :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
+        :ok = Pulsar.Broker.send_command(state.broker_pid, build_ack(state, message_ids_list))
         {new_callback_state, nacked_acc}
 
       {:noreply, new_callback_state} ->
@@ -800,13 +826,7 @@ defmodule Pulsar.Consumer do
   end
 
   def handle_call({:ack, message_ids}, _from, state) when is_list(message_ids) do
-    ack_command = %Binary.CommandAck{
-      consumer_id: state.consumer_id,
-      ack_type: :Individual,
-      message_id: message_ids
-    }
-
-    :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
+    :ok = Pulsar.Broker.send_command(state.broker_pid, build_ack(state, message_ids))
     {:reply, :ok, state}
   end
 

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -641,7 +641,6 @@ defmodule Pulsar.Consumer do
     {:stop, :broker_crashed, state}
   end
 
-  # Handle other info messages by delegating to callback module
   @impl true
   def handle_info(message, state) do
     case state.callback_module.handle_info(message, state.callback_state) do

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -552,6 +552,13 @@ defmodule Pulsar.Consumer do
     {:stop, :broker_close_requested, state}
   end
 
+  # Reaching the end of a (terminated or sealed) topic is informational: there
+  # are simply no more messages to deliver. Keep running.
+  def handle_info({:broker_message, %Binary.CommandReachedEndOfTopic{}}, state) do
+    Logger.debug("Reached end of topic for #{state.topic}")
+    {:noreply, state}
+  end
+
   def handle_info({:broker_message, message_data}, state) do
     {messages, new_state} =
       case message_data do

--- a/lib/pulsar/protocol.ex
+++ b/lib/pulsar/protocol.ex
@@ -196,6 +196,10 @@ defmodule Pulsar.Protocol do
     :redeliverUnacknowledgedMessages
   end
 
+  defp field_name_from_type(:REACHED_END_OF_TOPIC) do
+    :reachedEndOfTopic
+  end
+
   defp field_name_from_type(:SCALABLE_TOPIC_LOOKUP) do
     :scalableTopicLookup
   end

--- a/lib/pulsar/protocol.ex
+++ b/lib/pulsar/protocol.ex
@@ -146,6 +146,10 @@ defmodule Pulsar.Protocol do
 
   defp command_to_type(%Binary.CommandRedeliverUnacknowledgedMessages{}), do: :REDELIVER_UNACKNOWLEDGED_MESSAGES
 
+  defp command_to_type(%Binary.CommandScalableTopicLookup{}), do: :SCALABLE_TOPIC_LOOKUP
+  defp command_to_type(%Binary.CommandScalableTopicClose{}), do: :SCALABLE_TOPIC_CLOSE
+  defp command_to_type(%Binary.CommandScalableTopicSubscribe{}), do: :SCALABLE_TOPIC_SUBSCRIBE
+
   # defp command_to_type(command) do
   #   command
   #   |> Map.get(:__struct__)
@@ -190,6 +194,30 @@ defmodule Pulsar.Protocol do
 
   defp field_name_from_type(:REDELIVER_UNACKNOWLEDGED_MESSAGES) do
     :redeliverUnacknowledgedMessages
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_LOOKUP) do
+    :scalableTopicLookup
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_CLOSE) do
+    :scalableTopicClose
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_UPDATE) do
+    :scalableTopicUpdate
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_SUBSCRIBE) do
+    :scalableTopicSubscribe
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_SUBSCRIBE_RESPONSE) do
+    :scalableTopicSubscribeResponse
+  end
+
+  defp field_name_from_type(:SCALABLE_TOPIC_ASSIGNMENT_UPDATE) do
+    :scalableTopicAssignmentUpdate
   end
 
   defp field_name_from_type(type) do

--- a/lib/pulsar/protocol/binary.ex
+++ b/lib/pulsar/protocol/binary.ex
@@ -126,6 +126,32 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.KeySharedMode do
   field(:STICKY, 1)
 end
 
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.SegmentState do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "pulsar.proto.SegmentState",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:ACTIVE, 0)
+  field(:SEALED, 1)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableConsumerType do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "pulsar.proto.ScalableConsumerType",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:STREAM, 0)
+  field(:CHECKPOINT, 1)
+end
+
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.TxnAction do
   @moduledoc false
 
@@ -351,6 +377,18 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.BaseCommand.Type do
   field(:WATCH_TOPIC_UPDATE, 66)
   field(:WATCH_TOPIC_LIST_CLOSE, 67)
   field(:TOPIC_MIGRATED, 68)
+  field(:SCALABLE_TOPIC_LOOKUP, 70)
+  field(:SCALABLE_TOPIC_UPDATE, 71)
+  field(:SCALABLE_TOPIC_CLOSE, 72)
+  field(:SCALABLE_TOPIC_SUBSCRIBE, 73)
+  field(:SCALABLE_TOPIC_SUBSCRIBE_RESPONSE, 74)
+  field(:SCALABLE_TOPIC_ASSIGNMENT_UPDATE, 75)
+  field(:WATCH_SCALABLE_TOPICS, 76)
+  field(:WATCH_SCALABLE_TOPICS_UPDATE, 77)
+  field(:WATCH_SCALABLE_TOPICS_CLOSE, 78)
+  field(:WATCH_TC_ASSIGNMENTS, 79)
+  field(:WATCH_TC_ASSIGNMENTS_UPDATE, 80)
+  field(:WATCH_TC_ASSIGNMENTS_CLOSE, 81)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.Schema do
@@ -675,6 +713,20 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.FeatureFlags do
     optional: true,
     type: :bool,
     json_name: "supportsTopicWatcherReconcile",
+    default: false
+  )
+
+  field(:supports_scalable_topics, 8,
+    optional: true,
+    type: :bool,
+    json_name: "supportsScalableTopics",
+    default: false
+  )
+
+  field(:supports_tc_metadata_discovery, 9,
+    optional: true,
+    type: :bool,
+    json_name: "supportsTcMetadataDiscovery",
     default: false
   )
 end
@@ -1564,6 +1616,371 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTopicListClose do
   field(:watcher_id, 2, required: true, type: :uint64, json_name: "watcherId")
 end
 
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.SegmentInfoProto do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.SegmentInfoProto",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:segment_id, 1, required: true, type: :uint64, json_name: "segmentId")
+  field(:hash_start, 2, required: true, type: :uint32, json_name: "hashStart")
+  field(:hash_end, 3, required: true, type: :uint32, json_name: "hashEnd")
+
+  field(:state, 4,
+    required: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.SegmentState,
+    enum: true
+  )
+
+  field(:parent_ids, 5, repeated: true, type: :uint64, json_name: "parentIds")
+  field(:child_ids, 6, repeated: true, type: :uint64, json_name: "childIds")
+  field(:created_at_epoch, 7, required: true, type: :uint64, json_name: "createdAtEpoch")
+  field(:sealed_at_epoch, 8, optional: true, type: :uint64, json_name: "sealedAtEpoch")
+  field(:created_at_ms, 9, required: true, type: :uint64, json_name: "createdAtMs")
+  field(:sealed_at_ms, 10, optional: true, type: :uint64, json_name: "sealedAtMs")
+  field(:legacy_topic_name, 11, optional: true, type: :string, json_name: "legacyTopicName")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.SegmentBrokerAddress do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.SegmentBrokerAddress",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:segment_id, 1, required: true, type: :uint64, json_name: "segmentId")
+  field(:broker_url, 2, required: true, type: :string, json_name: "brokerUrl")
+  field(:broker_url_tls, 3, optional: true, type: :string, json_name: "brokerUrlTls")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicDAG do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.ScalableTopicDAG",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:epoch, 1, required: true, type: :uint64)
+  field(:segments, 2, repeated: true, type: Pulsar.Protocol.Binary.Pulsar.Proto.SegmentInfoProto)
+
+  field(:segment_brokers, 3,
+    repeated: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.SegmentBrokerAddress,
+    json_name: "segmentBrokers"
+  )
+
+  field(:controller_broker_url, 4, optional: true, type: :string, json_name: "controllerBrokerUrl")
+
+  field(:controller_broker_url_tls, 5,
+    optional: true,
+    type: :string,
+    json_name: "controllerBrokerUrlTls"
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicLookup do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicLookup",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:session_id, 1, required: true, type: :uint64, json_name: "sessionId")
+  field(:topic, 2, required: true, type: :string)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicUpdate do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:session_id, 1, required: true, type: :uint64, json_name: "sessionId")
+  field(:dag, 2, optional: true, type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicDAG)
+
+  field(:error, 3,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ServerError,
+    enum: true
+  )
+
+  field(:message, 4, optional: true, type: :string)
+  field(:resolved_topic_name, 5, optional: true, type: :string, json_name: "resolvedTopicName")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicClose do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicClose",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:session_id, 1, required: true, type: :uint64, json_name: "sessionId")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableAssignedSegment do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.ScalableAssignedSegment",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:segment_id, 1, required: true, type: :uint64, json_name: "segmentId")
+  field(:hash_start, 2, required: true, type: :uint32, json_name: "hashStart")
+  field(:hash_end, 3, required: true, type: :uint32, json_name: "hashEnd")
+  field(:segment_topic, 4, required: true, type: :string, json_name: "segmentTopic")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableConsumerAssignment do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.ScalableConsumerAssignment",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:layout_epoch, 1, required: true, type: :uint64, json_name: "layoutEpoch")
+
+  field(:segments, 2,
+    repeated: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableAssignedSegment
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicSubscribe do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicSubscribe",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:request_id, 1, required: true, type: :uint64, json_name: "requestId")
+  field(:topic, 2, required: true, type: :string)
+  field(:subscription, 3, required: true, type: :string)
+  field(:consumer_name, 4, required: true, type: :string, json_name: "consumerName")
+  field(:consumer_id, 5, required: true, type: :uint64, json_name: "consumerId")
+
+  field(:consumer_type, 6,
+    required: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableConsumerType,
+    json_name: "consumerType",
+    enum: true
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicSubscribeResponse do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicSubscribeResponse",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:request_id, 1, required: true, type: :uint64, json_name: "requestId")
+
+  field(:error, 2,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ServerError,
+    enum: true
+  )
+
+  field(:message, 3, optional: true, type: :string)
+
+  field(:assignment, 4,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableConsumerAssignment
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicAssignmentUpdate do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandScalableTopicAssignmentUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:consumer_id, 1, required: true, type: :uint64, json_name: "consumerId")
+
+  field(:assignment, 2,
+    required: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableConsumerAssignment
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopics do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchScalableTopics",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+  field(:namespace, 2, required: true, type: :string)
+
+  field(:property_filters, 3,
+    repeated: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.KeyValue,
+    json_name: "propertyFilters"
+  )
+
+  field(:current_hash, 4, optional: true, type: :string, json_name: "currentHash")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicsSnapshot do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.ScalableTopicsSnapshot",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:topics, 1, repeated: true, type: :string)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicsDiff do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.ScalableTopicsDiff",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:added, 1, repeated: true, type: :string)
+  field(:removed, 2, repeated: true, type: :string)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopicsUpdate do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchScalableTopicsUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  oneof(:event, 0)
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+
+  field(:snapshot, 2,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicsSnapshot,
+    oneof: 0
+  )
+
+  field(:diff, 3,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ScalableTopicsDiff,
+    oneof: 0
+  )
+
+  field(:error, 4,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ServerError,
+    enum: true
+  )
+
+  field(:message, 5, optional: true, type: :string)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopicsClose do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchScalableTopicsClose",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignments do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchTcAssignments",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.TcAssignment do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.TcAssignment",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:tc_id, 1, required: true, type: :uint64, json_name: "tcId")
+  field(:broker_service_url, 2, optional: true, type: :string, json_name: "brokerServiceUrl")
+
+  field(:broker_service_url_tls, 3,
+    optional: true,
+    type: :string,
+    json_name: "brokerServiceUrlTls"
+  )
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.TcAssignmentsSnapshot do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.TcAssignmentsSnapshot",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:parallelism, 1, required: true, type: :uint32)
+  field(:assignments, 2, repeated: true, type: Pulsar.Protocol.Binary.Pulsar.Proto.TcAssignment)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignmentsUpdate do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchTcAssignmentsUpdate",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+
+  field(:snapshot, 2,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.TcAssignmentsSnapshot
+  )
+
+  field(:error, 3,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.ServerError,
+    enum: true
+  )
+
+  field(:message, 4, optional: true, type: :string)
+end
+
+defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignmentsClose do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "pulsar.proto.CommandWatchTcAssignmentsClose",
+    protoc_gen_elixir_version: "0.17.0",
+    syntax: :proto2
+
+  field(:watch_id, 1, required: true, type: :uint64, json_name: "watchId")
+end
+
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandGetSchema do
   @moduledoc false
 
@@ -1610,6 +2027,7 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandGetOrCreateSchema do
   field(:request_id, 1, required: true, type: :uint64, json_name: "requestId")
   field(:topic, 2, required: true, type: :string)
   field(:schema, 3, required: true, type: Pulsar.Protocol.Binary.Pulsar.Proto.Schema)
+  field(:producerName, 4, optional: true, type: :string)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandGetOrCreateSchemaResponse do
@@ -1643,6 +2061,7 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandTcClientConnectRequest do
 
   field(:request_id, 1, required: true, type: :uint64, json_name: "requestId")
   field(:tc_id, 2, required: true, type: :uint64, json_name: "tcId", default: 0)
+  field(:scalable, 3, optional: true, type: :bool, default: false)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandTcClientConnectResponse do
@@ -1673,8 +2092,9 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandNewTxn do
     syntax: :proto2
 
   field(:request_id, 1, required: true, type: :uint64, json_name: "requestId")
-  field(:txn_ttl_seconds, 2, optional: true, type: :uint64, json_name: "txnTtlSeconds", default: 0)
+  field(:txn_ttl_millis, 2, optional: true, type: :uint64, json_name: "txnTtlMillis", default: 0)
   field(:tc_id, 3, optional: true, type: :uint64, json_name: "tcId", default: 0)
+  field(:scalable, 4, optional: true, type: :bool, default: false)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandNewTxnResponse do
@@ -1724,6 +2144,7 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandAddPartitionToTxn do
 
   field(:txnid_most_bits, 3, optional: true, type: :uint64, json_name: "txnidMostBits", default: 0)
   field(:partitions, 4, repeated: true, type: :string)
+  field(:scalable, 5, optional: true, type: :bool, default: false)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandAddPartitionToTxnResponse do
@@ -1785,6 +2206,7 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandAddSubscriptionToTxn do
 
   field(:txnid_most_bits, 3, optional: true, type: :uint64, json_name: "txnidMostBits", default: 0)
   field(:subscription, 4, repeated: true, type: Pulsar.Protocol.Binary.Pulsar.Proto.Subscription)
+  field(:scalable, 5, optional: true, type: :bool, default: false)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandAddSubscriptionToTxnResponse do
@@ -1840,6 +2262,8 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandEndTxn do
     json_name: "txnAction",
     enum: true
   )
+
+  field(:scalable, 5, optional: true, type: :bool, default: false)
 end
 
 defmodule Pulsar.Protocol.Binary.Pulsar.Proto.CommandEndTxnResponse do
@@ -2246,5 +2670,65 @@ defmodule Pulsar.Protocol.Binary.Pulsar.Proto.BaseCommand do
   field(:topicMigrated, 68,
     optional: true,
     type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandTopicMigrated
+  )
+
+  field(:scalableTopicLookup, 70,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicLookup
+  )
+
+  field(:scalableTopicUpdate, 71,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicUpdate
+  )
+
+  field(:scalableTopicClose, 72,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicClose
+  )
+
+  field(:scalableTopicSubscribe, 73,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicSubscribe
+  )
+
+  field(:scalableTopicSubscribeResponse, 74,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicSubscribeResponse
+  )
+
+  field(:scalableTopicAssignmentUpdate, 75,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandScalableTopicAssignmentUpdate
+  )
+
+  field(:watchScalableTopics, 76,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopics
+  )
+
+  field(:watchScalableTopicsUpdate, 77,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopicsUpdate
+  )
+
+  field(:watchScalableTopicsClose, 78,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchScalableTopicsClose
+  )
+
+  field(:watchTcAssignments, 79,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignments
+  )
+
+  field(:watchTcAssignmentsUpdate, 80,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignmentsUpdate
+  )
+
+  field(:watchTcAssignmentsClose, 81,
+    optional: true,
+    type: Pulsar.Protocol.Binary.Pulsar.Proto.CommandWatchTcAssignmentsClose
   )
 end

--- a/lib/pulsar/scalable_consumer.ex
+++ b/lib/pulsar/scalable_consumer.ex
@@ -1,0 +1,171 @@
+defmodule Pulsar.ScalableConsumer do
+  @moduledoc """
+  A supervisor that consumes a scalable topic (PIP-460/466/468) by fanning out
+  one `Pulsar.ConsumerGroup` per segment.
+
+  This is the scalable-topic analogue of `Pulsar.PartitionedConsumer`. The
+  segment set is driven by a single `Pulsar.ScalableWatcher` started in one of
+  two modes via `:scalable_type`:
+
+    * `:queue` (default) — consume *every* segment of the DAG (Shared, individual
+      acks). The analogue of how `Pulsar.PartitionDiscovery` grows a
+      `PartitionedConsumer`, but push-based and bidirectional (segments are also
+      removed when GC'd).
+    * `:stream` — register with the controller and consume only the *assigned*
+      subset of segments (Failover per segment, ordered). The broker guarantees
+      per-key ordering across split/merge by withholding child segments until
+      their parent has drained.
+
+  In both cases the watcher reconciles the per-segment consumer groups as the
+  topology/assignment changes.
+  """
+
+  use Supervisor
+
+  alias Pulsar.ScalableWatcher
+
+  require Logger
+
+  @default_client :default
+
+  @doc """
+  Starts a scalable consumer supervisor. Blocks until the first segment set has
+  been applied, so the initial consumers exist when this returns.
+
+  `opts`:
+    * `:scalable_type` - `:queue` (default) or `:stream`
+    * `:subscription_type` - per-segment subscription type for `:queue`
+      (default `:Shared`); ignored for `:stream` (which uses `:Failover`)
+    * other options are forwarded to the segment consumer groups
+  """
+  def start_link(name, topic, subscription_name, callback_module, opts \\ []) do
+    client = Keyword.get(opts, :client, @default_client)
+    consumer_registry = Pulsar.Client.consumer_registry(client)
+
+    case Supervisor.start_link(
+           __MODULE__,
+           {name, topic, subscription_name, callback_module, opts},
+           name: {:via, Registry, {consumer_registry, name}}
+         ) do
+      {:ok, supervisor} = ok ->
+        await_ready(supervisor, opts)
+        ok
+
+      other ->
+        other
+    end
+  end
+
+  @doc """
+  Stops a scalable consumer supervisor and all its segment consumer groups.
+  """
+  def stop(supervisor_pid, reason \\ :normal, timeout \\ :infinity) do
+    Supervisor.stop(supervisor_pid, reason, timeout)
+  end
+
+  @doc """
+  Returns `{segment_id, group_pid}` tuples for the segment consumer groups.
+  """
+  def get_segment_groups(supervisor_pid) do
+    supervisor_pid
+    |> Supervisor.which_children()
+    |> Enum.filter(fn {_id, _pid, type, _modules} -> type == :supervisor end)
+    |> Enum.map(fn {segment_id, group_pid, _type, _modules} -> {segment_id, group_pid} end)
+  end
+
+  @doc """
+  Returns all consumer processes across every segment group.
+  """
+  def get_consumers(supervisor_pid) do
+    supervisor_pid
+    |> get_segment_groups()
+    |> Enum.flat_map(fn {_segment_id, group_pid} ->
+      Pulsar.ConsumerGroup.get_consumers(group_pid)
+    end)
+  end
+
+  @impl true
+  def init({name, topic, subscription_name, callback_module, opts}) do
+    client = Keyword.get(opts, :client, @default_client)
+    {source, source_opts, segment_subscription_type} = source_config(opts, subscription_name, client)
+
+    Logger.info("Starting scalable #{Keyword.get(opts, :scalable_type, :queue)} consumer for #{topic}")
+
+    build_child_spec = fn segment_id, segment_topic ->
+      segment_child_spec(
+        segment_id,
+        name,
+        segment_topic,
+        subscription_name,
+        segment_subscription_type,
+        callback_module,
+        opts
+      )
+    end
+
+    watcher_opts =
+      [source: source, topic: topic, supervisor: self(), build_child_spec: build_child_spec] ++ source_opts
+
+    watcher_spec = %{
+      id: ScalableWatcher,
+      start: {ScalableWatcher, :start_link, [watcher_opts]},
+      restart: :permanent,
+      type: :worker
+    }
+
+    Supervisor.init([watcher_spec], strategy: :one_for_one)
+  end
+
+  defp source_config(opts, subscription_name, client) do
+    case Keyword.get(opts, :scalable_type, :queue) do
+      :stream ->
+        {ScalableWatcher.Assignment,
+         [client: client, subscription: subscription_name, consumer_name: Keyword.get(opts, :consumer_name)], :Failover}
+
+      :queue ->
+        {ScalableWatcher.Topology, [client: client], Keyword.get(opts, :subscription_type, :Shared)}
+    end
+  end
+
+  defp segment_child_spec(segment_id, name, topic, subscription_name, subscription_type, callback_module, opts) do
+    group_name = "#{name}-segment-#{segment_id}"
+
+    %{
+      id: segment_id,
+      start: {
+        Pulsar.ConsumerGroup,
+        :start_link,
+        [group_name, topic, subscription_name, subscription_type, callback_module, opts]
+      },
+      restart: :permanent,
+      type: :supervisor
+    }
+  end
+
+  defp await_ready(supervisor, opts) do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    case find_watcher(supervisor) do
+      nil ->
+        :ok
+
+      pid ->
+        try do
+          ScalableWatcher.await_ready(pid, timeout)
+        catch
+          :exit, _reason -> :ok
+        end
+
+        :ok
+    end
+  end
+
+  defp find_watcher(supervisor) do
+    supervisor
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {ScalableWatcher, pid, _type, _modules} when is_pid(pid) -> pid
+      _ -> nil
+    end)
+  end
+end

--- a/lib/pulsar/scalable_consumer.ex
+++ b/lib/pulsar/scalable_consumer.ex
@@ -5,7 +5,7 @@ defmodule Pulsar.ScalableConsumer do
 
   This is the scalable-topic analogue of `Pulsar.PartitionedConsumer`. The
   segment set is driven by a single `Pulsar.ScalableWatcher` started in one of
-  two modes via `:scalable_type`:
+  two modes via `:consumer_type`:
 
     * `:queue` (default) — consume *every* segment of the DAG (Shared, individual
       acks). The analogue of how `Pulsar.PartitionDiscovery` grows a
@@ -33,7 +33,7 @@ defmodule Pulsar.ScalableConsumer do
   been applied, so the initial consumers exist when this returns.
 
   `opts`:
-    * `:scalable_type` - `:queue` (default) or `:stream`
+    * `:consumer_type` - `:queue` (default) or `:stream`
     * `:subscription_type` - per-segment subscription type for `:queue`
       (default `:Shared`); ignored for `:stream` (which uses `:Failover`)
     * other options are forwarded to the segment consumer groups
@@ -89,7 +89,7 @@ defmodule Pulsar.ScalableConsumer do
     client = Keyword.get(opts, :client, @default_client)
     {source, source_opts, segment_subscription_type} = source_config(opts, subscription_name, client)
 
-    Logger.info("Starting scalable #{Keyword.get(opts, :scalable_type, :queue)} consumer for #{topic}")
+    Logger.info("Starting scalable #{Keyword.get(opts, :consumer_type, :queue)} consumer for #{topic}")
 
     build_child_spec = fn segment_id, segment_topic ->
       segment_child_spec(
@@ -117,7 +117,7 @@ defmodule Pulsar.ScalableConsumer do
   end
 
   defp source_config(opts, subscription_name, client) do
-    case Keyword.get(opts, :scalable_type, :queue) do
+    case Keyword.get(opts, :consumer_type, :queue) do
       :stream ->
         {ScalableWatcher.Assignment,
          [client: client, subscription: subscription_name, consumer_name: Keyword.get(opts, :consumer_name)], :Failover}

--- a/lib/pulsar/scalable_watcher.ex
+++ b/lib/pulsar/scalable_watcher.ex
@@ -1,0 +1,226 @@
+defmodule Pulsar.ScalableWatcher do
+  @moduledoc """
+  Watches a scalable topic (PIP-460/466/468) and reconciles one consumer group
+  per segment into a parent supervisor as the topology changes.
+
+  This is the single coordinator behind both scalable consumer models. The
+  difference between them lives entirely in a pluggable **source**
+  (`Pulsar.ScalableWatcher.Source`):
+
+    * `Pulsar.ScalableWatcher.Topology` (queue) — opens a DAG watch session and
+      consumes *every* segment.
+    * `Pulsar.ScalableWatcher.Assignment` (stream) — registers with the
+      controller and consumes the *assigned subset*.
+
+  A source turns the broker's pushed messages into a desired segment set
+  (`%{segment_id => topic}` + an epoch); everything else — broker connection
+  monitoring, the `await_ready/2` handshake, stale-epoch filtering, and the
+  add/remove reconcile against the supervisor — is handled here and is identical
+  for both models.
+
+  Runs as a worker child of the consumer's supervisor and adds/removes segment
+  children on it via the `build_child_spec` fun, so it stays agnostic to whether
+  the children are consumers or (eventually) producers.
+  """
+
+  use GenServer
+
+  require Logger
+
+  defmodule Source do
+    @moduledoc """
+    Behaviour for a scalable watcher's segment source.
+
+    Implementations encapsulate the broker protocol (watch session vs. controller
+    registration) and how a pushed message maps to the desired segment set.
+    """
+
+    @type state :: term()
+    @type desired :: %{integer() => String.t()}
+
+    @doc "Builds the source state from the watcher options."
+    @callback init(opts :: keyword()) :: state
+
+    @doc """
+    Establishes the broker channel for `owner` (resolve broker, register, send
+    the opening command). Returns the broker pid to monitor, the updated source
+    state, and an optional initial desired set (`nil` when it arrives later as a
+    pushed message).
+    """
+    @callback open(state, owner :: pid()) ::
+                {:ok, broker_pid :: pid(), state, nil | {epoch :: integer(), desired}}
+                | {:error, term()}
+
+    @doc """
+    Maps a pushed `{:broker_message, _}` payload to `{:update, epoch, desired,
+    state}`, or `:ignore` for messages this source doesn't care about.
+    """
+    @callback handle_update(message :: term(), state) :: {:update, integer(), desired, state} | :ignore
+  end
+
+  defstruct [
+    :source,
+    :source_state,
+    :topic,
+    :supervisor,
+    :build_child_spec,
+    :broker_pid,
+    :broker_monitor,
+    :epoch,
+    ready: false,
+    waiters: []
+  ]
+
+  @doc """
+  Starts a watcher.
+
+  Options: `:source` (a `Source` module), `:topic`, `:supervisor`,
+  `:build_child_spec` (required); plus any options the source's `init/1` needs.
+  """
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @doc """
+  Blocks until the first desired segment set has been applied (reconciled), so
+  the caller observes the segment consumers once it returns.
+  """
+  def await_ready(watcher, timeout \\ 5_000), do: GenServer.call(watcher, :await_ready, timeout)
+
+  @impl true
+  def init(opts) do
+    source = Keyword.fetch!(opts, :source)
+
+    state = %__MODULE__{
+      source: source,
+      source_state: source.init(opts),
+      topic: Keyword.fetch!(opts, :topic),
+      supervisor: Keyword.fetch!(opts, :supervisor),
+      build_child_spec: Keyword.fetch!(opts, :build_child_spec)
+    }
+
+    Logger.info("Starting scalable watcher (#{inspect(source)}) for #{state.topic}")
+    {:ok, state, {:continue, :open}}
+  end
+
+  @impl true
+  def handle_continue(:open, state) do
+    case state.source.open(state.source_state, self()) do
+      {:ok, broker_pid, source_state, initial} ->
+        broker_monitor = Process.monitor(broker_pid)
+
+        state = %{
+          state
+          | broker_pid: broker_pid,
+            broker_monitor: broker_monitor,
+            source_state: source_state
+        }
+
+        {:noreply, apply_initial(initial, state)}
+
+      {:error, reason} ->
+        {:stop, reason, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:await_ready, _from, %{ready: true} = state), do: {:reply, :ok, state}
+  def handle_call(:await_ready, from, state), do: {:noreply, %{state | waiters: [from | state.waiters]}}
+
+  @impl true
+  def handle_info({:broker_message, message}, state) do
+    case state.source.handle_update(message, state.source_state) do
+      {:update, epoch, desired, source_state} ->
+        {:noreply, apply_desired(%{state | source_state: source_state}, epoch, desired)}
+
+      :ignore ->
+        {:noreply, state}
+    end
+  end
+
+  # The broker connection died. Stop so the supervisor restarts us and we
+  # re-establish the source against a fresh connection.
+  def handle_info({:DOWN, monitor_ref, :process, _pid, reason}, %{broker_monitor: monitor_ref} = state) do
+    Logger.warning("Scalable watcher lost broker for #{state.topic}: #{inspect(reason)}")
+    {:stop, :broker_disconnected, state}
+  end
+
+  def handle_info(message, state) do
+    Logger.debug("ScalableWatcher ignoring unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  ## Internal
+
+  defp apply_initial(nil, state), do: state
+  defp apply_initial({epoch, desired}, state), do: apply_desired(state, epoch, desired)
+
+  defp apply_desired(state, epoch, desired) do
+    if stale?(state.epoch, epoch) do
+      Logger.debug("Ignoring stale scalable epoch #{epoch} for #{state.topic}")
+      state
+    else
+      Logger.debug("Scalable update for #{state.topic}: epoch #{epoch}, #{map_size(desired)} segment(s)")
+
+      # Reconcile before replying so a caller blocked in await_ready/2 observes
+      # the segment children once it returns.
+      reconcile(state, desired)
+      mark_ready(%{state | epoch: epoch})
+    end
+  end
+
+  defp stale?(nil, _incoming), do: false
+  defp stale?(current, incoming), do: incoming < current
+
+  defp mark_ready(state) do
+    Enum.each(state.waiters, &GenServer.reply(&1, :ok))
+    %{state | ready: true, waiters: []}
+  end
+
+  # Add a child for each desired segment we don't have; remove a child for each
+  # running segment no longer desired.
+  defp reconcile(state, desired) do
+    existing = existing_segment_ids(state.supervisor)
+
+    desired
+    |> Enum.reject(fn {segment_id, _topic} -> MapSet.member?(existing, segment_id) end)
+    |> Enum.each(fn {segment_id, segment_topic} -> add_segment(state, segment_id, segment_topic) end)
+
+    existing
+    |> Enum.reject(&Map.has_key?(desired, &1))
+    |> Enum.each(&remove_segment(state.supervisor, &1, state.topic))
+  end
+
+  defp add_segment(state, segment_id, segment_topic) do
+    case Supervisor.start_child(state.supervisor, state.build_child_spec.(segment_id, segment_topic)) do
+      {:ok, _pid} ->
+        Logger.info("Scalable watcher: added segment #{segment_id} (#{segment_topic}) for #{state.topic}")
+
+      {:ok, _pid, _info} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Scalable watcher: failed to add segment #{segment_id} for #{state.topic}: #{inspect(reason)}")
+    end
+  end
+
+  defp remove_segment(supervisor, segment_id, topic) do
+    Logger.info("Scalable watcher: removing segment #{segment_id} for #{topic}")
+
+    with :ok <- Supervisor.terminate_child(supervisor, segment_id),
+         :ok <- Supervisor.delete_child(supervisor, segment_id) do
+      :ok
+    else
+      {:error, reason} ->
+        Logger.warning("Scalable watcher: failed to remove segment #{segment_id} for #{topic}: #{inspect(reason)}")
+    end
+  end
+
+  defp existing_segment_ids(supervisor) do
+    supervisor
+    |> Supervisor.which_children()
+    |> Enum.filter(fn {id, _pid, type, _modules} -> type == :supervisor and is_integer(id) end)
+    |> MapSet.new(fn {id, _pid, _type, _modules} -> id end)
+  end
+end

--- a/lib/pulsar/scalable_watcher/assignment.ex
+++ b/lib/pulsar/scalable_watcher/assignment.ex
@@ -1,0 +1,77 @@
+defmodule Pulsar.ScalableWatcher.Assignment do
+  @moduledoc """
+  Stream-model source for `Pulsar.ScalableWatcher`.
+
+  Registers with the controller (`CommandScalableTopicSubscribe`, type STREAM),
+  taking the initial assignment from the response, and turns each pushed
+  `CommandScalableTopicAssignmentUpdate` into the assigned subset of segments.
+  Each assigned segment arrives as a ready-made `segment://…` topic.
+
+  Ordering across split/merge is the broker's job: the controller withholds a
+  child segment until its parent has drained, so this source only ever reports
+  whatever it is currently assigned.
+  """
+
+  @behaviour Pulsar.ScalableWatcher.Source
+
+  alias Pulsar.Broker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+  alias Pulsar.ServiceDiscovery
+
+  @default_client :default
+
+  defstruct [:topic, :client, :subscription, :consumer_name, :consumer_id, :consumer_type]
+
+  @impl true
+  def init(opts) do
+    consumer_id = System.unique_integer([:positive, :monotonic])
+
+    %__MODULE__{
+      topic: Keyword.fetch!(opts, :topic),
+      client: Keyword.get(opts, :client, @default_client),
+      subscription: Keyword.fetch!(opts, :subscription),
+      # The controller keys each consumer by name in a metadata path, so it must
+      # be non-empty and unique within the subscription.
+      consumer_name: Keyword.get(opts, :consumer_name) || "consumer-#{consumer_id}",
+      consumer_id: consumer_id,
+      consumer_type: Keyword.get(opts, :consumer_type, :STREAM)
+    }
+  end
+
+  @impl true
+  def open(state, owner) do
+    with {:ok, broker_pid} <- ServiceDiscovery.lookup_topic(state.topic, client: state.client),
+         :ok <- Broker.register_watcher(broker_pid, state.consumer_id, owner),
+         {:ok, %Binary.CommandScalableTopicSubscribeResponse{error: nil} = response} <-
+           Broker.send_request(broker_pid, %Binary.CommandScalableTopicSubscribe{
+             topic: state.topic,
+             subscription: state.subscription,
+             consumer_name: state.consumer_name,
+             consumer_id: state.consumer_id,
+             consumer_type: state.consumer_type
+           }) do
+      {:ok, broker_pid, state, to_desired(response.assignment)}
+    else
+      {:ok, %Binary.CommandScalableTopicSubscribeResponse{error: error, message: message}} ->
+        {:error, {:scalable_subscribe_failed, error, message}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def handle_update(%Binary.CommandScalableTopicAssignmentUpdate{} = update, state) do
+    {epoch, desired} = to_desired(update.assignment)
+    {:update, epoch, desired, state}
+  end
+
+  def handle_update(_message, _state), do: :ignore
+
+  defp to_desired(nil), do: {0, %{}}
+
+  defp to_desired(%Binary.ScalableConsumerAssignment{} = assignment) do
+    desired = Map.new(assignment.segments, fn segment -> {segment.segment_id, segment.segment_topic} end)
+    {assignment.layout_epoch, desired}
+  end
+end

--- a/lib/pulsar/scalable_watcher/topology.ex
+++ b/lib/pulsar/scalable_watcher/topology.ex
@@ -1,0 +1,97 @@
+defmodule Pulsar.ScalableWatcher.Topology do
+  @moduledoc """
+  Queue-model source for `Pulsar.ScalableWatcher`.
+
+  Opens a DAG watch session (`CommandScalableTopicLookup`) and turns each pushed
+  `CommandScalableTopicUpdate` into the set of *all* consumable segments — both
+  active and sealed, so sealed segments keep draining until the controller GC's
+  them out of the DAG.
+  """
+
+  @behaviour Pulsar.ScalableWatcher.Source
+
+  alias Pulsar.Broker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+  alias Pulsar.ServiceDiscovery
+
+  require Logger
+
+  @default_client :default
+
+  defstruct [:topic, :client, :session_id, :resolved_topic_name]
+
+  @impl true
+  def init(opts) do
+    %__MODULE__{
+      topic: Keyword.fetch!(opts, :topic),
+      client: Keyword.get(opts, :client, @default_client),
+      session_id: System.unique_integer([:positive, :monotonic])
+    }
+  end
+
+  @impl true
+  def open(state, owner) do
+    close_command = %Binary.CommandScalableTopicClose{session_id: state.session_id}
+
+    with {:ok, broker_pid} <- ServiceDiscovery.lookup_topic(state.topic, client: state.client),
+         :ok <- Broker.register_watcher(broker_pid, state.session_id, owner, close_command) do
+      # Fire-and-forget: the initial reply and all later updates arrive as routed
+      # CommandScalableTopicUpdate messages, not a synchronous response.
+      Broker.send_command(broker_pid, %Binary.CommandScalableTopicLookup{
+        session_id: state.session_id,
+        topic: state.topic
+      })
+
+      {:ok, broker_pid, state, nil}
+    end
+  end
+
+  @impl true
+  def handle_update(%Binary.CommandScalableTopicUpdate{error: error} = update, _state) when error != nil do
+    Logger.warning("Scalable topology watch error: #{error} #{update.message}")
+    :ignore
+  end
+
+  def handle_update(%Binary.CommandScalableTopicUpdate{dag: nil}, _state), do: :ignore
+
+  def handle_update(%Binary.CommandScalableTopicUpdate{dag: dag} = update, state) do
+    resolved = update.resolved_topic_name || state.resolved_topic_name
+    desired = desired_segments(dag, resolved, state.topic)
+    {:update, dag.epoch, desired, %{state | resolved_topic_name: resolved}}
+  end
+
+  def handle_update(_message, _state), do: :ignore
+
+  # %{segment_id => consume_topic} for every consumable segment in the DAG.
+  defp desired_segments(dag, resolved_topic_name, topic) do
+    Enum.reduce(dag.segments, %{}, fn segment, acc ->
+      case consume_target(segment, resolved_topic_name) do
+        {:ok, consume_topic} ->
+          Map.put(acc, segment.segment_id, consume_topic)
+
+        {:error, reason} ->
+          Logger.warning("Scalable topology: skipping segment #{segment.segment_id} for #{topic}: #{inspect(reason)}")
+          acc
+      end
+    end)
+  end
+
+  # Legacy segments carry the backing persistent:// topic; native segments are
+  # addressed by a computed segment://<topic>/<hash_start:04x>-<hash_end:04x>-<id>
+  # URI derived from the canonical (topic://…) name, which classic subscribe accepts.
+  defp consume_target(%Binary.SegmentInfoProto{legacy_topic_name: name}, _resolved) when is_binary(name) and name != "" do
+    {:ok, name}
+  end
+
+  defp consume_target(%Binary.SegmentInfoProto{} = segment, resolved_topic_name) when is_binary(resolved_topic_name) do
+    base = String.replace_prefix(resolved_topic_name, "topic://", "")
+    descriptor = "#{hex4(segment.hash_start)}-#{hex4(segment.hash_end)}-#{segment.segment_id}"
+    {:ok, "segment://#{base}/#{descriptor}"}
+  end
+
+  defp consume_target(%Binary.SegmentInfoProto{segment_id: id}, _resolved) do
+    {:error, {:unresolved_segment, id}}
+  end
+
+  defp hex4(n), do: n |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(4, "0")
+end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Pulsar.MixProject do
         main: "Pulsar",
         extras: [
           "README.md",
+          "docs/consumers.md",
           "docs/chunking.md",
           "docs/schemas.md",
           "docs/reader.md"

--- a/pulsar.proto
+++ b/pulsar.proto
@@ -316,6 +316,8 @@ message FeatureFlags {
   optional bool supports_get_partitioned_metadata_without_auto_creation = 5 [default = false];
   optional bool supports_repl_dedup_by_lid_and_eid = 6 [default = false];
   optional bool supports_topic_watcher_reconcile = 7 [default = false];
+  optional bool supports_scalable_topics = 8 [default = false];
+  optional bool supports_tc_metadata_discovery = 9 [default = false];
 }
 
 message CommandConnected {
@@ -834,6 +836,226 @@ message CommandWatchTopicListClose {
     required uint64 watcher_id     = 2;
 }
 
+/// --- Scalable topic commands ---
+
+enum SegmentState {
+    ACTIVE = 0;
+    SEALED = 1;
+}
+
+message SegmentInfoProto {
+    required uint64 segment_id       = 1;
+    required uint32 hash_start       = 2;
+    required uint32 hash_end         = 3;
+    required SegmentState state      = 4;
+    repeated uint64 parent_ids       = 5;
+    repeated uint64 child_ids        = 6;
+    required uint64 created_at_epoch = 7;
+    optional uint64 sealed_at_epoch  = 8;
+    // Wall-clock millis at create / seal time. Used for retention-based segment GC
+    // and timestamp-based seek; epoch above is a DAG generation number, not a clock.
+    required uint64 created_at_ms    = 9;
+    optional uint64 sealed_at_ms     = 10;
+
+    // Legacy-segment marker. When set, this segment is not managed by the scalable-topic
+    // controller and has no segment://... topic of its own — it wraps the named, externally
+    // managed persistent://... topic instead. Used by the synthetic-layout response the
+    // broker returns for a regular (partitioned or non-partitioned) topic that has not yet
+    // been migrated to a scalable topic. When absent, the segment URI is computed normally
+    // from the scalable topic name and segment_id (segment://<topic>/<descriptor>).
+    optional string legacy_topic_name = 11;
+}
+
+message SegmentBrokerAddress {
+    required uint64 segment_id     = 1;
+    required string broker_url     = 2;
+    optional string broker_url_tls = 3;
+}
+
+message ScalableTopicDAG {
+    required uint64 epoch                           = 1;
+    repeated SegmentInfoProto segments              = 2;
+    repeated SegmentBrokerAddress segment_brokers   = 3;
+    optional string controller_broker_url           = 4;
+    optional string controller_broker_url_tls       = 5;
+}
+
+// Client -> Broker: Request scalable topic metadata and initiate watch session
+message CommandScalableTopicLookup {
+    required uint64 session_id = 1;   // Client-assigned session ID
+    // Any of "topic://t/n/x", "persistent://t/n/x", or a short form like
+    // "my-topic" (normalized by the broker to persistent://public/default/my-topic).
+    // The broker resolves the input to the canonical topic://... identity and
+    // returns it in CommandScalableTopicUpdate.resolved_topic_name.
+    required string topic      = 2;
+}
+
+// Broker -> Client: Used for BOTH initial response and subsequent pushed updates
+message CommandScalableTopicUpdate {
+    required uint64 session_id         = 1;
+    optional ScalableTopicDAG dag      = 2;
+
+    optional ServerError error         = 3;
+    optional string message            = 4;
+
+    // Canonical scalable-topic identity (always "topic://t/n/x") that the client
+    // should use for downstream operations. Set on every success response,
+    // including for inputs that were given as persistent://... or short-form.
+    // Absent on error responses.
+    optional string resolved_topic_name = 5;
+}
+
+// Client -> Broker: Close the DAG watch session
+message CommandScalableTopicClose {
+    required uint64 session_id = 1;
+}
+
+// Kind of scalable consumer registering with the controller leader.
+// QueueConsumer never registers — it attaches directly to all active and sealed
+// segment topics — so it does not appear here.
+enum ScalableConsumerType {
+    STREAM     = 0;
+    CHECKPOINT = 1;
+}
+
+// A single segment assigned to a scalable consumer.
+message ScalableAssignedSegment {
+    required uint64 segment_id             = 1;
+    required uint32 hash_start             = 2;
+    required uint32 hash_end               = 3;
+    // Fully-qualified segment:// topic name the consumer should attach to.
+    required string segment_topic          = 4;
+}
+
+// An assignment of active segments to a single consumer. Carries the layout epoch
+// it was computed from so the client can reject stale updates.
+message ScalableConsumerAssignment {
+    required uint64 layout_epoch                    = 1;
+    repeated ScalableAssignedSegment segments       = 2;
+}
+
+// Client -> Broker: register as an ordered (Stream) or external (Checkpoint) consumer
+// on a scalable topic and request the initial segment assignment. The broker leader
+// persists the consumer registration and returns the current assignment.
+message CommandScalableTopicSubscribe {
+    required uint64 request_id                  = 1;
+    required string topic                       = 2;  // e.g. "topic://tenant/ns/my-topic"
+    required string subscription                = 3;
+    required string consumer_name               = 4;
+    required uint64 consumer_id                 = 5;
+    required ScalableConsumerType consumer_type = 6;
+}
+
+// Broker -> Client: response to CommandScalableTopicSubscribe. On success, carries
+// the initial ScalableConsumerAssignment. On failure, error + message are populated
+// and the assignment is absent.
+message CommandScalableTopicSubscribeResponse {
+    required uint64 request_id                 = 1;
+    optional ServerError error                 = 2;
+    optional string message                    = 3;
+    optional ScalableConsumerAssignment assignment = 4;
+}
+
+// Broker -> Client: push a new assignment to a subscribed consumer after a rebalance
+// (triggered by a peer joining/leaving the subscription or by a segment split/merge).
+message CommandScalableTopicAssignmentUpdate {
+    required uint64 consumer_id                = 1;
+    required ScalableConsumerAssignment assignment = 2;
+}
+
+// Multi-topic consumer watcher: subscribes to the union of scalable topics in a
+// namespace that match a (possibly empty) set of property filters. The broker keeps
+// pushing updates as topics enter or leave the matching set. See
+// `multi-topic-consumer-design.md` for the full design.
+
+// Client -> Broker: open a watch session.
+message CommandWatchScalableTopics {
+    required uint64 watch_id          = 1;   // Client-assigned watch ID
+    required string namespace         = 2;   // tenant/namespace
+    // Optional AND filters; empty list means "match all topics in the namespace".
+    repeated KeyValue property_filters = 3;
+    // Hash of the topics the client believes are currently in its set. Sent on
+    // reconnect; absent on first subscribe. If it matches the broker's freshly
+    // computed hash, the broker skips emitting the initial Snapshot — the client's
+    // local state is already correct and future Diffs will flow as usual. Same
+    // hash function as CommandGetTopicsOfNamespace (CRC32C over sorted topics).
+    optional string current_hash       = 4;
+}
+
+// Snapshot of the full matching set. Sent on initial subscribe and on every
+// reconnect-resync. The client replaces its local set with this list.
+message ScalableTopicsSnapshot {
+    repeated string topics = 1;
+}
+
+// Incremental membership change. Apply removed before added when both are present.
+message ScalableTopicsDiff {
+    repeated string added   = 1;
+    repeated string removed = 2;
+}
+
+// Broker -> Client: either Snapshot or Diff (mutually exclusive via oneof). When the
+// initial subscribe fails, neither variant is set and `error`/`message` carry the
+// failure reason.
+message CommandWatchScalableTopicsUpdate {
+    required uint64 watch_id              = 1;
+
+    oneof event {
+        ScalableTopicsSnapshot snapshot = 2;
+        ScalableTopicsDiff diff         = 3;
+    }
+
+    optional ServerError error            = 4;
+    optional string message               = 5;
+}
+
+// Client -> Broker: close the watch session.
+message CommandWatchScalableTopicsClose {
+    required uint64 watch_id = 1;
+}
+
+/// --- Transaction-coordinator assignment watch ---
+// The scalable-topics transaction coordinator's discovery surface. The client opens one watch
+// and the broker replies with the full (partition -> leader) map, then pushes a fresh full
+// snapshot whenever any partition's leader changes. There is no point lookup and no diff: the
+// map is bounded (parallelism, ~16) and changes rarely, so always sending the whole snapshot is
+// simpler and removes a class of apply-ordering / drift bugs. Gated by the
+// supports_tc_metadata_discovery feature flag.
+
+// Client -> Broker: open the assignment watch.
+message CommandWatchTcAssignments {
+    required uint64 watch_id = 1;   // client-assigned
+}
+
+// One (partition -> leader) entry. A partition currently mid-election is simply absent from the
+// snapshot; the client parks any transaction routed there until a later snapshot fills it in.
+message TcAssignment {
+    required uint64 tc_id                  = 1;   // TC partition = TxnID.mostSigBits
+    optional string broker_service_url     = 2;
+    optional string broker_service_url_tls = 3;
+}
+
+// Full map. Sent on initial watch and again, in full, on every change. The client replaces its
+// local map wholesale — no merge, no ordering rules. parallelism lets the client size its handler
+// array without a separate metadata read.
+message TcAssignmentsSnapshot {
+    required uint32 parallelism       = 1;
+    repeated TcAssignment assignments = 2;
+}
+
+// Broker -> Client: the current full snapshot, or (on initial-watch failure) an error.
+message CommandWatchTcAssignmentsUpdate {
+    required uint64 watch_id                 = 1;
+    optional TcAssignmentsSnapshot snapshot  = 2;
+    optional ServerError error               = 3;
+    optional string message                  = 4;
+}
+
+// Client -> Broker: close the watch.
+message CommandWatchTcAssignmentsClose {
+    required uint64 watch_id = 1;
+}
+
 message CommandGetSchema {
     required uint64 request_id = 1;
     required string topic      = 2;
@@ -851,9 +1073,10 @@ message CommandGetSchemaResponse {
 }
 
 message CommandGetOrCreateSchema {
-    required uint64 request_id = 1;
-    required string topic      = 2;
-    required Schema schema     = 3;
+    required uint64 request_id      = 1;
+    required string topic           = 2;
+    required Schema schema          = 3;
+    optional string producerName    = 4;
 }
 
 message CommandGetOrCreateSchemaResponse {
@@ -874,6 +1097,8 @@ enum TxnAction {
 message CommandTcClientConnectRequest {
     required uint64 request_id = 1;
     required uint64 tc_id = 2 [default = 0];
+    // Route to the scalable-topics (PIP-473) coordinator. See CommandNewTxn.scalable.
+    optional bool scalable = 3 [default = false];
 }
 
 message CommandTcClientConnectResponse {
@@ -884,8 +1109,15 @@ message CommandTcClientConnectResponse {
 
 message CommandNewTxn {
     required uint64 request_id = 1;
-    optional uint64 txn_ttl_seconds = 2 [default = 0];
+    // Transaction timeout in milliseconds. Despite the field number's legacy name history, the value
+    // has always been carried in milliseconds (the client sends unit.toMillis(...) and both
+    // coordinators consume it as ms); the field is named accordingly to avoid confusion.
+    optional uint64 txn_ttl_millis = 2 [default = 0];
     optional uint64 tc_id = 3 [default = 0];
+    // When true, route to the metadata-driven (scalable-topics, PIP-473) transaction coordinator
+    // instead of the legacy one. Set by v5 clients; absent for v4 clients. Lets both coordinators
+    // serve their own clients on the same cluster.
+    optional bool scalable = 4 [default = false];
 }
 
 message CommandNewTxnResponse {
@@ -901,6 +1133,8 @@ message CommandAddPartitionToTxn {
     optional uint64 txnid_least_bits = 2 [default = 0];
     optional uint64 txnid_most_bits = 3 [default = 0];
     repeated string partitions = 4;
+    // Route to the scalable-topics (PIP-473) coordinator. See CommandNewTxn.scalable.
+    optional bool scalable = 5 [default = false];
 }
 
 message CommandAddPartitionToTxnResponse {
@@ -920,6 +1154,8 @@ message CommandAddSubscriptionToTxn {
     optional uint64 txnid_least_bits = 2 [default = 0];
     optional uint64 txnid_most_bits = 3 [default = 0];
     repeated Subscription subscription = 4;
+    // Route to the scalable-topics (PIP-473) coordinator. See CommandNewTxn.scalable.
+    optional bool scalable = 5 [default = false];
 }
 
 message CommandAddSubscriptionToTxnResponse {
@@ -935,6 +1171,8 @@ message CommandEndTxn {
     optional uint64 txnid_least_bits = 2 [default = 0];
     optional uint64 txnid_most_bits = 3 [default = 0];
     optional TxnAction txn_action = 4;
+    // Route to the scalable-topics (PIP-473) coordinator. See CommandNewTxn.scalable.
+    optional bool scalable = 5 [default = false];
 }
 
 message CommandEndTxnResponse {
@@ -1070,6 +1308,22 @@ message BaseCommand {
         WATCH_TOPIC_LIST_CLOSE = 67;
 
         TOPIC_MIGRATED = 68;
+
+        SCALABLE_TOPIC_LOOKUP  = 70;
+        SCALABLE_TOPIC_UPDATE  = 71;
+        SCALABLE_TOPIC_CLOSE   = 72;
+
+        SCALABLE_TOPIC_SUBSCRIBE              = 73;
+        SCALABLE_TOPIC_SUBSCRIBE_RESPONSE     = 74;
+        SCALABLE_TOPIC_ASSIGNMENT_UPDATE      = 75;
+
+        WATCH_SCALABLE_TOPICS                 = 76;
+        WATCH_SCALABLE_TOPICS_UPDATE          = 77;
+        WATCH_SCALABLE_TOPICS_CLOSE           = 78;
+
+        WATCH_TC_ASSIGNMENTS                  = 79;
+        WATCH_TC_ASSIGNMENTS_UPDATE           = 80;
+        WATCH_TC_ASSIGNMENTS_CLOSE            = 81;
     }
 
 
@@ -1153,4 +1407,20 @@ message BaseCommand {
     optional CommandWatchTopicListClose watchTopicListClose = 67;
 
     optional CommandTopicMigrated topicMigrated = 68;
+
+    optional CommandScalableTopicLookup scalableTopicLookup   = 70;
+    optional CommandScalableTopicUpdate scalableTopicUpdate    = 71;
+    optional CommandScalableTopicClose scalableTopicClose      = 72;
+
+    optional CommandScalableTopicSubscribe scalableTopicSubscribe                     = 73;
+    optional CommandScalableTopicSubscribeResponse scalableTopicSubscribeResponse     = 74;
+    optional CommandScalableTopicAssignmentUpdate scalableTopicAssignmentUpdate       = 75;
+
+    optional CommandWatchScalableTopics watchScalableTopics                           = 76;
+    optional CommandWatchScalableTopicsUpdate watchScalableTopicsUpdate               = 77;
+    optional CommandWatchScalableTopicsClose watchScalableTopicsClose                 = 78;
+
+    optional CommandWatchTcAssignments watchTcAssignments                             = 79;
+    optional CommandWatchTcAssignmentsUpdate watchTcAssignmentsUpdate                 = 80;
+    optional CommandWatchTcAssignmentsClose watchTcAssignmentsClose                   = 81;
 }

--- a/test/integration/consumer/ack_test.exs
+++ b/test/integration/consumer/ack_test.exs
@@ -1,0 +1,65 @@
+defmodule Pulsar.Integration.Consumer.AckTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Test.Support.System
+  alias Pulsar.Test.Support.Utils
+
+  @moduletag :integration
+  @client :ack_test_client
+
+  # Hands each message to the test process and acknowledges nothing
+  # automatically, so the test can drive a manual (cumulative) ack.
+  defmodule ManualAckConsumer do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(opts), do: {:ok, Keyword.fetch!(opts, :notify_pid)}
+
+    def handle_message(%Pulsar.Message{} = message, notify_pid) do
+      send(notify_pid, {:message, message})
+      {:noreply, notify_pid}
+    end
+  end
+
+  setup_all do
+    {:ok, _client_pid} =
+      Pulsar.Client.start_link(name: @client, host: System.broker().service_url)
+
+    on_exit(fn -> Pulsar.Client.stop(@client) end)
+
+    :ok
+  end
+
+  test "cumulative ack advances the cursor past all earlier messages" do
+    topic = "persistent://public/default/cumulative-ack-#{:erlang.unique_integer([:positive])}"
+    subscription = "cumulative-sub"
+    System.create_topic(topic)
+
+    {:ok, group} =
+      Pulsar.start_consumer(topic, subscription, ManualAckConsumer,
+        client: @client,
+        subscription_type: :Exclusive,
+        ack_type: :Cumulative,
+        initial_position: :earliest,
+        init_args: [notify_pid: self()]
+      )
+
+    System.produce_messages(topic, for(i <- 1..5, do: {"key-#{i}", "message-#{i}"}))
+
+    # Collect the 5 messages in delivery order (Exclusive preserves order),
+    # acknowledging none automatically.
+    messages = for _ <- 1..5, do: assert_receive({:message, %Pulsar.Message{} = m}, 5_000) && m
+    assert Enum.map(messages, & &1.payload) == for(i <- 1..5, do: "message-#{i}")
+
+    # Cumulatively ack the 3rd message: this marks 1, 2 and 3 as consumed, so the
+    # backlog drops to 2. With an Individual ack only message 3 would clear,
+    # leaving a backlog of 4.
+    [consumer_pid] = Pulsar.get_consumers(group)
+    third = Enum.at(messages, 2)
+    :ok = Pulsar.Consumer.ack(consumer_pid, third.message_id_to_ack)
+
+    assert :ok = Utils.wait_for(fn -> System.subscription_backlog(topic, subscription) == 2 end)
+
+    :ok = Pulsar.stop_consumer(group)
+  end
+end

--- a/test/integration/consumer/end_of_topic_test.exs
+++ b/test/integration/consumer/end_of_topic_test.exs
@@ -1,0 +1,62 @@
+defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Test.Support.System
+  alias Pulsar.Test.Support.Utils
+
+  @moduletag :integration
+  @client :end_of_topic_test_client
+  @consumer_callback Pulsar.Test.Support.DummyConsumer
+
+  setup_all do
+    {:ok, _client_pid} =
+      Pulsar.Client.start_link(name: @client, host: System.broker().service_url)
+
+    on_exit(fn -> Pulsar.Client.stop(@client) end)
+
+    :ok
+  end
+
+  # When a topic is terminated, the broker notifies a caught-up consumer with
+  # `CommandReachedEndOfTopic`. Reaching the end of a topic is informational, so
+  # the consumer must keep running and its broker connection must stay healthy.
+  test "consumer survives reaching the end of a terminated topic" do
+    topic = "persistent://public/default/end-of-topic-#{:erlang.unique_integer([:positive])}"
+    System.create_topic(topic)
+
+    {:ok, group} =
+      Pulsar.start_consumer(topic, "end-of-topic-sub", @consumer_callback,
+        client: @client,
+        initial_position: :earliest
+      )
+
+    messages = for i <- 1..3, do: {"key-#{i}", "message-#{i}"}
+    System.produce_messages(topic, messages)
+
+    assert :ok = Utils.wait_for(fn -> total_consumed(group) == length(messages) end)
+
+    [consumer_pid] = Pulsar.get_consumers(group)
+    ref = Process.monitor(consumer_pid)
+
+    System.terminate_topic(topic)
+
+    # The consumer must not be taken down by the end-of-topic notification.
+    refute_receive {:DOWN, ^ref, :process, ^consumer_pid, _reason}, 3_000
+    assert Process.alive?(consumer_pid)
+
+    :ok = Pulsar.stop_consumer(group)
+  end
+
+  defp total_consumed(group) do
+    group
+    |> Pulsar.get_consumers()
+    |> Enum.filter(&is_pid/1)
+    |> Enum.reduce(0, fn pid, acc ->
+      try do
+        @consumer_callback.count_messages(pid) + acc
+      catch
+        :exit, _reason -> acc
+      end
+    end)
+  end
+end

--- a/test/integration/consumer/scalable_consumer_test.exs
+++ b/test/integration/consumer/scalable_consumer_test.exs
@@ -41,6 +41,25 @@ defmodule Pulsar.Integration.Consumer.ScalableConsumerTest do
     :ok = Pulsar.stop_consumer(consumer)
   end
 
+  test "queue consumer consumes a legacy (non-scalable) topic" do
+    # `consumer_type: :queue` routes a regular `persistent://` topic to the
+    # scalable consumer. The broker resolves it to a synthetic single legacy
+    # segment backed by the persistent:// topic, which is consumed like any other.
+    topic = "persistent://" <> unique_topic("legacy-queue")
+    System.create_topic(topic)
+
+    messages = for i <- 1..5, do: {"key-#{i}", "message-#{i}"}
+    System.produce_messages(topic, messages)
+
+    {:ok, consumer} =
+      Pulsar.start_consumer(topic, "legacy-sub", @consumer_callback, subscription_options())
+
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(messages) end)
+    assert length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 1
+
+    :ok = Pulsar.stop_consumer(consumer)
+  end
+
   test "grows consumers when a segment splits" do
     path = unique_topic("scalable-split")
     topic = "topic://" <> path
@@ -69,7 +88,7 @@ defmodule Pulsar.Integration.Consumer.ScalableConsumerTest do
   end
 
   test "stream consumer consumes all messages across its assigned segments" do
-    # `scalable_type: :stream` registers with the controller and consumes the
+    # `consumer_type: :stream` registers with the controller and consumes the
     # assigned subset of segments. A lone stream consumer is assigned all of them.
     path = unique_topic("stream-multi")
     topic = "topic://" <> path
@@ -160,6 +179,7 @@ defmodule Pulsar.Integration.Consumer.ScalableConsumerTest do
   defp subscription_options do
     [
       client: @client,
+      consumer_type: :queue,
       initial_position: :earliest,
       flow_initial: 1,
       flow_threshold: 0,
@@ -167,7 +187,7 @@ defmodule Pulsar.Integration.Consumer.ScalableConsumerTest do
     ]
   end
 
-  defp stream_options, do: Keyword.put(subscription_options(), :scalable_type, :stream)
+  defp stream_options, do: Keyword.put(subscription_options(), :consumer_type, :stream)
 
   # Sums consumed messages across every segment consumer. Tolerates the churn
   # while the topology reconciles: a group being (re)started can briefly surface

--- a/test/integration/consumer/scalable_consumer_test.exs
+++ b/test/integration/consumer/scalable_consumer_test.exs
@@ -1,0 +1,210 @@
+defmodule Pulsar.Integration.Consumer.ScalableConsumerTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Test.Support.System
+  alias Pulsar.Test.Support.Utils
+
+  @moduletag :integration
+  @client :scalable_consumer_test_client
+  @consumer_callback Pulsar.Test.Support.DummyConsumer
+
+  setup_all do
+    {:ok, _client_pid} =
+      Pulsar.Client.start_link(name: @client, host: System.broker().service_url)
+
+    on_exit(fn -> Pulsar.Client.stop(@client) end)
+
+    :ok
+  end
+
+  test "consumes all messages across a multi-segment scalable topic" do
+    # A scalable topic is addressed by the `topic://` scheme. Passing such a
+    # topic to `Pulsar.start_consumer/4` transparently starts a scalable
+    # consumer that fans out one consumer group per segment.
+    path = unique_topic("scalable-multi")
+    topic = "topic://" <> path
+    System.create_scalable_topic(path, _segments = 2)
+
+    messages = for i <- 1..6, do: {"key-#{i}", "message-#{i}"}
+    System.produce_messages(topic, messages)
+
+    {:ok, consumer} =
+      Pulsar.start_consumer(topic, "multi-segment-sub", @consumer_callback, subscription_options())
+
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(messages) end)
+
+    # One consumer group per segment; every produced message is consumed
+    # exactly once, regardless of how keys hash across the two segments.
+    assert length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 2
+    assert total_consumed(consumer) == length(messages)
+
+    :ok = Pulsar.stop_consumer(consumer)
+  end
+
+  test "grows consumers when a segment splits" do
+    path = unique_topic("scalable-split")
+    topic = "topic://" <> path
+    System.create_scalable_topic(path, _segments = 1)
+
+    {:ok, consumer} =
+      Pulsar.start_consumer(topic, "split-sub", @consumer_callback, subscription_options())
+
+    # A single-segment topic starts with one consumer group.
+    assert length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 1
+
+    # Splitting segment 0 seals it and adds two active child segments. The
+    # watcher receives the pushed topology update and reconciles: the sealed
+    # parent is kept (to drain its backlog) and the two children get their own
+    # consumer groups, so the count grows from 1 to 3.
+    System.split_scalable_segment(path, 0)
+    assert :ok = Utils.wait_for(fn -> length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 3 end)
+
+    # Messages produced after the split route to the active child segments and
+    # are consumed by the newly added groups.
+    messages = for i <- 1..8, do: {"key-#{i}", "message-#{i}"}
+    System.produce_messages(topic, messages)
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(messages) end)
+
+    :ok = Pulsar.stop_consumer(consumer)
+  end
+
+  test "stream consumer consumes all messages across its assigned segments" do
+    # `scalable_type: :stream` registers with the controller and consumes the
+    # assigned subset of segments. A lone stream consumer is assigned all of them.
+    path = unique_topic("stream-multi")
+    topic = "topic://" <> path
+    System.create_scalable_topic(path, _segments = 2)
+
+    messages = for i <- 1..6, do: {"key-#{i}", "message-#{i}"}
+    System.produce_messages(topic, messages)
+
+    {:ok, consumer} =
+      Pulsar.start_consumer(topic, "stream-multi-sub", @consumer_callback, stream_options())
+
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(messages) end)
+    assert length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 2
+
+    :ok = Pulsar.stop_consumer(consumer)
+  end
+
+  test "stream consumer is assigned the children once a segment drains and splits" do
+    path = unique_topic("stream-split")
+    topic = "topic://" <> path
+    System.create_scalable_topic(path, _segments = 1)
+
+    {:ok, consumer} =
+      Pulsar.start_consumer(topic, "stream-split-sub", @consumer_callback, stream_options())
+
+    assert length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) == 1
+
+    # The consumer drains segment 0 (it acks as it consumes). The controller
+    # withholds the children until the parent is drained, so only after that does
+    # splitting yield an assignment update that adds the child segment groups.
+    before = for i <- 1..5, do: {"key-#{i}", "before-#{i}"}
+    System.produce_messages(topic, before)
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(before) end)
+
+    System.split_scalable_segment(path, 0)
+    assert :ok = Utils.wait_for(fn -> length(Pulsar.ScalableConsumer.get_segment_groups(consumer)) > 1 end)
+
+    # Messages produced after the split route to the active children and are
+    # consumed by the newly assigned groups.
+    after_split = for i <- 6..10, do: {"key-#{i}", "after-#{i}"}
+    System.produce_messages(topic, after_split)
+    assert :ok = Utils.wait_for(fn -> total_consumed(consumer) == length(before) + length(after_split) end)
+
+    :ok = Pulsar.stop_consumer(consumer)
+  end
+
+  # Producing each message shells out to pulsar-client (a JVM boot), so allow
+  # extra time over the default 60s test timeout.
+  @tag timeout: 120_000
+  test "stream consumers on one subscription split segments and preserve key affinity" do
+    # The stream analogue of a multi-consumer Key_Shared subscription: several
+    # consumers register on the same subscription and the controller distributes
+    # the key-range segments across them, each key staying with one consumer.
+    path = unique_topic("stream-parallel")
+    topic = "topic://" <> path
+    System.create_scalable_topic(path, _segments = 2)
+
+    {:ok, a} = Pulsar.start_consumer(topic, "parallel-sub", @consumer_callback, [name: "a-#{topic}"] ++ stream_options())
+    {:ok, b} = Pulsar.start_consumer(topic, "parallel-sub", @consumer_callback, [name: "b-#{topic}"] ++ stream_options())
+
+    # Once the second consumer joins, the controller rebalances the active
+    # segments so each consumer owns a disjoint, non-empty subset.
+    assert :ok =
+             Utils.wait_for(fn ->
+               a_segs = segment_ids(a)
+               b_segs = segment_ids(b)
+               a_segs != [] and b_segs != [] and Enum.sort(a_segs ++ b_segs) == [0, 1]
+             end)
+
+    # Produce after the split has settled so each key routes cleanly to its
+    # segment's owner (no mid-handover races).
+    messages = for k <- 1..5, n <- 1..2, do: {"key-#{k}", "key-#{k}/#{n}"}
+    System.produce_messages(topic, messages)
+
+    expected = Enum.sort(for {_key, payload} <- messages, do: payload)
+    assert :ok = Utils.wait_for(fn -> Enum.sort(consumed_payloads(a) ++ consumed_payloads(b)) == expected end)
+
+    # Each key was handled by exactly one consumer (the basis of in-order,
+    # parallel, per-key consumption).
+    a_keys = a |> consumed_payloads() |> MapSet.new(&key_of/1)
+    b_keys = b |> consumed_payloads() |> MapSet.new(&key_of/1)
+    assert MapSet.disjoint?(a_keys, b_keys)
+
+    :ok = Pulsar.stop_consumer(a)
+    :ok = Pulsar.stop_consumer(b)
+  end
+
+  defp subscription_options do
+    [
+      client: @client,
+      initial_position: :earliest,
+      flow_initial: 1,
+      flow_threshold: 0,
+      flow_refill: 1
+    ]
+  end
+
+  defp stream_options, do: Keyword.put(subscription_options(), :scalable_type, :stream)
+
+  # Sums consumed messages across every segment consumer. Tolerates the churn
+  # while the topology reconciles: a group being (re)started can briefly surface
+  # an `:undefined` child or a pid that exits between lookup and call.
+  defp total_consumed(consumer) do
+    consumer
+    |> Pulsar.get_consumers()
+    |> Enum.filter(&is_pid/1)
+    |> Enum.reduce(0, fn consumer_pid, acc ->
+      try do
+        @consumer_callback.count_messages(consumer_pid) + acc
+      catch
+        :exit, _reason -> acc
+      end
+    end)
+  end
+
+  defp segment_ids(consumer) do
+    consumer |> Pulsar.ScalableConsumer.get_segment_groups() |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+  end
+
+  # Collects the payloads consumed across every segment of one scalable consumer.
+  defp consumed_payloads(consumer) do
+    consumer
+    |> Pulsar.get_consumers()
+    |> Enum.filter(&is_pid/1)
+    |> Enum.flat_map(fn pid ->
+      try do
+        @consumer_callback.get_messages(pid)
+      catch
+        :exit, _reason -> []
+      end
+    end)
+    |> Enum.map(& &1.payload)
+  end
+
+  defp key_of(payload), do: payload |> String.split("/") |> hd()
+
+  defp unique_topic(prefix), do: "public/default/#{prefix}-#{:erlang.unique_integer([:positive])}"
+end

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -149,6 +149,18 @@ defmodule Pulsar.Test.Support.System do
     :ok
   end
 
+  @doc """
+  Terminates a topic: no further messages can be published, and consumers that
+  have caught up are notified via `CommandReachedEndOfTopic`.
+  """
+  def terminate_topic(topic) do
+    broker = broker()
+    command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", "terminate", topic]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
   def produce_messages(topic, messages, broker \\ broker()) do
     base_cmd = [
       "bin/pulsar-client",

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -150,6 +150,21 @@ defmodule Pulsar.Test.Support.System do
   end
 
   @doc """
+  Returns a subscription's message backlog (unacknowledged count) from
+  `topics stats`, for asserting cursor/ack effects without redelivery timing.
+  """
+  def subscription_backlog(topic, subscription) do
+    broker = broker()
+    command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", "stats", topic]
+    {raw, 0} = docker_exec(broker.container, command)
+
+    {start, _} = :binary.match(raw, "{")
+    json = binary_part(raw, start, byte_size(raw) - start)
+
+    get_in(Jason.decode!(json), ["subscriptions", subscription, "msgBacklog"])
+  end
+
+  @doc """
   Terminates a topic: no further messages can be published, and consumers that
   have caught up are notified via `CommandReachedEndOfTopic`.
   """

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -161,6 +161,72 @@ defmodule Pulsar.Test.Support.System do
     :ok
   end
 
+  @doc """
+  Creates a native scalable topic (PIP-460/466/468) with `segments` initial
+  segments. `topic` is the bare `tenant/namespace/name` form (no scheme).
+  """
+  def create_scalable_topic(topic, segments \\ 1) do
+    broker = broker()
+
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "scalable-topics",
+      "create",
+      "-s",
+      "#{segments}",
+      topic
+    ]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
+  @doc """
+  Splits a scalable topic segment into two halves: the parent is sealed and two
+  active child segments are added to the DAG.
+  """
+  def split_scalable_segment(topic, segment_id) do
+    broker = broker()
+
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "scalable-topics",
+      "split-segment",
+      "-s",
+      "#{segment_id}",
+      topic
+    ]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
+  @doc """
+  Merges two adjacent scalable topic segments into one active child segment. The
+  merged parents are sealed (and kept in the DAG until they are GC'd).
+  """
+  def merge_scalable_segments(topic, segment_id_1, segment_id_2) do
+    broker = broker()
+
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "scalable-topics",
+      "merge-segments",
+      "--segment-id-1=#{segment_id_1}",
+      "--segment-id-2=#{segment_id_2}",
+      topic
+    ]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
   def produce_messages(topic, messages, broker \\ broker()) do
     base_cmd = [
       "bin/pulsar-client",


### PR DESCRIPTION
https://pulsar.apache.org/blog/2026/06/23/announcing-apache-pulsar-5-0-m1/

- [x] Extended wire protocol
- [x] New abstractions (e.g. topology watchers)
- [x] Scalable Consumers
    - [x] Stream
    - [x] Queue
    - [ ] Checkpoint
- [ ] Scalable Producers
- [x] End of topic support
- [x] Cumulative ACKing support

Stream abstraction feels like a step backwards? Whilst it preserves ordering across a changing number of segments (~partitions), we cannot spin up an arbitrary number of parallel consumers using a Key-Shared subscription. That is, orderly parallel consumption is now much more limited than before. The number of parallel consumers is now dictated by the number of segments (~partitions) in the topic.

The scalable producer is somewhat disappointing. Given that the broker knows about the DAG topology and is responsible for coordinating segments, etc. I would have expected for the producer flow to be as simple as sending a keyed message to the broker and let the broker handle it internally. It turns out routing has to be implemented in the client.