### PR TITLE
feat: add became_{active, passive}/1 callbacks for failover consumers

### DIFF
--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -731,6 +731,20 @@ defmodule Pulsar.Broker do
     end
   end
 
+  # Failover subscriptions: broker notifies a consumer when it becomes the
+  # active (or passive) consumer for the subscription.
+  defp handle_command(%Binary.CommandActiveConsumerChange{consumer_id: consumer_id} = command, broker) do
+    case Map.get(broker.consumers, consumer_id) do
+      nil ->
+        Logger.warning("Received active consumer change for unknown consumer #{consumer_id}")
+        :keep_state_and_data
+
+      {consumer_pid, _monitor_ref} ->
+        send(consumer_pid, {:broker_message, command})
+        :keep_state_and_data
+    end
+  end
+
   defp handle_command(%Binary.CommandCloseProducer{producer_id: producer_id} = command, broker) do
     case Map.get(broker.producers, producer_id) do
       nil ->

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -552,6 +552,18 @@ defmodule Pulsar.Consumer do
     {:stop, :broker_close_requested, state}
   end
 
+  def handle_info({:broker_message, %Binary.CommandActiveConsumerChange{is_active: true}}, state) do
+    Logger.info("Consumer #{state.consumer_id} became the active consumer for subscription #{state.subscription_name}")
+
+    dispatch_active_state_change(state, :became_active)
+  end
+
+  def handle_info({:broker_message, %Binary.CommandActiveConsumerChange{is_active: false}}, state) do
+    Logger.info("Consumer #{state.consumer_id} became a passive consumer for subscription #{state.subscription_name}")
+
+    dispatch_active_state_change(state, :became_passive)
+  end
+
   def handle_info({:broker_message, message_data}, state) do
     {messages, new_state} =
       case message_data do
@@ -633,6 +645,19 @@ defmodule Pulsar.Consumer do
   @impl true
   def handle_info(message, state) do
     case state.callback_module.handle_info(message, state.callback_state) do
+      {:noreply, new_callback_state} ->
+        {:noreply, %{state | callback_state: new_callback_state}}
+
+      {:noreply, new_callback_state, timeout_or_hibernate} ->
+        {:noreply, %{state | callback_state: new_callback_state}, timeout_or_hibernate}
+
+      {:stop, reason, new_callback_state} ->
+        {:stop, reason, %{state | callback_state: new_callback_state}}
+    end
+  end
+
+  defp dispatch_active_state_change(state, callback_fun) do
+    case apply(state.callback_module, callback_fun, [state.callback_state]) do
       {:noreply, new_callback_state} ->
         {:noreply, %{state | callback_state: new_callback_state}}
 

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -37,6 +37,8 @@ defmodule Pulsar.Consumer.Callback do
   - `handle_call/3` - Handle synchronous calls (default: `{:reply, {:error, :not_implemented}, state}`)
   - `handle_cast/2` - Handle asynchronous casts (default: `{:noreply, state}`)
   - `handle_info/2` - Handle other messages (default: `{:noreply, state}`)
+  - `became_active/1` - Called when this consumer becomes the active consumer of a `:Failover` subscription (default: `{:noreply, state}`)
+  - `became_passive/1` - Called when this consumer becomes a passive (standby) consumer of a `:Failover` subscription (default: `{:noreply, state}`)
 
   ## Message Format
 
@@ -181,6 +183,14 @@ defmodule Pulsar.Consumer.Callback do
   - `:ok` - Cleanup completed successfully
   - Any other value is ignored
 
+  ## Failover Consumer Events
+
+  For `:Failover` subscriptions, `became_active/1` and `became_passive/1`
+  notify a consumer when the broker promotes it to (or demotes it from) the
+  active role. Useful for metrics/alerting or warming up state before a
+  takeover; not meaningful for other subscription types. A passive consumer
+  never receives messages, so there is nothing to pause or resume.
+
   ## Manual Acknowledgment
 
   When you return `{:noreply, state}` from `handle_message/2`, the message will NOT be automatically
@@ -222,7 +232,13 @@ defmodule Pulsar.Consumer.Callback do
               | {:noreply, state}
               | {:stop, state}
 
-  @optional_callbacks init: 1, terminate: 2, handle_call: 3, handle_cast: 2, handle_info: 2
+  @optional_callbacks init: 1,
+                      terminate: 2,
+                      handle_call: 3,
+                      handle_cast: 2,
+                      handle_info: 2,
+                      became_active: 1,
+                      became_passive: 1
   @callback terminate(reason, state) :: term()
   @callback handle_call(term(), GenServer.from(), state) ::
               {:reply, term(), state}
@@ -236,6 +252,14 @@ defmodule Pulsar.Consumer.Callback do
               | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
               | {:stop, term(), state}
   @callback handle_info(term(), state) ::
+              {:noreply, state}
+              | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
+              | {:stop, term(), state}
+  @callback became_active(state) ::
+              {:noreply, state}
+              | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
+              | {:stop, term(), state}
+  @callback became_passive(state) ::
               {:noreply, state}
               | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
               | {:stop, term(), state}
@@ -261,7 +285,21 @@ defmodule Pulsar.Consumer.Callback do
         {:noreply, state}
       end
 
-      defoverridable init: 1, terminate: 2, handle_call: 3, handle_cast: 2, handle_info: 2
+      def became_active(state) do
+        {:noreply, state}
+      end
+
+      def became_passive(state) do
+        {:noreply, state}
+      end
+
+      defoverridable init: 1,
+                     terminate: 2,
+                     handle_call: 3,
+                     handle_cast: 2,
+                     handle_info: 2,
+                     became_active: 1,
+                     became_passive: 1
     end
   end
 end

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -141,6 +141,12 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
 
     assert (count1 == expected_count and count2 == 0) or
              (count1 == 0 and count2 == expected_count)
+
+    {active_consumer, passive_consumer} =
+      if count1 == expected_count, do: {consumer1, consumer2}, else: {consumer2, consumer1}
+
+    assert @consumer_callback.active?(active_consumer) == true
+    assert @consumer_callback.active?(passive_consumer) == false
   end
 
   test "exclusive subscription receives all messages", %{expected_count: expected_count} do

--- a/test/support/dummy_consumer.ex
+++ b/test/support/dummy_consumer.ex
@@ -9,7 +9,7 @@ defmodule Pulsar.Test.Support.DummyConsumer do
       send(notify_pid, {:consumer_ready, self()})
     end
 
-    {:ok, %{messages: [], count: 0, fail_all: fail_all}}
+    {:ok, %{messages: [], count: 0, fail_all: fail_all, is_active: false}}
   end
 
   def handle_message(%Pulsar.Message{chunk_metadata: %{chunked: true, complete: false}}, state) do
@@ -46,6 +46,22 @@ defmodule Pulsar.Test.Support.DummyConsumer do
     GenServer.call(consumer_pid, :get_state)
   end
 
+  def active?(consumer_pid) do
+    GenServer.call(consumer_pid, :active?)
+  end
+
+  def became_active(state) do
+    {:noreply, %{state | is_active: true}}
+  end
+
+  def became_passive(state) do
+    {:noreply, %{state | is_active: false}}
+  end
+
+  def handle_call(:active?, _from, state) do
+    {:reply, state.is_active, state}
+  end
+
   def handle_call(:get_messages, _from, state) do
     {:reply, Enum.reverse(state.messages), state}
   end
@@ -59,6 +75,6 @@ defmodule Pulsar.Test.Support.DummyConsumer do
   end
 
   def handle_cast(:clear_messages, state) do
-    {:noreply, %{messages: [], count: 0, fail_all: state.fail_all}}
+    {:noreply, %{state | messages: [], count: 0}}
   end
 end


### PR DESCRIPTION
### Description

When using a [failover subscription](https://pulsar.apache.org/docs/next/concepts-messaging/#failover), multiple consumers attach to one subscription but only one of them is `active` while the other remain as `passive`. When the `active` consumer stops, the next consumer in line becomes `active` and starts consuming messages from the subscription.

The Pulsar broker sends a [CommandActiveConsumerChange](https://github.com/efcasado/pulsar-elixir/blob/88aa5c290e5f9ce0207ff03297d1288b56d1812e/pulsar.proto#L613-L616) to `failover` consumers.

This pull requests adds the `became_{active, passive}/1` callbacks to the consumer callback module. These callbacks can be used by applications to implement logic leveraging the `active/passive` state of a `failover` consumer.