### PR TITLE
feat(consumer)!: pass the resolved topic and subscription to callback

### DIFF
--- a/examples/bingo.exs
+++ b/examples/bingo.exs
@@ -4,7 +4,7 @@ defmodule BingoPlayer do
 
   require Logger
 
-  def init([game_master, card_size]) do
+  def init([game_master, card_size], _context) do
     card = card(card_size)
     IO.puts("#{inspect(self())} started with card: #{inspect(card, charlists: :as_lists)}")
     Process.send(game_master, {:player_ready, self()}, [])

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -32,7 +32,8 @@ defmodule Pulsar.Consumer.Callback do
 
   All optional callbacks have sensible defaults that you can override:
 
-  - `init/1` - Initialize the callback module state (default: `{:ok, nil}`)
+  - `init/2` - Initialize the callback module state, given the consumer's resolved topic and
+    subscription (default: `{:ok, nil}`)
   - `terminate/2` - Cleanup when consumer terminates (default: `:ok`)
   - `handle_call/3` - Handle synchronous calls (default: `{:reply, {:error, :not_implemented}, state}`)
   - `handle_cast/2` - Handle asynchronous casts (default: `{:noreply, state}`)
@@ -70,7 +71,7 @@ defmodule Pulsar.Consumer.Callback do
       defmodule MyApp.MessageCounter do
         use Pulsar.Consumer.Callback
 
-        def init(opts) do
+        def init(opts, _context) do
           max_messages = Keyword.get(opts, :max_messages, 1000)
           {:ok, %{count: 0, max_messages: max_messages, messages: []}}
         end
@@ -119,12 +120,14 @@ defmodule Pulsar.Consumer.Callback do
 
   ## Return Values
 
-  ### `init/1` (Optional)
+  ### `init/2` (Optional)
 
   If not implemented, defaults to `{:ok, nil}`.
 
   - `{:ok, state}` - Successful initialization with initial state
   - `{:error, reason}` - Initialization failed
+
+  Its second argument is the consumer's resolved context; see `## Consumer Context` below.
 
   ### `handle_message/2`
 
@@ -139,6 +142,45 @@ defmodule Pulsar.Consumer.Callback do
 
   - `:ok` - Cleanup completed successfully
   - Any other value is ignored
+
+  ## Consumer Context
+
+  A consumer on a partitioned topic subscribes to one partition of it, so several callback
+  processes share a configured topic while each handles a different partition. `init/2`
+  receives which one this process ended up on:
+
+      %{
+        topic: "persistent://public/default/orders-partition-2",
+        base_topic: "persistent://public/default/orders",
+        partition: 2,
+        subscription_name: "order-service",
+        subscription_type: :Shared,
+        consumer_name: "orders-order-service-partition-2-1"
+      }
+
+  `:topic` is what this consumer subscribed to and `:base_topic` what it was configured with;
+  they are equal, and `:partition` is `nil`, when the topic is not partitioned. Use `:topic`
+  as a per-partition key for metrics or flow accounting, and `:base_topic` where business
+  logic cares about the logical topic.
+
+  `:partition` is the index this library fanned out to, so a consumer configured with an
+  already concrete partition topic such as `"orders-partition-2"` reports `nil` for it: the
+  caller did the fanning out, and the topic it gave has no partitions of its own.
+
+  Keep whatever you need in your state rather than looking it up per message:
+
+      defmodule MyApp.PerPartitionMetrics do
+        use Pulsar.Consumer.Callback
+
+        def init(_init_args, context) do
+          {:ok, %{topic: context.topic, partition: context.partition, count: 0}}
+        end
+
+        def handle_message(%Pulsar.Message{}, state) do
+          :telemetry.execute([:my_app, :message], %{count: 1}, %{topic: state.topic})
+          {:ok, %{state | count: state.count + 1}}
+        end
+      end
 
   ## Failover Consumer Events
 
@@ -184,14 +226,31 @@ defmodule Pulsar.Consumer.Callback do
   @type state :: term()
   @type reason :: term()
 
-  @callback init(init_arg) :: {:ok, state} | {:error, reason}
+  @typedoc """
+  The consumer's resolved identity, passed to `c:init/2`.
+
+  `:topic` is the topic this consumer subscribed to, which for a partitioned topic is one
+  concrete partition. `:base_topic` is the topic the consumer was configured with, and equals
+  `:topic` unless the topic is partitioned. `:partition` is the partition index, or `nil` when
+  the topic is not partitioned.
+  """
+  @type context :: %{
+          topic: String.t(),
+          base_topic: String.t(),
+          partition: non_neg_integer() | nil,
+          subscription_name: String.t(),
+          subscription_type: atom(),
+          consumer_name: String.t() | nil
+        }
+
+  @callback init(init_arg, context) :: {:ok, state} | {:error, reason}
   @callback handle_message(message_args, state) ::
               {:ok, state}
               | {:error, reason, state}
               | {:noreply, state}
               | {:stop, state}
 
-  @optional_callbacks init: 1,
+  @optional_callbacks init: 2,
                       terminate: 2,
                       handle_call: 3,
                       handle_cast: 2,
@@ -233,7 +292,7 @@ defmodule Pulsar.Consumer.Callback do
       @behaviour Pulsar.Consumer.Callback
 
       # Provide default implementations for optional callbacks
-      def init(_init_args), do: {:ok, nil}
+      def init(_init_args, _context), do: {:ok, nil}
 
       def terminate(_reason, _state), do: :ok
 
@@ -265,7 +324,7 @@ defmodule Pulsar.Consumer.Callback do
         {:ok, state}
       end
 
-      defoverridable init: 1,
+      defoverridable init: 2,
                      terminate: 2,
                      handle_call: 3,
                      handle_cast: 2,

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -163,9 +163,12 @@ defmodule Pulsar.Consumer.Callback do
   as a per-partition key for metrics or flow accounting, and `:base_topic` where business
   logic cares about the logical topic.
 
-  `:partition` is the index this library fanned out to, so a consumer configured with an
-  already concrete partition topic such as `"orders-partition-2"` reports `nil` for it: the
-  caller did the fanning out, and the topic it gave has no partitions of its own.
+  A consumer configured with an already concrete partition topic such as
+  `"orders-partition-2"` reports `partition: nil`, because that is what the broker reports:
+  metadata for a concrete partition gives a partition count of zero, so the consumer is not a
+  partitioned one. The index is not recovered from the name, since a topic legitimately named
+  `"events-partition-3"` would otherwise be given a partition it does not have. Such a consumer
+  still gets its topic in `:topic`; only the index is unavailable.
 
   Keep whatever you need in your state rather than looking it up per message:
 
@@ -229,10 +232,15 @@ defmodule Pulsar.Consumer.Callback do
   @typedoc """
   The consumer's resolved identity, passed to `c:init/2`.
 
-  `:topic` is the topic this consumer subscribed to, which for a partitioned topic is one
-  concrete partition. `:base_topic` is the topic the consumer was configured with, and equals
-  `:topic` unless the topic is partitioned. `:partition` is the partition index, or `nil` when
-  the topic is not partitioned.
+  - `:topic` - the topic this consumer subscribed to, which for a partitioned topic is one
+    concrete partition
+  - `:base_topic` - the topic the consumer was configured with; equals `:topic` unless the
+    topic is partitioned
+  - `:partition` - the partition index, or `nil` when the topic is not partitioned
+  - `:subscription_name` - the subscription this consumer belongs to
+  - `:subscription_type` - how that subscription is shared
+  - `:consumer_name` - this worker's broker-visible name, which is its group's name suffixed
+    with the worker's position in it, not the `:name` the consumer was configured with
   """
   @type context :: %{
           topic: String.t(),
@@ -290,6 +298,7 @@ defmodule Pulsar.Consumer.Callback do
   defmacro __using__(_opts) do
     quote do
       @behaviour Pulsar.Consumer.Callback
+      @before_compile Pulsar.Consumer.Callback
 
       # Provide default implementations for optional callbacks
       def init(_init_args, _context), do: {:ok, nil}
@@ -332,6 +341,23 @@ defmodule Pulsar.Consumer.Callback do
                      became_active: 1,
                      became_passive: 1,
                      handle_invalid_message: 2
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    if Module.defines?(env.module, {:init, 1}) do
+      raise CompileError,
+        file: env.file,
+        line: env.line,
+        description: """
+        #{inspect(env.module)} defines init/1, which is no longer a Pulsar.Consumer.Callback \
+        callback and would never be called. Take the consumer's context as a second argument:
+
+            def init(init_args, _context) do
+
+        See Pulsar.Consumer.Callback for what the context contains.\
+        """
     end
   end
 end

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -69,7 +69,7 @@ defmodule Pulsar.Consumer.Worker do
           base_topic: String.t(),
           partition: non_neg_integer() | nil,
           subscription_name: String.t(),
-          subscription_type: String.t(),
+          subscription_type: atom(),
           consumer_id: integer(),
           consumer_name: String.t() | nil,
           callback_module: module(),

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -30,6 +30,8 @@ defmodule Pulsar.Consumer.Worker do
   defstruct [
     :client,
     :topic,
+    :base_topic,
+    :partition,
     :subscription_name,
     :subscription_type,
     :consumer_id,
@@ -64,6 +66,8 @@ defmodule Pulsar.Consumer.Worker do
 
   @type t :: %__MODULE__{
           topic: String.t(),
+          base_topic: String.t(),
+          partition: non_neg_integer() | nil,
           subscription_name: String.t(),
           subscription_type: String.t(),
           consumer_id: integer(),
@@ -312,13 +316,24 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_continue({:init_callback, init_args}, state) do
-    case state.callback_module.init(init_args) do
+    case state.callback_module.init(init_args, context(state)) do
       {:ok, callback_state} ->
         {:noreply, %{state | callback_state: callback_state, ready: true}}
 
       {:error, reason} ->
         {:stop, reason, nil}
     end
+  end
+
+  defp context(state) do
+    %{
+      topic: state.topic,
+      base_topic: state.base_topic,
+      partition: state.partition,
+      subscription_name: state.subscription_name,
+      subscription_type: state.subscription_type,
+      consumer_name: state.consumer_name
+    }
   end
 
   defp subscribe(state) do

--- a/lib/pulsar/reader/callback.ex
+++ b/lib/pulsar/reader/callback.ex
@@ -10,7 +10,7 @@ defmodule Pulsar.Reader.Callback do
   use Pulsar.Consumer.Callback
 
   @impl true
-  def init([stream_pid, reader_ref]) do
+  def init([stream_pid, reader_ref], _context) do
     {:ok, %{stream_pid: stream_pid, reader_ref: reader_ref}}
   end
 

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -520,17 +520,25 @@ defmodule Pulsar.Topology do
     end
   end
 
+  # :topic is the topic a worker subscribes to and :base_topic the one the resource was
+  # configured with; they differ only for a partition. Workers carry both so a callback can
+  # tell which partition it handles without inspecting the tree it lives in.
   defp topic_child_spec(%{worker: worker, count_key: count_key, opts: opts}) do
-    group_child_spec({:topic, :non_partitioned}, worker, count_key, opts)
+    topic_opts = Keyword.merge(opts, base_topic: Keyword.fetch!(opts, :topic), partition: nil)
+
+    group_child_spec({:topic, :non_partitioned}, worker, count_key, topic_opts)
   end
 
   defp partition_child_spec(partition_index, %{worker: worker, count_key: count_key, opts: opts}) do
-    partition_topic = Topic.partition(Keyword.fetch!(opts, :topic), partition_index)
+    base_topic = Keyword.fetch!(opts, :topic)
 
     partition_opts =
-      opts
-      |> Keyword.put(:topic, partition_topic)
-      |> Keyword.put(:name, Topic.partition(Keyword.fetch!(opts, :name), partition_index))
+      Keyword.merge(opts,
+        topic: Topic.partition(base_topic, partition_index),
+        base_topic: base_topic,
+        partition: partition_index,
+        name: Topic.partition(Keyword.fetch!(opts, :name), partition_index)
+      )
 
     group_child_spec({:partition, partition_index}, worker, count_key, partition_opts)
   end

--- a/test/integration/client/supervision_tree_test.exs
+++ b/test/integration/client/supervision_tree_test.exs
@@ -14,7 +14,7 @@ defmodule Pulsar.Integration.Client.SupervisionTreeTest do
     use Pulsar.Consumer.Callback
 
     @impl true
-    def init([test_pid]), do: {:ok, test_pid}
+    def init([test_pid], _context), do: {:ok, test_pid}
 
     @impl true
     def handle_message(message, test_pid) do

--- a/test/integration/consumer/partitioned_topic_test.exs
+++ b/test/integration/consumer/partitioned_topic_test.exs
@@ -155,6 +155,61 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
     :ok = Pulsar.Consumer.stop(consumer)
   end
 
+  test "init/2 tells each worker which partition it resolved to" do
+    {:ok, consumer} =
+      Pulsar.Consumer.start(@topic, "init-context", @consumer_callback, subscription_options(1))
+
+    assert :ok = Pulsar.Consumer.await_ready(consumer)
+
+    workers =
+      Utils.wait_for(fn -> Topology.workers(consumer) end,
+        until: &(length(&1) == 3),
+        description: "partitioned consumer workers to start"
+      )
+
+    contexts = Enum.map(workers, &@consumer_callback.context/1)
+
+    assert contexts |> Enum.map(& &1.partition) |> Enum.sort() == [0, 1, 2]
+
+    for context <- contexts do
+      assert context.base_topic == @topic
+      assert context.topic == Pulsar.Topic.partition(@topic, context.partition)
+      assert context.subscription_name == "init-context"
+      assert context.subscription_type == :Shared
+      assert context.consumer_name =~ "-partition-#{context.partition}-"
+    end
+
+    :ok = Pulsar.Consumer.stop(consumer)
+  end
+
+  test "init/2 reports no partition for a consumer started on a concrete partition topic" do
+    partition_topic = Pulsar.Topic.partition(@topic, 0)
+
+    {:ok, consumer} =
+      Pulsar.Consumer.start(
+        partition_topic,
+        "init-context-explicit-partition",
+        @consumer_callback,
+        subscription_options(1)
+      )
+
+    assert :ok = Pulsar.Consumer.await_ready(consumer)
+
+    assert [worker] =
+             Utils.wait_for(fn -> Topology.workers(consumer) end,
+               until: &match?([_worker], &1),
+               description: "explicit partition consumer to start"
+             )
+
+    context = @consumer_callback.context(worker)
+
+    assert context.partition == nil
+    assert context.topic == partition_topic
+    assert context.base_topic == partition_topic
+
+    :ok = Pulsar.Consumer.stop(consumer)
+  end
+
   test "send_flow/2 reports an unavailable partition after granting the live ones" do
     test_id = :erlang.unique_integer([:positive])
     topic = "persistent://public/default/partial-flow-#{test_id}"

--- a/test/integration/consumer/validation_test.exs
+++ b/test/integration/consumer/validation_test.exs
@@ -64,7 +64,7 @@ defmodule Pulsar.Integration.Consumer.ValidationTest do
       @moduledoc false
       use Pulsar.Consumer.Callback
 
-      def init(notify_pid), do: {:ok, notify_pid}
+      def init(notify_pid, _context), do: {:ok, notify_pid}
 
       def handle_message(message, notify_pid) do
         send(notify_pid, {:handled, message})

--- a/test/support/dummy_consumer.ex
+++ b/test/support/dummy_consumer.ex
@@ -2,14 +2,14 @@ defmodule Pulsar.Test.Support.DummyConsumer do
   @moduledoc false
   use Pulsar.Consumer.Callback
 
-  def init(opts) do
+  def init(opts, context) do
     fail_all = Keyword.get(opts, :fail_all, false)
 
     if notify_pid = Keyword.get(opts, :notify_pid) do
       send(notify_pid, {:consumer_ready, self()})
     end
 
-    {:ok, %{messages: [], count: 0, fail_all: fail_all, is_active: false}}
+    {:ok, %{messages: [], count: 0, fail_all: fail_all, is_active: false, context: context}}
   end
 
   def handle_message(%Pulsar.Message{chunk_metadata: %{chunked: true, complete: false}}, state) do
@@ -51,6 +51,10 @@ defmodule Pulsar.Test.Support.DummyConsumer do
     GenServer.call(consumer_pid, :get_state)
   end
 
+  def context(consumer_pid) do
+    GenServer.call(consumer_pid, :context)
+  end
+
   def active?(consumer_pid) do
     GenServer.call(consumer_pid, :active?)
   end
@@ -77,6 +81,10 @@ defmodule Pulsar.Test.Support.DummyConsumer do
 
   def handle_call(:get_state, _from, state) do
     {:reply, state, state}
+  end
+
+  def handle_call(:context, _from, state) do
+    {:reply, state.context, state}
   end
 
   def handle_cast(:clear_messages, state) do

--- a/test/unit/consumer_callback_test.exs
+++ b/test/unit/consumer_callback_test.exs
@@ -44,5 +44,19 @@ defmodule Pulsar.Consumer.CallbackTest do
       assert {:init, 2} in callbacks
       refute {:init, 1} in callbacks
     end
+
+    test "refuses to compile a callback still defining init/1" do
+      assert_raise CompileError, ~r/defines init\/1.*would never be called/s, fn ->
+        Code.compile_string("""
+        defmodule Pulsar.Consumer.CallbackTest.Unmigrated do
+          use Pulsar.Consumer.Callback
+
+          def init(opts), do: {:ok, opts}
+
+          def handle_message(_message, state), do: {:ok, state}
+        end
+        """)
+      end
+    end
   end
 end

--- a/test/unit/consumer_callback_test.exs
+++ b/test/unit/consumer_callback_test.exs
@@ -1,0 +1,48 @@
+defmodule Pulsar.Consumer.CallbackTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Consumer.Callback
+
+  defmodule WithInit do
+    @moduledoc false
+    use Callback
+
+    def init(init_args, context), do: {:ok, {init_args, context}}
+
+    def handle_message(_message, state), do: {:ok, state}
+  end
+
+  defmodule WithoutInit do
+    @moduledoc false
+    use Callback
+
+    def handle_message(_message, state), do: {:ok, state}
+  end
+
+  @context %{
+    topic: "persistent://public/default/orders-partition-2",
+    base_topic: "persistent://public/default/orders",
+    partition: 2,
+    subscription_name: "order-service",
+    subscription_type: :Shared,
+    consumer_name: "orders-order-service-partition-2-1"
+  }
+
+  describe "init/2" do
+    test "receives the init args and the consumer's context" do
+      assert WithInit.init(:args, @context) == {:ok, {:args, @context}}
+    end
+
+    test "defaults to {:ok, nil}" do
+      assert WithoutInit.init(:args, @context) == {:ok, nil}
+    end
+
+    test "is the only arity the behaviour defines" do
+      callbacks = Callback.behaviour_info(:callbacks)
+
+      assert {:init, 2} in callbacks
+      refute {:init, 1} in callbacks
+    end
+  end
+end

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -1,0 +1,58 @@
+defmodule Pulsar.Consumer.WorkerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Consumer.Worker
+
+  defmodule Callback do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(:refuse, _context), do: {:error, :init_refused}
+    def init(init_args, context), do: {:ok, {init_args, context}}
+
+    def handle_message(_message, state), do: {:ok, state}
+  end
+
+  @topic "persistent://public/default/orders"
+
+  defp worker_state do
+    struct(Worker,
+      topic: Pulsar.Topic.partition(@topic, 2),
+      base_topic: @topic,
+      partition: 2,
+      subscription_name: "order-service",
+      subscription_type: :Shared,
+      consumer_name: "orders-order-service-partition-2-1",
+      callback_module: Callback
+    )
+  end
+
+  describe "callback initialization" do
+    test "hands the callback its resolved topic and subscription" do
+      assert {:noreply, state} = Worker.handle_continue({:init_callback, :args}, worker_state())
+
+      assert {:args, context} = state.callback_state
+
+      assert context == %{
+               topic: "persistent://public/default/orders-partition-2",
+               base_topic: @topic,
+               partition: 2,
+               subscription_name: "order-service",
+               subscription_type: :Shared,
+               consumer_name: "orders-order-service-partition-2-1"
+             }
+    end
+
+    test "marks the consumer ready only once the callback has initialized" do
+      refute worker_state().ready
+
+      assert {:noreply, state} = Worker.handle_continue({:init_callback, :args}, worker_state())
+      assert state.ready
+    end
+
+    test "stops without a state when the callback refuses to initialize" do
+      assert {:stop, :init_refused, nil} = Worker.handle_continue({:init_callback, :refuse}, worker_state())
+    end
+  end
+end

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -122,7 +122,8 @@ defmodule Pulsar.TopologyTest do
     {root, registry}
   end
 
-  defp start_async_topology(resolver, opts \\ [], controller_opts \\ [], worker \\ StubWorker) do
+  defp start_async_topology(resolver, opts \\ [], controller_opts \\ []) do
+    {worker, controller_opts} = Keyword.pop(controller_opts, :worker, StubWorker)
     registry = :"registry-#{System.unique_integer([:positive])}"
     start_supervised!({Registry, keys: :unique, name: registry})
 
@@ -476,7 +477,7 @@ defmodule Pulsar.TopologyTest do
 
   describe "worker options" do
     test "gives a partition worker its own topic alongside the configured one" do
-      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 3} end, [], [], OptsWorker)
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 3} end, [], worker: OptsWorker)
       :ok = Topology.await_ready(root, 1_000)
 
       for {index, opts} <- worker_opts(root) do
@@ -487,7 +488,7 @@ defmodule Pulsar.TopologyTest do
     end
 
     test "leaves a non-partitioned worker on the configured topic, with no partition" do
-      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 0} end, [], [], OptsWorker)
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 0} end, [], worker: OptsWorker)
       :ok = Topology.await_ready(root, 1_000)
 
       assert [{0, opts}] = worker_opts(root)

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -88,6 +88,13 @@ defmodule Pulsar.TopologyTest do
     end
   end
 
+  defmodule OptsWorker do
+    @moduledoc false
+    use Agent
+
+    def start_link(opts), do: Agent.start_link(fn -> opts end)
+  end
+
   defmodule DisappearingSupervisor do
     @moduledoc false
 
@@ -115,7 +122,7 @@ defmodule Pulsar.TopologyTest do
     {root, registry}
   end
 
-  defp start_async_topology(resolver, opts \\ [], controller_opts \\ []) do
+  defp start_async_topology(resolver, opts \\ [], controller_opts \\ [], worker \\ StubWorker) do
     registry = :"registry-#{System.unique_integer([:positive])}"
     start_supervised!({Registry, keys: :unique, name: registry})
 
@@ -136,7 +143,7 @@ defmodule Pulsar.TopologyTest do
         id: {:root, System.unique_integer([:positive])},
         start:
           {Topology, :start_link,
-           [StubWorker, registry, :count_key, topology_opts, Keyword.put(controller_opts, :resolver, resolver)]},
+           [worker, registry, :count_key, topology_opts, Keyword.put(controller_opts, :resolver, resolver)]},
         type: :supervisor
       })
 
@@ -464,6 +471,36 @@ defmodule Pulsar.TopologyTest do
         assert [{_id, new_worker, :worker, _modules}] = Supervisor.which_children(new_group)
         assert Agent.get(new_worker, & &1) == Pulsar.Topic.partition(@topic, index)
       end
+    end
+  end
+
+  describe "worker options" do
+    test "gives a partition worker its own topic alongside the configured one" do
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 3} end, [], [], OptsWorker)
+      :ok = Topology.await_ready(root, 1_000)
+
+      for {index, opts} <- worker_opts(root) do
+        assert Keyword.fetch!(opts, :topic) == Pulsar.Topic.partition(@topic, index)
+        assert Keyword.fetch!(opts, :base_topic) == @topic
+        assert Keyword.fetch!(opts, :partition) == index
+      end
+    end
+
+    test "leaves a non-partitioned worker on the configured topic, with no partition" do
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 0} end, [], [], OptsWorker)
+      :ok = Topology.await_ready(root, 1_000)
+
+      assert [{0, opts}] = worker_opts(root)
+      assert Keyword.fetch!(opts, :topic) == @topic
+      assert Keyword.fetch!(opts, :base_topic) == @topic
+      assert Keyword.fetch!(opts, :partition) == nil
+    end
+  end
+
+  defp worker_opts(root) do
+    for {index, group} <- Topology.groups(root) do
+      [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
+      {index, Agent.get(worker, & &1)}
     end
   end
 


### PR DESCRIPTION
## Summary

`Pulsar.Consumer.Callback` gains the consumer's resolved identity at initialization: the partition topic the worker actually subscribed to, the base topic it was configured with, the partition index, and the subscription details. `init/1` is replaced by `init/2`, which receives that context as its second argument.

This is a breaking change. Closes #166.

## Motivation

A caller configures a consumer with a base topic and the library resolves it to `"<base>-partition-<n>"`, one worker per partition. A callback therefore runs in a process whose topic it was never told, which matters for per-partition metrics, logging, flow accounting, and routing.

`Pulsar.Consumer.topic/1` could answer, but only from inside the callback, `self()` is the worker, and only by paying a call per message for something fixed at startup. It has no callers in `lib/`.

Callbacks that need the partition today reach around the library instead. `off_broadway_pulsar` resolves its own topic by walking `Process.info(self(), :links)` to find its group, looking that pid up in a client registry threaded in as an init argument, regex-matching `-partition-(\d+)$` off the registered group name, and rebuilding the topic from it. It needs the value before `init` returns, because it reports the topic to its Broadway producer, which keys flow permits on it.

The information is already in hand when the callback starts: the worker calls the callback's `init` from its last `handle_continue`, by which point the topic is resolved and the subscription is established. Handing it over costs nothing.

## The context

`init/2` receives a map:

| Key | Value |
| --- | --- |
| `:topic` | The topic this consumer subscribed to; a concrete partition for a partitioned topic |
| `:base_topic` | The topic the consumer was configured with; equal to `:topic` when not partitioned |
| `:partition` | The partition index, or `nil` when the topic is not partitioned |
| `:subscription_name` | The subscription this consumer belongs to |
| `:subscription_type` | `:Exclusive`, `:Shared`, `:Failover`, or `:Key_Shared` |
| `:consumer_name` | This worker's name within its group |

`:topic` and `:base_topic` are both present so neither has to be derived from the other by string surgery, recovering the logical name from a partition name is exactly the reflection this PR removes.

`:partition` is the index this library fanned out to. A consumer configured with an already concrete partition topic reports `nil` for it, because that is what the broker reports: metadata for a concrete partition gives a partition count of zero, so the consumer is not a partitioned one. The index is deliberately not recovered from the topic name, since a topic legitimately named `"events-partition-3"` would otherwise be handed a partition it does not have.

Workers carry `:base_topic` and `:partition` alongside `:topic`, threaded from `Pulsar.Topology`, where the partition fan-out already knows both. Nothing parses topic names.

## Why `init/1` is removed rather than kept alongside

Issue #166 proposed adding `init/2` next to `init/1` for compatibility. Keeping both costs an injected delegating `init/2` in the `__using__` macro, an arity probe (`Code.ensure_loaded?/1` plus `function_exported?/3`) on the worker's initialization path, and a permanently ambiguous "which one runs" in the documentation.

The latest release is 2.11.1 and the open 3.0.0 release PR already carries #164's breaking changes, so removing `init/1` rides an existing major rather than costing a second one. The result is one callback, one arity, and a direct call.

## Breaking changes and migration

| Before | After |
| --- | --- |
| `def init(args)` | `def init(args, _context)` |
| `Pulsar.Consumer.topic(self())` inside a callback | Stash `context.topic` from `init/2` |

`init/2` remains optional and still defaults to `{:ok, nil}`, so a callback that does not implement it is unaffected. Callbacks that do implement `init/1` must add the second parameter; there is no compatibility shim.

Migration is enforced at compile time. `use Pulsar.Consumer.Callback` refuses to compile a module that still defines `init/1`, naming the module and the replacement signature. Without that guard the failure would be silent rather than loud: the injected `init/2` default would satisfy the worker, the leftover `init/1` would never be called, and the callback would run with `nil` state and no warning from the compiler.

## Follow-ups

- `off_broadway_pulsar` can drop `resolve_topic/3`, its `partition_topic/2` regex, and the `consumer_registry` init argument once it moves to 3.x. That also removes the last known external caller of the client's registry accessor.

