### PR TITLE
fix(broker): broker crashes on unexpected info messages

### DIFF
--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -559,6 +559,11 @@ defmodule Pulsar.Broker do
     {:keep_state, new_broker}
   end
 
+  def connected(:info, message, _broker) do
+    Logger.warning("Discarding unexpected message: #{inspect(message)}")
+    :keep_state_and_data
+  end
+
   def connected({:call, from}, {:register_producer, producer_id, producer_pid}, broker) do
     # Monitor the producer process
     monitor_ref = Process.monitor(producer_pid)

--- a/test/unit/broker_test.exs
+++ b/test/unit/broker_test.exs
@@ -48,6 +48,22 @@ defmodule Pulsar.BrokerTest do
     assert [{:next_event, :internal, {:command, %Proto.CommandPing{}}}] = actions
   end
 
+  test "discards unexpected messages rather than crashing the connection" do
+    broker = %Broker{socket: :current_socket}
+
+    messages = [
+      :stray_atom,
+      {:hello, :world},
+      {:ssl_passive, :current_socket},
+      {:EXIT, self(), :normal}
+    ]
+
+    for message <- messages do
+      assert :keep_state_and_data = Broker.connected(:info, message, broker),
+             "expected #{inspect(message)} to be discarded"
+    end
+  end
+
   defp buffered({head, pending, _size}), do: :erlang.iolist_to_binary([head | pending])
   defp buffered(binary) when is_binary(binary), do: binary
 


### PR DESCRIPTION
### Description

Add a safety catch-all function clause to `connected/3` [like the one we already have for `disconnected/3`](https://github.com/efcasado/pulsar-elixir/blob/31cfddfefd4ce242ca7279ac4cc9e12a4b9ac7de/lib/pulsar/broker.ex#L364), that prevents the broker from crashing when receiving unexpected info messages. Without this, the broker could crash and would bring down all its consumers, producers, etc.

Instead of silently ignoring the unexpected message, we log a warning message

```
Discarding unexpected message: #{inspect(message)}
```