### PR TITLE
improved handling of options

### DIFF
--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -121,7 +121,7 @@ consumers: [
 
 - **`expire_incomplete_chunked_message_after`**: How long to wait for all chunks before timing out. Expired messages are delivered as incomplete with `error: :expired`.
 
-- **`chunk_cleanup_interval`**: How often to check for and clean up expired chunked messages. Set to `nil` to disable automatic cleanup (not recommended for production).
+- **`chunk_cleanup_interval`**: How often to check for and clean up expired chunked messages. Set to `false` to disable automatic cleanup (not recommended for production); `nil` is accepted as an alias. Keep it below `expire_incomplete_chunked_message_after`, since an expired chunk is only released on the next sweep.
 
 ## Handling Incomplete Chunks
 

--- a/docs/reader.md
+++ b/docs/reader.md
@@ -154,18 +154,5 @@ For most use cases, the default is fine. Adjust this if you're processing very l
 
 ## Configuration Options
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `:host` | string | - | Pulsar broker URL (mutually exclusive with `:client`) |
-| `:name` | atom | `:default` | Name for the internal client (only used with `:host`) |
-| `:auth` | tuple | - | Authentication configuration (only used with `:host`) |
-| `:socket_opts` | list | - | Socket options (only used with `:host`) |
-| `:client` | atom | `:default` | Name of existing client (mutually exclusive with `:host`) |
-| `:start_position` | atom | `:earliest` | `:earliest` or `:latest` |
-| `:start_message_id` | tuple | - | `{ledger_id, entry_id}` tuple to start from |
-| `:start_timestamp` | integer | - | Unix timestamp (ms) to start from |
-| `:flow_permits` | integer | 100 | Number of messages to request per flow batch |
-| `:timeout` | integer | 60_000 | Inactivity timeout in milliseconds |
-| `:read_compacted` | boolean | `false` | Read only latest value for each key (compacted topics) |
-| `:startup_delay_ms` | integer | 0 | Delay before consumer starts (ms) |
-| `:startup_jitter_ms` | integer | 0 | Random jitter added to startup delay (ms) |
+See `Pulsar.Reader.stream/2`, whose option list is generated from the schema it
+validates against, so the two cannot disagree.

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -325,7 +325,7 @@ defmodule Pulsar do
     client = Keyword.get(opts, :client, @default_client)
     consumer_supervisor = Pulsar.Client.consumer_supervisor(client)
     subscription_type = Keyword.get(opts, :subscription_type, :Shared)
-    name = Keyword.get(opts, :name, topic <> "-" <> subscription_name)
+    {name, opts} = Keyword.pop(opts, :name, topic <> "-" <> subscription_name)
 
     case check_partitioned_topic(topic, client) do
       {:ok, 0} ->

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -254,19 +254,10 @@ defmodule Pulsar do
   - `topic` - The topic to subscribe to (regular or partitioned)
   - `subscription_name` - Name of the subscription
   - `callback_module` - Module that implements `Pulsar.Consumer.Callback` behaviour
-  - `opts` - Optional parameters:
-    - `:subscription_type` - Type of subscription (e.g., :Exclusive, :Shared, :Key_Shared, default: :Shared)
-    - `:name` - Custom name for the consumer (default: "topic-subscription_name")
-    - `:consumer_count` - Number of consumer processes per topic/partition (default: 1)
-    - `:init_args` - Arguments passed to callback module's init/1 function
-    - `:flow_initial` - Initial flow permits (default: 100)
-    - `:flow_threshold` - Flow permits threshold for refill (default: 50)
-    - `:flow_refill` - Flow permits refill amount (default: 50)
-    - `:initial_position` - Initial position for subscription (`:latest` or `:earliest`, defaults to `:latest`)
-    - `:partition_discovery_interval_ms` - For partitioned topics, how often to poll
-      for newly added partitions, in milliseconds (default: 60000). Set to `false`
-      to disable auto-discovery. Discovery is grow-only.
-    - Other options passed to ConsumerGroup supervisor
+
+  ## Options
+
+  #{Pulsar.Consumer.Options.docs()}
 
   ## Return Values
 
@@ -323,9 +314,10 @@ defmodule Pulsar do
   """
   @spec start_consumer(String.t(), String.t(), module(), keyword()) :: {:ok, pid} | {:error, term}
   def start_consumer(topic, subscription_name, callback_module, opts \\ []) do
-    client = Keyword.get(opts, :client, @default_client)
+    opts = Pulsar.Consumer.Options.validate!(opts)
+    client = Keyword.fetch!(opts, :client)
     consumer_supervisor = Pulsar.Client.consumer_supervisor(client)
-    subscription_type = Keyword.get(opts, :subscription_type, :Shared)
+    subscription_type = Keyword.fetch!(opts, :subscription_type)
     {name, opts} = Keyword.pop(opts, :name, topic <> "-" <> subscription_name)
 
     case check_partitioned_topic(topic, client) do

--- a/lib/pulsar.ex
+++ b/lib/pulsar.ex
@@ -130,6 +130,7 @@ defmodule Pulsar do
       {:ok, consumer_pid} = Pulsar.lookup_consumer("my-topic-my-subscription")
       {:ok, producer_pid} = Pulsar.lookup_producer(:my_producer)
   """
+  alias Pulsar.Producer.Options
   alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
 
   require Logger
@@ -485,18 +486,10 @@ defmodule Pulsar do
   ## Parameters
 
   - `topic` - The topic to publish to (required)
-  - `opts` - Optional parameters:
-    - `:name` - Custom name for the producer group (default: "<topic>-producer")
-    - `:producer_count` - Number of producer processes in the group (default: 1)
-    - `:access_mode` - Producer access mode (default: `:Shared`). Available modes:
-      - `:Shared` - Multiple producers can publish on the topic
-      - `:Exclusive` - Only one producer can publish. Other producers get errors immediately.
-      - `:WaitForExclusive` - Wait for exclusive access if another producer is connected
-      - `:ExclusiveWithFencing` - Immediately remove any existing producer
-    - `:partition_discovery_interval_ms` - For partitioned topics, how often to poll
-      for newly added partitions, in milliseconds (default: 60000). Set to `false`
-      to disable auto-discovery. Discovery is grow-only.
-    - Other options passed to individual producer processes
+
+  ## Options
+
+  #{Options.docs()}
 
   ## Producer Naming and Registry
 
@@ -539,7 +532,8 @@ defmodule Pulsar do
   """
   @spec start_producer(String.t(), keyword()) :: {:ok, pid()} | {:error, term()}
   def start_producer(topic, opts \\ []) do
-    client = Keyword.get(opts, :client, @default_client)
+    opts = Options.validate!(opts)
+    client = Keyword.fetch!(opts, :client)
     producer_supervisor = Pulsar.Client.producer_supervisor(client)
     {name, producer_opts} = Keyword.pop(opts, :name, "#{topic}-producer")
 

--- a/lib/pulsar/application.ex
+++ b/lib/pulsar/application.ex
@@ -6,6 +6,8 @@ defmodule Pulsar.Application do
   @default_client :default
   @app_supervisor Pulsar.Supervisor
 
+  @app_only_opts [:clients, :consumers, :producers]
+
   @impl true
   def start(_type, opts) do
     consumers =
@@ -21,12 +23,8 @@ defmodule Pulsar.Application do
           # Fallback to legacy single-client mode with :host
           bootstrap_host = Keyword.get(opts, :host, Application.get_env(:pulsar, :host))
 
-          # Only the keys the client understands: the rest of the application
-          # configuration, :consumers and :producers among it, is not its business.
-          client_opts = Keyword.take(opts, Pulsar.Client.supported_options())
-
           if bootstrap_host,
-            do: [{@default_client, Keyword.put(client_opts, :host, bootstrap_host)}],
+            do: [{@default_client, Keyword.put(client_opts(opts), :host, bootstrap_host)}],
             else: []
 
         clients when is_list(clients) ->
@@ -76,6 +74,13 @@ defmodule Pulsar.Application do
 
     {:ok, pid}
   end
+
+  # Everything that is not application-level plumbing is forwarded, so that an
+  # option the client does not recognise is reported by the client rather than
+  # dropped here. Multi-client mode has always forwarded its options verbatim.
+  @doc false
+  @spec client_opts(keyword()) :: keyword()
+  def client_opts(opts), do: Keyword.drop(opts, @app_only_opts)
 
   @impl true
   def stop(pid) when is_pid(pid) do

--- a/lib/pulsar/application.ex
+++ b/lib/pulsar/application.ex
@@ -20,7 +20,14 @@ defmodule Pulsar.Application do
         nil ->
           # Fallback to legacy single-client mode with :host
           bootstrap_host = Keyword.get(opts, :host, Application.get_env(:pulsar, :host))
-          if bootstrap_host, do: [{@default_client, [host: bootstrap_host] ++ opts}], else: []
+
+          # Only the keys the client understands: the rest of the application
+          # configuration, :consumers and :producers among it, is not its business.
+          client_opts = Keyword.take(opts, Pulsar.Client.supported_options())
+
+          if bootstrap_host,
+            do: [{@default_client, Keyword.put(client_opts, :host, bootstrap_host)}],
+            else: []
 
         clients when is_list(clients) ->
           clients

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -73,6 +73,8 @@ defmodule Pulsar.Broker do
     producers: %{}
   }
 
+  @ssl_only_opts [:verify, :cacerts, :cacertfile, :certfile, :keyfile]
+
   ## Public API
 
   @doc """
@@ -322,14 +324,10 @@ defmodule Pulsar.Broker do
 
     host_charlist = String.to_charlist(host)
 
-    # Filter SSL-specific options for TCP connections
     filtered_socket_opts =
       case mod do
-        :gen_tcp ->
-          Keyword.drop(socket_opts, [:verify, :cacerts, :cacertfile, :certfile, :keyfile])
-
-        :ssl ->
-          socket_opts
+        :gen_tcp -> drop_ssl_opts(socket_opts)
+        :ssl -> socket_opts
       end
 
     full_socket_opts =
@@ -878,6 +876,14 @@ defmodule Pulsar.Broker do
   end
 
   ## Private Functions
+
+  # Socket option lists are not keyword lists: `:inet6` and `{:raw, level, opt, value}`
+  # are both valid and match neither `{key, value}` nor `Keyword.drop/2`.
+  @doc false
+  @spec drop_ssl_opts([:gen_tcp.connect_option()]) :: [:gen_tcp.connect_option()]
+  def drop_ssl_opts(socket_opts) do
+    Enum.reject(socket_opts, &match?({key, _value} when key in @ssl_only_opts, &1))
+  end
 
   defp restart_consumers_and_producers(broker) do
     # Exit all consumer processes - supervision trees will restart them

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -53,7 +53,7 @@ defmodule Pulsar.Broker do
           socket: :gen_tcp.socket() | :ssl.sslsocket() | nil,
           prev_backoff: integer(),
           socket_opts: list(),
-          conn_timeout: integer(),
+          conn_timeout: timeout(),
           auth: list(),
           max_frame_size: pos_integer(),
           buffer: Pulsar.Protocol.buffer(),

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -59,8 +59,12 @@ defmodule Pulsar.Client do
       """
     ],
     socket_opts: [
-      type: :keyword_list,
-      doc: "Options passed to `:gen_tcp.connect/4` or `:ssl.connect/4`."
+      type: {:list, :any},
+      doc: """
+      Options passed to `:gen_tcp.connect/4` or `:ssl.connect/4`. Not a keyword list:
+      bare atoms such as `:inet6` and tuples such as `{:raw, level, opt, value}` are
+      valid entries.
+      """
     ]
   ]
 

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -39,12 +39,52 @@ defmodule Pulsar.Client do
 
   use Supervisor
 
-  @supported_broker_opts [
-    :auth,
-    :conn_timeout,
-    :max_frame_size,
-    :socket_opts
+  require Logger
+
+  @broker_opts [
+    auth: [
+      type: :keyword_list,
+      doc: "Authentication configuration, as `[type: module, opts: keyword]`."
+    ],
+    conn_timeout: [
+      type: :pos_integer,
+      doc: "Milliseconds to wait for a connection to a broker. Defaults to 1000."
+    ],
+    max_frame_size: [
+      type: :pos_integer,
+      doc: """
+      Largest frame accepted from this cluster, in bytes. Defaults to
+      `Pulsar.Config.max_frame_size/0`. Raise it to match a broker configured with a
+      larger `maxMessageSize`.
+      """
+    ],
+    socket_opts: [
+      type: :keyword_list,
+      doc: "Options passed to `:gen_tcp.connect/4` or `:ssl.connect/4`."
+    ]
   ]
+
+  # No defaults here on purpose: an option the caller omitted has to stay absent so
+  # that build_broker_opts/1 can fall back to the application environment before the
+  # broker applies its own default.
+  @schema [
+            name: [
+              type: :atom,
+              required: true,
+              doc: "Name the client is registered under."
+            ],
+            host: [
+              type: :string,
+              required: true,
+              doc: "Bootstrap broker URL, e.g. `pulsar://localhost:6650`."
+            ]
+          ] ++ @broker_opts
+
+  @supported_broker_opts Keyword.keys(@broker_opts)
+
+  @doc false
+  @spec supported_options() :: [atom()]
+  def supported_options, do: Keyword.keys(@schema)
 
   ## Public API
 
@@ -53,16 +93,10 @@ defmodule Pulsar.Client do
 
   ## Options
 
-  - `:name` - Required. The name of the client (atom)
-  - `:host` - Required. Bootstrap broker URL
-  - `:auth` - Optional. Authentication configuration
-  - `:conn_timeout` - Optional. Connection timeout (default: 5000)
-  - `:max_frame_size` - Optional. Largest frame accepted from this cluster, in
-    bytes (default: `Pulsar.Config.max_frame_size/0`). Raise it to match a broker
-    configured with a larger `maxMessageSize`.
-  - `:socket_opts` - Optional. Socket options
+  #{NimbleOptions.docs(@schema)}
   """
   def start_link(opts) do
+    opts = validate_options!(opts)
     name = Keyword.fetch!(opts, :name)
     bootstrap_host = Keyword.fetch!(opts, :host)
 
@@ -265,6 +299,18 @@ defmodule Pulsar.Client do
   end
 
   ## Private Functions
+
+  # Unknown options are only warned about for now, and will be rejected in the next
+  # major version.
+  defp validate_options!(opts) do
+    {known, unknown} = Keyword.split(opts, Keyword.keys(@schema))
+
+    if unknown != [] do
+      Logger.warning("Pulsar.Client ignoring unknown options: #{inspect(Keyword.keys(unknown))}")
+    end
+
+    NimbleOptions.validate!(known, @schema)
+  end
 
   defp build_broker_opts(opts) do
     app_opts =

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -86,10 +86,6 @@ defmodule Pulsar.Client do
 
   @supported_broker_opts Keyword.keys(@broker_opts)
 
-  @doc false
-  @spec supported_options() :: [atom()]
-  def supported_options, do: Keyword.keys(@schema)
-
   ## Public API
 
   @doc """

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -47,8 +47,12 @@ defmodule Pulsar.Client do
       doc: "Authentication configuration, as `[type: module, opts: keyword]`."
     ],
     conn_timeout: [
-      type: :pos_integer,
-      doc: "Milliseconds to wait for a connection to a broker. Defaults to 1000."
+      type: :timeout,
+      doc: """
+      Milliseconds to wait for a connection to a broker. Defaults to 1000. `:infinity`
+      waits indefinitely, which leaves the broker process blocked in `connect` with no
+      reconnect timer and no way to answer calls until the network gives up.
+      """
     ],
     max_frame_size: [
       type: :pos_integer,

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -1199,7 +1199,7 @@ defmodule Pulsar.Consumer do
 
   defp chunked_message?(_metadata), do: false
 
-  defp schedule_chunk_cleanup(nil), do: :ok
+  defp schedule_chunk_cleanup(interval) when interval in [false, nil], do: :ok
 
   defp schedule_chunk_cleanup(interval) when is_integer(interval) and interval > 0 do
     Process.send_after(self(), :cleanup_expired_chunks, interval)

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -1,0 +1,178 @@
+defmodule Pulsar.Consumer.Options do
+  @moduledoc false
+
+  require Logger
+
+  # Options whose current default is read from the application environment carry no
+  # default here: they have to stay absent so the process that reads them can still
+  # consult Pulsar.Config.
+  @schema [
+    client: [
+      type: :atom,
+      default: :default,
+      doc: "Client the consumer belongs to."
+    ],
+    name: [
+      type: {:or, [:string, :atom]},
+      doc: """
+      Name the consumer group is registered under. Defaults to
+      `"<topic>-<subscription_name>"`. Consumers within it are named after the group
+      and their index on the broker.
+      """
+    ],
+    subscription_type: [
+      type: {:in, [:Exclusive, :Shared, :Failover, :Key_Shared]},
+      default: :Shared,
+      doc: "How the subscription is shared between consumers."
+    ],
+    consumer_count: [
+      type: :pos_integer,
+      default: 1,
+      doc: "Number of consumer processes to start for the topic, or for each partition."
+    ],
+    init_args: [
+      type: :any,
+      default: [],
+      doc: "Passed to the callback module's `init/1`."
+    ],
+    flow_initial: [
+      type: :non_neg_integer,
+      default: 100,
+      doc: """
+      Permits granted to the broker on subscribe. `0` disables automatic flow control,
+      leaving it to `Pulsar.Consumer.send_flow/2`.
+      """
+    ],
+    flow_threshold: [
+      type: :non_neg_integer,
+      default: 50,
+      doc: "Outstanding permits at which more are requested. Ignored when `:flow_initial` is 0."
+    ],
+    flow_refill: [
+      type: :non_neg_integer,
+      default: 50,
+      doc: "Permits requested on each refill. Ignored when `:flow_initial` is 0."
+    ],
+    initial_position: [
+      type: {:in, [:earliest, :latest]},
+      default: :latest,
+      doc: "Where a new subscription starts reading."
+    ],
+    start_message_id: [
+      type: {:tuple, [:non_neg_integer, :non_neg_integer]},
+      doc: "Seek to a `{ledger_id, entry_id}` before reading."
+    ],
+    start_timestamp: [
+      type: :non_neg_integer,
+      doc: "Seek to a publish time, in milliseconds since the epoch, before reading."
+    ],
+    durable: [
+      type: :boolean,
+      default: true,
+      doc: "Whether the broker persists the subscription's position."
+    ],
+    read_compacted: [
+      type: :boolean,
+      default: false,
+      doc: "Read only the latest value per key from a compacted topic."
+    ],
+    force_create_topic: [
+      type: :boolean,
+      default: true,
+      doc: "Create the topic if it does not exist."
+    ],
+    redelivery_interval: [
+      type: :pos_integer,
+      doc: """
+      Milliseconds between redelivery requests for negatively acknowledged messages.
+      Absent by default, in which case they are not redelivered.
+      """
+    ],
+    dead_letter_policy: [
+      type: :keyword_list,
+      keys: [
+        max_redelivery: [
+          type: :pos_integer,
+          required: true,
+          doc: "Deliveries to attempt before diverting the message."
+        ],
+        topic: [
+          type: :string,
+          doc: "Topic to divert to. Defaults to `\"<topic>-<subscription>-DLQ\"`."
+        ]
+      ],
+      doc: """
+      Diverts a message to another topic once it has been redelivered too often.
+      Omit it entirely for no dead letter topic.
+      """
+    ],
+    max_pending_chunked_messages: [
+      type: :pos_integer,
+      default: 10,
+      doc: "Incomplete chunked messages to hold before evicting the oldest."
+    ],
+    expire_incomplete_chunked_message_after: [
+      type: :pos_integer,
+      default: 60_000,
+      doc: "Milliseconds before an incomplete chunked message is given up on."
+    ],
+    chunk_cleanup_interval: [
+      type: {:or, [:pos_integer, {:in, [false, nil]}]},
+      default: 30_000,
+      doc: """
+      Milliseconds between sweeps for expired chunked messages. `false` disables the
+      sweep, leaving incomplete chunks to accumulate until the consumer restarts;
+      `nil` is accepted as an alias for `false`.
+      """
+    ],
+    schema: [
+      type: :keyword_list,
+      doc: """
+      Schema to register with the subscription, as `[type: atom, definition: term]`.
+      See `Pulsar.Schema`.
+      """
+    ],
+    partition_discovery_interval_ms: [
+      type: {:or, [:pos_integer, {:in, [false]}]},
+      doc: """
+      For a partitioned topic, how often to look for partitions added since startup.
+      `false` disables it. Defaults to `Pulsar.Config.partition_discovery_interval/0`.
+      """
+    ],
+    max_restarts: [
+      type: :non_neg_integer,
+      default: 10,
+      doc: "Restarts the consumer group tolerates in a minute."
+    ],
+    startup_delay_ms: [
+      type: :non_neg_integer,
+      doc: "Delay before a consumer subscribes. Defaults to `Pulsar.Config.startup_delay/0`."
+    ],
+    startup_jitter_ms: [
+      type: :non_neg_integer,
+      doc: "Random delay added to `:startup_delay_ms`. Defaults to `Pulsar.Config.startup_jitter/0`."
+    ]
+  ]
+
+  @spec schema() :: keyword()
+  def schema, do: @schema
+
+  @spec docs() :: String.t()
+  def docs, do: NimbleOptions.docs(@schema)
+
+  @doc """
+  Validates consumer options, warning about any the schema does not know.
+
+  Unknown options will be rejected in the next major version.
+  """
+  @spec validate!(keyword()) :: keyword()
+  def validate!(opts) do
+    {known, unknown} = Keyword.split(opts, Keyword.keys(@schema))
+
+    if unknown != [] do
+      Logger.warning("Pulsar consumer ignoring unknown options: #{inspect(Keyword.keys(unknown))}")
+    end
+
+    NimbleOptions.validate!(known, @schema)
+  end
+end

--- a/lib/pulsar/consumer_group.ex
+++ b/lib/pulsar/consumer_group.ex
@@ -1,15 +1,8 @@
 defmodule Pulsar.ConsumerGroup do
-  @moduledoc """
-  A supervisor that manages a group of consumer processes for a single topic.
+  @moduledoc false
 
-  This module provides a reusable abstraction for creating and managing
-  consumer groups, whether for regular topics or individual partitions
-  within a partitioned topic.
-
-  Each consumer group manages multiple consumer processes (configurable via
-  `consumer_count`) that all subscribe to the same topic with the same
-  subscription configuration.
-  """
+  # Supervises the consumer processes for one topic or partition. Started by
+  # Pulsar.start_consumer/4, which owns the option surface.
 
   use Supervisor
 

--- a/lib/pulsar/consumer_group.ex
+++ b/lib/pulsar/consumer_group.ex
@@ -110,7 +110,7 @@ defmodule Pulsar.ConsumerGroup do
         start: {
           Pulsar.Consumer,
           :start_link,
-          [topic, subscription_name, subscription_type, callback_module, opts]
+          [topic, subscription_name, subscription_type, callback_module, [name: consumer_id] ++ opts]
         },
         restart: :transient,
         type: :worker

--- a/lib/pulsar/partitioned_consumer.ex
+++ b/lib/pulsar/partitioned_consumer.ex
@@ -1,14 +1,7 @@
 defmodule Pulsar.PartitionedConsumer do
-  @moduledoc """
-  A supervisor that manages individual consumer groups for partitioned topics.
+  @moduledoc false
 
-  This module provides a logical abstraction over multiple consumer groups,
-  allowing the `start_consumer` API to return a single PID for partitioned topics
-  while maintaining the individual consumer group architecture underneath.
-
-  The supervisor manages one consumer group per partition, with the number of
-  partitions provided by the caller.
-  """
+  # Supervises one consumer group per partition of a partitioned topic.
 
   use Supervisor
 

--- a/lib/pulsar/partitioned_producer.ex
+++ b/lib/pulsar/partitioned_producer.ex
@@ -1,20 +1,9 @@
 defmodule Pulsar.PartitionedProducer do
-  @moduledoc """
-  A supervisor that manages individual producer groups for partitioned topics.
+  @moduledoc false
 
-  This module provides a logical abstraction over multiple producer groups,
-  allowing the `start_producer` API to return a single PID for partitioned topics
-  while maintaining the individual producer group architecture underneath.
-
-  The supervisor manages one producer group per partition, with the number of
-  partitions provided by the caller.
-
-  ## Message Routing
-
-  Messages are routed to partitions based on the `:partition_key` option:
-  - With `:partition_key` - Consistent hash routing via `:erlang.phash2(partition_key, num_partitions)`
-  - Without `:partition_key` - Random selection
-  """
+  # Supervises one producer group per partition of a partitioned topic.
+  # Messages are routed to a partition by :partition_key, hashed with
+  # :erlang.phash2/2, or at random when no key is given.
 
   use Supervisor
 

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -1,0 +1,113 @@
+defmodule Pulsar.Producer.Options do
+  @moduledoc false
+
+  require Logger
+
+  # Options whose current default is read from the application environment carry no
+  # default here: they have to stay absent so the process that reads them can still
+  # consult Pulsar.Config.
+  @schema [
+    client: [
+      type: :atom,
+      default: :default,
+      doc: "Client the producer belongs to."
+    ],
+    name: [
+      type: {:or, [:string, :atom]},
+      doc: "Name the producer is registered under. Defaults to `\"<topic>-producer\"`."
+    ],
+    producer_count: [
+      type: :pos_integer,
+      default: 1,
+      doc: "Number of producer processes to start for the topic, or for each partition."
+    ],
+    access_mode: [
+      type: {:in, [:Shared, :Exclusive, :WaitForExclusive, :ExclusiveWithFencing]},
+      default: :Shared,
+      doc: """
+      How the topic is shared with other producers. `:Shared` allows several,
+      `:Exclusive` fails if one is already connected, `:WaitForExclusive` waits for
+      it to disconnect, and `:ExclusiveWithFencing` evicts it.
+      """
+    ],
+    compression: [
+      type: {:in, [:NONE, :LZ4, :ZLIB, :SNAPPY, :ZSTD]},
+      default: :NONE,
+      doc: "Compression applied to the payload."
+    ],
+    batch_enabled: [
+      type: :boolean,
+      default: false,
+      doc: "Collect messages and publish them as one batch."
+    ],
+    batch_size: [
+      type: :pos_integer,
+      default: 100,
+      doc: "Messages to collect before flushing a batch. Only used when batching."
+    ],
+    flush_interval: [
+      type: :pos_integer,
+      default: 10,
+      doc: "Milliseconds between batch flushes. Only used when batching."
+    ],
+    chunking_enabled: [
+      type: :boolean,
+      default: false,
+      doc: "Split payloads larger than `:max_message_size` across several messages."
+    ],
+    max_message_size: [
+      type: :pos_integer,
+      default: 5_242_880,
+      doc: "Largest chunk to send, in bytes. Only used when chunking."
+    ],
+    schema: [
+      type: :keyword_list,
+      doc: """
+      Schema to register with the topic, as `[type: atom, definition: term]`. See
+      `Pulsar.Schema`.
+      """
+    ],
+    partition_discovery_interval_ms: [
+      type: {:or, [:pos_integer, {:in, [false]}]},
+      doc: """
+      For a partitioned topic, how often to look for partitions added since startup.
+      `false` disables it. Defaults to `Pulsar.Config.partition_discovery_interval/0`.
+      """
+    ],
+    max_restarts: [
+      type: :non_neg_integer,
+      default: 100,
+      doc: "Restarts the producer group tolerates in a minute."
+    ],
+    startup_delay_ms: [
+      type: :non_neg_integer,
+      doc: "Delay before a producer connects. Defaults to `Pulsar.Config.startup_delay/0`."
+    ],
+    startup_jitter_ms: [
+      type: :non_neg_integer,
+      doc: "Random delay added to `:startup_delay_ms`. Defaults to `Pulsar.Config.startup_jitter/0`."
+    ]
+  ]
+
+  @spec schema() :: keyword()
+  def schema, do: @schema
+
+  @spec docs() :: String.t()
+  def docs, do: NimbleOptions.docs(@schema)
+
+  @doc """
+  Validates producer options, warning about any the schema does not know.
+
+  Unknown options will be rejected in the next major version.
+  """
+  @spec validate!(keyword()) :: keyword()
+  def validate!(opts) do
+    {known, unknown} = Keyword.split(opts, Keyword.keys(@schema))
+
+    if unknown != [] do
+      Logger.warning("Pulsar producer ignoring unknown options: #{inspect(Keyword.keys(unknown))}")
+    end
+
+    NimbleOptions.validate!(known, @schema)
+  end
+end

--- a/lib/pulsar/producer_group.ex
+++ b/lib/pulsar/producer_group.ex
@@ -1,34 +1,8 @@
 defmodule Pulsar.ProducerGroup do
-  @moduledoc """
-  A supervisor that manages a group of producer processes for a single topic.
+  @moduledoc false
 
-  ## Examples
-
-      # Start a producer group with default settings (1 producer)
-      {:ok, group_pid} = ProducerGroup.start_link(
-        "my-topic-producer",
-        "persistent://public/default/my-topic"
-      )
-
-      # Start a producer group with 3 producers
-      {:ok, group_pid} = ProducerGroup.start_link(
-        "my-topic-producer",
-        "persistent://public/default/my-topic",
-        producer_count: 3
-      )
-
-      # Start with batching enabled
-      {:ok, group_pid} = ProducerGroup.start_link(
-        "my-topic-producer",
-        "persistent://public/default/my-topic",
-        batch_enabled: true,
-        batch_size: 100,
-        flush_interval: 10
-      )
-
-      # Get all producer PIDs from the group
-      producer_pids = ProducerGroup.get_producers(group_pid)
-  """
+  # Supervises the producer processes for one topic. Started by Pulsar.start_producer/2,
+  # which owns the option surface.
 
   use Supervisor
 

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -50,21 +50,7 @@ defmodule Pulsar.Reader do
 
   ## Options
 
-  - `:host` - Pulsar broker URL (e.g., "pulsar://localhost:6650").
-    If provided, creates a temporary client for this stream. Mutually exclusive with `:client`.
-  - `:name` - Name for the internal client (default: `:default`). Only used with `:host`.
-    Use this to avoid conflicts when running multiple readers with `:host`.
-  - `:auth` - Authentication configuration (only used with `:host`)
-  - `:socket_opts` - Socket options (only used with `:host`)
-  - `:client` - Name of existing Pulsar client to use (default: `:default`).
-    Use this when Pulsar is already started in your supervision tree. Mutually exclusive with `:host`.
-  - `:start_position` - Where to start reading (`:earliest` or `:latest`, default: `:earliest`)
-  - `:start_message_id` - Start from specific message ID as `{ledger_id, entry_id}` tuple
-  - `:start_timestamp` - Start from specific timestamp (milliseconds since epoch)
-  - `:flow_permits` - Number of messages to request per flow command (default: 100)
-  - `:read_compacted` - Only read non-deleted messages from compacted topics (default: false)
-  - `:timeout` - Inactivity timeout in milliseconds (default: `60_000`). Stream halts if
-    no message is received within this time.
+  See `stream/2`.
 
   ## Connection Management
 
@@ -122,7 +108,75 @@ defmodule Pulsar.Reader do
 
   alias Pulsar.Consumer
 
+  require Logger
+
   @default_flow_permits 100
+
+  @schema [
+    host: [
+      type: :string,
+      doc: """
+      Broker URL for a client the stream starts and stops itself, e.g.
+      `pulsar://localhost:6650`. Mutually exclusive with `:client`.
+      """
+    ],
+    client: [
+      type: :atom,
+      default: :default,
+      doc: "An already running client to read through. Mutually exclusive with `:host`."
+    ],
+    name: [
+      type: :atom,
+      default: :default,
+      doc: "Name for the client started from `:host`. Ignored when reading through `:client`."
+    ],
+    auth: [
+      type: :keyword_list,
+      doc: "Authentication for the client started from `:host`."
+    ],
+    socket_opts: [
+      type: :keyword_list,
+      doc: "Socket options for the client started from `:host`."
+    ],
+    start_position: [
+      type: {:in, [:earliest, :latest]},
+      default: :earliest,
+      doc: "Where to start reading when no message id or timestamp is given."
+    ],
+    start_message_id: [
+      type: {:tuple, [:non_neg_integer, :non_neg_integer]},
+      doc: "Start from a `{ledger_id, entry_id}`."
+    ],
+    start_timestamp: [
+      type: :non_neg_integer,
+      doc: "Start from a publish time, in milliseconds since the epoch."
+    ],
+    read_compacted: [
+      type: :boolean,
+      default: false,
+      doc: "Read only the latest value per key from a compacted topic."
+    ],
+    flow_permits: [
+      type: :pos_integer,
+      default: 100,
+      doc: "Messages to request from the broker at a time."
+    ],
+    timeout: [
+      type: :timeout,
+      default: 60_000,
+      doc: "Milliseconds without a message after which the stream halts."
+    ],
+    startup_delay_ms: [
+      type: :non_neg_integer,
+      default: 0,
+      doc: "Delay before the underlying consumer subscribes."
+    ],
+    startup_jitter_ms: [
+      type: :non_neg_integer,
+      default: 0,
+      doc: "Random delay added to `:startup_delay_ms`."
+    ]
+  ]
 
   @doc """
   Creates a stream of messages from a Pulsar topic.
@@ -132,6 +186,10 @@ defmodule Pulsar.Reader do
 
   The stream handles connection lifecycle automatically based on whether
   you provide `:host` or `:client`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@schema)}
 
   ## Examples
 
@@ -169,24 +227,8 @@ defmodule Pulsar.Reader do
     )
   end
 
-  @supported_options [
-    :host,
-    :name,
-    :client,
-    :start_position,
-    :start_message_id,
-    :start_timestamp,
-    :flow_permits,
-    :read_compacted,
-    :timeout,
-    :auth,
-    :socket_opts,
-    :startup_delay_ms,
-    :startup_jitter_ms
-  ]
-
   defp start_reader(topic, opts) do
-    validate_options!(opts)
+    opts = validate_options!(opts)
 
     {connection_mode, client_name} = resolve_connection_mode(opts)
 
@@ -345,13 +387,16 @@ defmodule Pulsar.Reader do
     end
   end
 
+  # Unknown options are only warned about for now, and will be rejected in the next
+  # major version.
   defp validate_options!(opts) do
-    unknown_opts = Keyword.keys(opts) -- @supported_options
+    {known, unknown} = Keyword.split(opts, Keyword.keys(@schema))
 
-    if unknown_opts != [] do
-      raise ArgumentError,
-            "unknown options #{inspect(unknown_opts)}, supported options are: #{inspect(@supported_options)}"
+    if unknown != [] do
+      Logger.warning("Pulsar.Reader ignoring unknown options: #{inspect(Keyword.keys(unknown))}")
     end
+
+    NimbleOptions.validate!(known, @schema)
   end
 
   defp maybe_put(keyword, _key, nil), do: keyword

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -135,8 +135,8 @@ defmodule Pulsar.Reader do
       doc: "Authentication for the client started from `:host`."
     ],
     socket_opts: [
-      type: :keyword_list,
-      doc: "Socket options for the client started from `:host`."
+      type: {:list, :any},
+      doc: "Socket options for the client started from `:host`. Not necessarily a keyword list."
     ],
     start_position: [
       type: {:in, [:earliest, :latest]},

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -233,14 +233,18 @@ defmodule Pulsar.Reader do
       subscription_type: :Exclusive,
       durable: false,
       initial_position: start_position,
-      start_message_id: start_message_id,
-      start_timestamp: start_timestamp,
       read_compacted: read_compacted,
       flow_initial: 0,
       startup_delay_ms: startup_delay_ms,
       startup_jitter_ms: startup_jitter_ms,
       init_args: [self(), reader_ref]
     ]
+
+    # Absent rather than nil, so they read as "not given" instead of "seek to nil".
+    consumer_opts =
+      consumer_opts
+      |> maybe_put(:start_message_id, start_message_id)
+      |> maybe_put(:start_timestamp, start_timestamp)
 
     case Pulsar.start_consumer(topic, subscription_name, Pulsar.Reader.Callback, consumer_opts) do
       {:ok, consumer_group_pid} ->

--- a/mix.exs
+++ b/mix.exs
@@ -65,6 +65,7 @@ defmodule Pulsar.MixProject do
       {:ezstd, "~> 1.2"},
       {:jason, "~> 1.4"},
       {:nimble_lz4, "~> 1.1"},
+      {:nimble_options, "~> 1.1"},
       {:oauth2, "~> 2.1"},
       {:protobuf, "~> 0.17.0"},
       {:snappyer, "~> 1.2"},

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -130,7 +130,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
     assert dlq_payloads == @messages
   end
 
-  test "dead letter policy with nil max_redelivery does not send to DLQ" do
+  test "no dead letter policy means no DLQ" do
     topic = @topic
     subscription = "no-dlq"
     expected_dlq_topic = "#{topic}-#{subscription}-DLQ"
@@ -144,10 +144,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         client: @client,
         initial_position: :earliest,
         subscription_type: :Shared,
-        redelivery_interval: 100,
-        dead_letter_policy: [
-          max_redelivery: nil
-        ]
+        redelivery_interval: 100
       )
 
     [failing_consumer] = Pulsar.get_consumers(consumer_group)

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -48,6 +48,30 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
 
   setup [:telemetry_listen]
 
+  test ":name names the group, and each consumer is named after it on the broker" do
+    {:ok, group} =
+      Pulsar.start_consumer(
+        "persistent://public/default/consumer-naming",
+        "naming",
+        @consumer_callback,
+        client: @client,
+        name: "naming-group",
+        consumer_count: 2
+      )
+
+    on_exit(fn -> Pulsar.stop_consumer(group) end)
+
+    assert {:ok, ^group} = Pulsar.lookup_consumer("naming-group", client: @client)
+
+    names =
+      group
+      |> Pulsar.get_consumers()
+      |> Enum.map(fn pid -> :sys.get_state(pid).consumer_name end)
+      |> Enum.sort()
+
+    assert names == ["naming-group-consumer-1", "naming-group-consumer-2"]
+  end
+
   test "initial_position latest skips existing messages", %{expected_count: _expected_count} do
     {:ok, latest_group} =
       Pulsar.start_consumer(

--- a/test/unit/application_test.exs
+++ b/test/unit/application_test.exs
@@ -1,0 +1,25 @@
+defmodule Pulsar.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  describe "client_opts/1" do
+    test "keeps application-level configuration away from the client" do
+      opts =
+        Pulsar.Application.client_opts(
+          host: "pulsar://localhost:6650",
+          clients: [],
+          consumers: [a: []],
+          producers: [b: []]
+        )
+
+      assert opts == [host: "pulsar://localhost:6650"]
+    end
+
+    test "forwards an unrecognised option so the client reports it" do
+      # Filtering to the client's known keys hid typos on this path while
+      # multi-client mode warned about them.
+      opts = Pulsar.Application.client_opts(host: "pulsar://localhost:6650", conn_timout: 500)
+
+      assert opts[:conn_timout] == 500
+    end
+  end
+end

--- a/test/unit/broker_test.exs
+++ b/test/unit/broker_test.exs
@@ -81,4 +81,19 @@ defmodule Pulsar.BrokerTest do
       assert :keep_state_and_data = Broker.connected(:info, event, broker)
     end
   end
+
+  describe "drop_ssl_opts/1" do
+    test "strips TLS-only options before a plain TCP connect" do
+      opts = [verify: :verify_peer, cacertfile: "/ca.pem", certfile: "/c.pem", keyfile: "/k.pem"]
+
+      assert Broker.drop_ssl_opts(opts ++ [nodelay: true]) == [nodelay: true]
+    end
+
+    test "keeps socket options that are not keyword pairs" do
+      # Keyword.drop/2 raised a FunctionClauseError on every one of these.
+      opts = [:inet6, {:raw, 6, 1, <<1::32>>}, {:verify, :verify_peer}, {:nodelay, true}]
+
+      assert Broker.drop_ssl_opts(opts) == [:inet6, {:raw, 6, 1, <<1::32>>}, {:nodelay, true}]
+    end
+  end
 end

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -80,4 +80,22 @@ defmodule Pulsar.ClientTest do
       refute :clients in Client.supported_options()
     end
   end
+
+  describe "socket options" do
+    test "accepts options that are not keyword pairs" do
+      # :inet6 and {:raw, ...} are valid for :gen_tcp.connect/4 and :ssl.connect/4,
+      # and neither is a keyword pair.
+      opts = [:inet6, {:raw, 6, 1, <<1::32>>}, {:nodelay, true}]
+
+      start_supervised!({Client, name: :raw_socket_opts, host: "pulsar://127.0.0.1:6650", socket_opts: opts})
+
+      assert Client.get_broker_opts(:raw_socket_opts)[:socket_opts] == opts
+    end
+
+    test "still rejects socket options that are not a list" do
+      assert_raise NimbleOptions.ValidationError, ~r/:socket_opts/, fn ->
+        Client.start_link(name: :bad_socket_opts, host: "pulsar://127.0.0.1:6650", socket_opts: :inet6)
+      end
+    end
+  end
 end

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -67,20 +67,6 @@ defmodule Pulsar.ClientTest do
     end
   end
 
-  describe "supported_options/0" do
-    test "covers everything the schema accepts" do
-      assert :name in Client.supported_options()
-      assert :host in Client.supported_options()
-      assert :max_frame_size in Client.supported_options()
-    end
-
-    test "excludes application configuration the client has no use for" do
-      refute :consumers in Client.supported_options()
-      refute :producers in Client.supported_options()
-      refute :clients in Client.supported_options()
-    end
-  end
-
   describe "socket options" do
     test "accepts options that are not keyword pairs" do
       # :inet6 and {:raw, ...} are valid for :gen_tcp.connect/4 and :ssl.connect/4,

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -1,0 +1,83 @@
+defmodule Pulsar.ClientTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Pulsar.Client
+
+  describe "start_link/1 option validation" do
+    test "requires a name and a host" do
+      assert_raise NimbleOptions.ValidationError, ~r/required :name option not found/, fn ->
+        Client.start_link(host: "pulsar://localhost:6650")
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/required :host option not found/, fn ->
+        Client.start_link(name: :missing_host)
+      end
+    end
+
+    test "rejects an option of the wrong type" do
+      assert_raise NimbleOptions.ValidationError, ~r/expected positive integer/, fn ->
+        Client.start_link(name: :bad_type, host: "pulsar://localhost:6650", conn_timeout: "soon")
+      end
+    end
+
+    test "warns about unknown options rather than failing" do
+      log =
+        capture_log(fn ->
+          {:ok, _pid} =
+            Client.start_link(
+              name: :unknown_opts,
+              host: "pulsar://127.0.0.1:1",
+              conn_timout: 500,
+              bogus: true
+            )
+
+          Client.stop(:unknown_opts)
+        end)
+
+      assert log =~ "ignoring unknown options"
+      assert log =~ ":conn_timout"
+      assert log =~ ":bogus"
+    end
+  end
+
+  describe "broker option precedence" do
+    test "falls back to the application environment when an option is omitted" do
+      Application.put_env(:pulsar, :max_frame_size, 777_777)
+      on_exit(fn -> Application.delete_env(:pulsar, :max_frame_size) end)
+
+      {:ok, _pid} = Client.start_link(name: :from_env, host: "pulsar://127.0.0.1:1")
+
+      assert Client.get_broker_opts(:from_env) == [max_frame_size: 777_777]
+
+      Client.stop(:from_env)
+    end
+
+    test "prefers an option passed to start_link over the application environment" do
+      Application.put_env(:pulsar, :max_frame_size, 777_777)
+      on_exit(fn -> Application.delete_env(:pulsar, :max_frame_size) end)
+
+      {:ok, _pid} =
+        Client.start_link(name: :from_opts, host: "pulsar://127.0.0.1:1", max_frame_size: 111_111)
+
+      assert Client.get_broker_opts(:from_opts) == [max_frame_size: 111_111]
+
+      Client.stop(:from_opts)
+    end
+  end
+
+  describe "supported_options/0" do
+    test "covers everything the schema accepts" do
+      assert :name in Client.supported_options()
+      assert :host in Client.supported_options()
+      assert :max_frame_size in Client.supported_options()
+    end
+
+    test "excludes application configuration the client has no use for" do
+      refute :consumers in Client.supported_options()
+      refute :producers in Client.supported_options()
+      refute :clients in Client.supported_options()
+    end
+  end
+end

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -17,7 +17,7 @@ defmodule Pulsar.ClientTest do
     end
 
     test "rejects an option of the wrong type" do
-      assert_raise NimbleOptions.ValidationError, ~r/expected positive integer/, fn ->
+      assert_raise NimbleOptions.ValidationError, ~r/invalid value for :conn_timeout/, fn ->
         Client.start_link(name: :bad_type, host: "pulsar://localhost:6650", conn_timeout: "soon")
       end
     end
@@ -64,6 +64,20 @@ defmodule Pulsar.ClientTest do
       assert Client.get_broker_opts(:from_opts) == [max_frame_size: 111_111]
 
       Client.stop(:from_opts)
+    end
+  end
+
+  describe "conn_timeout" do
+    test "accepts :infinity to wait indefinitely" do
+      start_supervised!({Client, name: :infinite_conn_timeout, host: "pulsar://127.0.0.1:6650", conn_timeout: :infinity})
+
+      assert Client.get_broker_opts(:infinite_conn_timeout)[:conn_timeout] == :infinity
+    end
+
+    test "still rejects a value that is not a timeout" do
+      assert_raise NimbleOptions.ValidationError, ~r/:conn_timeout/, fn ->
+        Client.start_link(name: :bad_conn_timeout, host: "pulsar://127.0.0.1:6650", conn_timeout: -1)
+      end
     end
   end
 

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -1,0 +1,108 @@
+defmodule Pulsar.Consumer.OptionsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Pulsar.Consumer.Options
+
+  describe "validate!/1" do
+    test "applies defaults for options that have one" do
+      opts = Options.validate!([])
+
+      assert opts[:client] == :default
+      assert opts[:subscription_type] == :Shared
+      assert opts[:consumer_count] == 1
+      assert opts[:flow_initial] == 100
+      assert opts[:initial_position] == :latest
+      assert opts[:durable] == true
+    end
+
+    test "leaves options backed by the application environment absent" do
+      opts = Options.validate!([])
+
+      refute Keyword.has_key?(opts, :startup_delay_ms)
+      refute Keyword.has_key?(opts, :startup_jitter_ms)
+      refute Keyword.has_key?(opts, :partition_discovery_interval_ms)
+    end
+
+    test "accepts a name as either a string or an atom" do
+      assert Options.validate!(name: "a-group")[:name] == "a-group"
+      assert Options.validate!(name: MyApp.Consumer)[:name] == MyApp.Consumer
+    end
+
+    test "rejects an unknown subscription type" do
+      assert_raise NimbleOptions.ValidationError, ~r/:subscription_type/, fn ->
+        Options.validate!(subscription_type: :Whatever)
+      end
+    end
+
+    test "accepts a start_message_id as a ledger and entry pair" do
+      assert Options.validate!(start_message_id: {1, 2})[:start_message_id] == {1, 2}
+
+      assert_raise NimbleOptions.ValidationError, ~r/:start_message_id/, fn ->
+        Options.validate!(start_message_id: 1)
+      end
+    end
+
+    test "warns about unknown options rather than failing" do
+      log = capture_log(fn -> Options.validate!(flow_intial: 10, nonsense: true) end)
+
+      assert log =~ "ignoring unknown options"
+      assert log =~ ":flow_intial"
+      assert log =~ ":nonsense"
+    end
+  end
+
+  describe "validate!/1 with a dead letter policy" do
+    test "is absent unless asked for" do
+      refute Keyword.has_key?(Options.validate!([]), :dead_letter_policy)
+    end
+
+    test "requires a redelivery threshold once asked for" do
+      assert Options.validate!(dead_letter_policy: [max_redelivery: 3])[:dead_letter_policy] ==
+               [max_redelivery: 3]
+
+      assert_raise NimbleOptions.ValidationError, ~r/required :max_redelivery option not found/, fn ->
+        Options.validate!(dead_letter_policy: [topic: "a-dlq"])
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/:max_redelivery/, fn ->
+        Options.validate!(dead_letter_policy: [max_redelivery: nil])
+      end
+    end
+
+    test "rejects a misspelled key rather than silently disabling the policy" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:max_redeliveries\]/, fn ->
+        Options.validate!(dead_letter_policy: [max_redeliveries: 3])
+      end
+    end
+  end
+
+  describe "validate!/1 chunk cleanup" do
+    test "sweeps every 30 seconds by default" do
+      assert Options.validate!([])[:chunk_cleanup_interval] == 30_000
+    end
+
+    test "accepts false, and nil as its alias, to disable the sweep" do
+      # docs/chunking.md documented nil before the schema existed.
+      assert Options.validate!(chunk_cleanup_interval: false)[:chunk_cleanup_interval] == false
+      assert Options.validate!(chunk_cleanup_interval: nil)[:chunk_cleanup_interval] == nil
+    end
+
+    test "rejects an interval that would sweep continuously" do
+      assert_raise NimbleOptions.ValidationError, ~r/:chunk_cleanup_interval/, fn ->
+        Options.validate!(chunk_cleanup_interval: 0)
+      end
+    end
+  end
+
+  describe "docs/0" do
+    test "documents every option in the schema" do
+      docs = Options.docs()
+
+      for option <- Keyword.keys(Options.schema()) do
+        assert docs =~ "`:#{option}`", "#{option} is missing from the generated docs"
+      end
+    end
+  end
+end

--- a/test/unit/producer_options_test.exs
+++ b/test/unit/producer_options_test.exs
@@ -1,0 +1,69 @@
+defmodule Pulsar.Producer.OptionsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Pulsar.Producer.Options
+
+  describe "validate!/1" do
+    test "applies defaults for options that have one" do
+      opts = Options.validate!([])
+
+      assert opts[:client] == :default
+      assert opts[:producer_count] == 1
+      assert opts[:access_mode] == :Shared
+      assert opts[:compression] == :NONE
+      assert opts[:batch_enabled] == false
+    end
+
+    test "leaves options backed by the application environment absent" do
+      opts = Options.validate!([])
+
+      # These fall back to Pulsar.Config at the point they are read, so a default
+      # here would shadow the application environment.
+      refute Keyword.has_key?(opts, :startup_delay_ms)
+      refute Keyword.has_key?(opts, :startup_jitter_ms)
+      refute Keyword.has_key?(opts, :partition_discovery_interval_ms)
+    end
+
+    test "accepts a name as either a string or an atom" do
+      assert Options.validate!(name: "a-producer")[:name] == "a-producer"
+      assert Options.validate!(name: :a_producer)[:name] == :a_producer
+    end
+
+    test "rejects an unknown access mode" do
+      assert_raise NimbleOptions.ValidationError, ~r/:access_mode/, fn ->
+        Options.validate!(access_mode: :Whatever)
+      end
+    end
+
+    test "rejects a non-integer producer count" do
+      assert_raise NimbleOptions.ValidationError, ~r/:producer_count/, fn ->
+        Options.validate!(producer_count: "two")
+      end
+    end
+
+    test "accepts false to disable partition discovery" do
+      assert Options.validate!(partition_discovery_interval_ms: false)[:partition_discovery_interval_ms] == false
+      assert Options.validate!(partition_discovery_interval_ms: 5_000)[:partition_discovery_interval_ms] == 5_000
+    end
+
+    test "warns about unknown options rather than failing" do
+      log = capture_log(fn -> Options.validate!(batch_sze: 10, nonsense: true) end)
+
+      assert log =~ "ignoring unknown options"
+      assert log =~ ":batch_sze"
+      assert log =~ ":nonsense"
+    end
+  end
+
+  describe "docs/0" do
+    test "documents every option in the schema" do
+      docs = Options.docs()
+
+      for option <- Keyword.keys(Options.schema()) do
+        assert docs =~ "`:#{option}`", "#{option} is missing from the generated docs"
+      end
+    end
+  end
+end

--- a/test/unit/reader_options_test.exs
+++ b/test/unit/reader_options_test.exs
@@ -30,4 +30,18 @@ defmodule Pulsar.ReaderOptionsTest do
       start(host: "pulsar://127.0.0.1:1", client: :other)
     end
   end
+
+  describe "socket options" do
+    test "accepts options that are not keyword pairs" do
+      # The :host/:client conflict is checked after the schema, so reaching it proves
+      # these got through validation.
+      assert_raise ArgumentError, ~r/cannot specify both :host and :client/, fn ->
+        start(host: "pulsar://127.0.0.1:1", client: :other, socket_opts: [:inet6, {:raw, 6, 1, <<1::32>>}])
+      end
+    end
+
+    test "still rejects socket options that are not a list" do
+      assert_raise NimbleOptions.ValidationError, ~r/:socket_opts/, fn -> start(socket_opts: :inet6) end
+    end
+  end
 end

--- a/test/unit/reader_options_test.exs
+++ b/test/unit/reader_options_test.exs
@@ -1,0 +1,33 @@
+defmodule Pulsar.ReaderOptionsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  # stream/2 is lazy, so the options are only validated once something enumerates it.
+  defp start(opts), do: "persistent://public/default/unread" |> Pulsar.Reader.stream(opts) |> Enum.take(1)
+
+  test "warns about unknown options rather than raising, as the other surfaces do" do
+    log =
+      capture_log(fn ->
+        assert_raise ArgumentError, fn -> start(timeut: 5, host: "pulsar://127.0.0.1:1", client: :other) end
+      end)
+
+    assert log =~ "Pulsar.Reader ignoring unknown options"
+    assert log =~ ":timeut"
+  end
+
+  test "rejects an option of the wrong type" do
+    assert_raise NimbleOptions.ValidationError, ~r/:timeout/, fn -> start(timeout: :soon) end
+    assert_raise NimbleOptions.ValidationError, ~r/:flow_permits/, fn -> start(flow_permits: 0) end
+
+    assert_raise NimbleOptions.ValidationError, ~r/:start_message_id/, fn ->
+      start(start_message_id: 1)
+    end
+  end
+
+  test "still refuses a host and a client together" do
+    assert_raise ArgumentError, ~r/cannot specify both :host and :client/, fn ->
+      start(host: "pulsar://127.0.0.1:1", client: :other)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Options were popped one at a time with no validation, so a misspelled key was silently dropped and the caller got default behaviour they had not asked for. The same options were documented in several modules at once, which had already let the docs drift from the code.

Every public entry point now validates its options against a [NimbleOptions](https://hex.pm/packages/nimble_options) schema and generates its option documentation from that same schema. The supervisors behind those entry points become internal, so there is one place per surface where options are checked and described.

## What changed

### Option validation

Four surfaces, four schemas:

| entry point | schema | replaces |
| --- | --- | --- |
| `Pulsar.Client.start_link/1` | inline | a hand-kept `Keyword.take` list |
| `Pulsar.start_producer/2` | `Pulsar.Producer.Options` | 12 chained `Keyword.pop` calls |
| `Pulsar.start_consumer/4` | `Pulsar.Consumer.Options` | 20 chained `Keyword.pop` calls |
| `Pulsar.Reader.stream/2` | inline | a hand-kept `@supported_options` list |

- Unknown options are logged and ignored rather than rejected, so existing code keeps working. They will be rejected in the next major version.
- Values are type-checked, so `producer_count: "two"` or `subscription_type: :Whatever` fails at the call site instead of surfacing later as odd behaviour.
- Where a value has an established Erlang or in-repo spelling, the schema keeps it: `:conn_timeout` is a `timeout()`, so `:infinity` still disables the connection deadline as `:gen_tcp.connect/4` allows, and `:socket_opts` is a plain list rather than a keyword list.
- `## Options` sections are generated with `NimbleOptions.docs/1`, so the documented surface cannot drift from the validated one.

Options whose default is read from the application environment — `:startup_delay_ms`, `:startup_jitter_ms`, `:partition_discovery_interval_ms` — deliberately carry no schema default on the consumer and producer surfaces. They have to stay absent for the process that reads them to fall back to `Pulsar.Config`, and there are tests for both directions of that precedence. The reader's own startup delays default to `0` rather than to `Pulsar.Config`, so there they are schema defaults like any other.

Two things a schema cannot express stay as they were: the mutual exclusion of `Pulsar.Reader`'s `:host` and `:client`, and defaults derived from an argument, such as a producer name built from its topic.

### Internal modules

`Pulsar.ConsumerGroup`, `Pulsar.PartitionedConsumer`, `Pulsar.ProducerGroup` and `Pulsar.PartitionedProducer` are now `@moduledoc false`. They are plumbing behind `start_consumer/4` and `start_producer/2`, and their examples taught direct use of an API that owns no option surface of its own.

This turned up documentation that existed nowhere else: `:batch_enabled`, `:batch_size` and `:flush_interval` were documented only on `Pulsar.ProducerGroup`, so hiding it would have deleted them. They are in the producer schema now, and appear on `start_producer/2` for the first time.

### Bugs found on the way

- **`:name` named two things at once.** `start_consumer/4` read it with `Keyword.get` and forwarded the options unchanged, so `Pulsar.Consumer.start_link/5` popped the same key again as the broker-side consumer name. Every consumer in a group reported the same name. It is now popped for the group, and the group names each consumer after itself and the consumer's index.
- **The client received the whole application configuration**, `:consumers` and `:producers` included, because single-client mode passed `Pulsar.Application.start/2`'s options through verbatim. It now drops the application-level keys and forwards the rest, so an option the client does not recognise is reported by the client instead of being filtered away here. Filtering to the client's known keys instead would have hidden typos on exactly the path this PR is about: `Pulsar.start(host: url, conn_timout: 500)` would have discarded the misspelling before the client could warn, while multi-client mode, which forwards its options verbatim, warned about the same typo. Both paths now behave the same.
- **`Pulsar.Reader` passed `nil` for options it had not been given**, which read as "seek to nil" rather than "not given" once validation was in place.
- **Socket option lists are not keyword lists, and the broker already could not handle them.** Typing `:socket_opts` as a keyword list surfaced a pre-existing crash: on the plain TCP path `Pulsar.Broker` stripped TLS-only keys with `Keyword.drop/2`, which raises `FunctionClauseError` on entries that are not `{key, value}` pairs. `:inet6` and `{:raw, level, opt, value}` are both valid for `:gen_tcp.connect/4`, so either one crashed the broker mid-connect on `pulsar://` and worked on `pulsar+ssl://`, whose branch skips the filter. The filter now drops only TLS keyword pairs and leaves every other entry alone, and both schemas type `:socket_opts` as a plain list.

### A stricter dead letter policy

`dead_letter_policy: [max_redelivery: nil]` used to mean "no dead letter topic", as did any other value the code did not recognise. That is the silent-default behaviour this PR exists to remove: a threshold built from configuration that turned out to be missing disabled the policy without a word.

Opting in now means configuring it — `:max_redelivery` is required and must be a positive integer. Omitting `:dead_letter_policy` entirely is still how you ask for no dead letter topic, and there is a test for that guarantee rather than for the quirk. A misspelled key inside the policy is now rejected too, where it previously disabled the policy silently.

### Keeping chunk cleanup disablable

`chunk_cleanup_interval: nil` is documented in `docs/chunking.md` as the way to switch the sweep for expired chunks off, and `Pulsar.Consumer` handles it explicitly. The first version of the consumer schema typed it `:pos_integer` and rejected it.

It now takes `false`, which is how `:partition_discovery_interval_ms` already spells the same idea, and keeps `nil` working as an alias. `0` is still rejected: as an interval rather than a timeout it reads as "sweep continuously" at least as easily as "never sweep".

### Documentation

`docs/reader.md` kept its own table of reader options, which was a third copy alongside the schema and the docs generated from it, and had already drifted — it typed `:auth` as a tuple. It now points at `Pulsar.Reader.stream/2`.

## Compatibility notes

- `dead_letter_policy: [max_redelivery: nil]` now raises. Omit the option instead.
- Passing `nil` for `:auth`, `:conn_timeout`, `:max_frame_size` or `:socket_opts` now raises. `build_broker_opts/1` used to strip nil values before merging, so `auth: maybe_auth` fell back to the application environment when `maybe_auth` was nil. Build the option list conditionally instead — `if auth, do: [auth: auth], else: []` — so that "not given" is spelled as absence. For `:auth` in particular the old behaviour meant a nil where a credential was expected produced an unauthenticated connection rather than an error.
- Consumers report `<group>-consumer-<n>` rather than the group name in broker stats, so anything matching on consumer names there needs updating.
- Unknown options log a warning where they were previously silent. Anything that surfaces is an option that was already being ignored.
- `Pulsar.Reader.stream/2` warns about unknown options where it used to raise. This is the one place validation got weaker, for consistency with the other three; all four will reject them in the next major version.

## Tests

- Unit coverage for each schema: defaults applied, application-environment fallback left alone, types rejected, unknown keys warned about, and every schema key present in the generated docs.
- Unit coverage for the dead letter policy requiring its threshold and rejecting a misspelled key rather than silently disabling itself.
- Unit coverage that the reader still refuses a `:host` and a `:client` together.
- Unit coverage that the TLS option filter keeps bare atoms and n-tuples, the shapes that used to raise, and that both schemas still reject a `:socket_opts` value that is not a list.
- Unit coverage that chunk cleanup accepts `false` and `nil`, defaults to 30 seconds, and rejects `0`.
- Unit coverage that the single-client path forwards unrecognised options and keeps `:clients`, `:consumers` and `:producers` out of the client.
- Unit coverage that `:conn_timeout` accepts `:infinity` and still rejects a value that is not a timeout.
- Integration coverage that `:name` registers the group and names each consumer after it.

## Next

The intended direction is for the public API to be `Pulsar.Client`, `Pulsar.Consumer` and `Pulsar.Producer`, with `Pulsar` delegating to them and the consumer and producer modules absorbing what the group supervisors do today. Making those supervisors internal here is the first step; the schemas already live next to the modules that will own them.

`Pulsar.Consumer.start_link/5` and `Pulsar.Producer.start_link/2` keep their chained `Keyword.pop` calls for now. They are documented entry points of their own, so their inline defaults are the only thing standing behind a direct call, and removing them before those modules own a schema would change behaviour for that caller. The cost until then is that a default such as `flow_initial: 100` is written twice, once in the schema and once in the pop, so the two have to be kept in step.

Two of the workarounds here are waiting on #163. `Pulsar.Client`'s schema defines no defaults at all, and `:startup_delay_ms`, `:startup_jitter_ms` and `:partition_discovery_interval_ms` are deliberately absent from the consumer and producer schemas, both so that an omitted option can still fall back to the application environment before a default is applied. Once the environment stops being a tuning layer, `build_broker_opts/1` goes, those options get ordinary `NimbleOptions` defaults, and the seven `refute Keyword.has_key?/2` assertions that pin the workaround go with them.
