### PR TITLE
refactor!: make Pulsar.Message independent of batching and chunking

### DIFF
--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -79,13 +79,12 @@ The `Pulsar.Message` struct provides information about chunked messages:
   - `received_chunks` - Number of chunks received (for incomplete messages)
   - `error` - Reason for incompleteness (if incomplete)
 
-For chunked messages, some fields contain data from all chunks:
-- `command` - List of commands from all chunks
-- `metadata` - List of metadata from all chunks
-- `broker_metadata` - List of broker metadata from all chunks
-- `message_id_to_ack` - List of all chunk message IDs
+A chunked message is assembled before the callback sees it, so `payload` is the complete
+payload and `message_id` covers every chunk: acknowledging it acknowledges them all.
 
-For non-chunked messages, these fields contain single values.
+`Pulsar.Message`'s accessors — `producer_name/1`, `key/1`, `properties/1` and the rest — answer
+the same way for a chunked message as for any other. Only the `raw` field reflects the split,
+holding a list of protocol structs per chunk rather than a single one.
 
 ## Configuration Options
 

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -142,7 +142,7 @@ defmodule Pulsar.Consumer do
   along the worker and the message id:
 
       def handle_message(message, state) do
-        MyApp.Jobs.enqueue(message.payload, ack: {self(), message.message_id_to_ack})
+        MyApp.Jobs.enqueue(message.payload, ack: {self(), message.message_id})
         {:noreply, state}
       end
 

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -62,7 +62,7 @@ defmodule Pulsar.Consumer.Callback do
 
       def handle_message(%Pulsar.Message{} = message, state) do
         payload = message.payload
-        message_id = message.message_id_to_ack
+        producer = Pulsar.Message.producer_name(message)
         {:ok, state}
       end
 
@@ -205,17 +205,14 @@ defmodule Pulsar.Consumer.Callback do
 
   Example with manual ACK:
 
-      def handle_message(%Pulsar.Message{payload: payload, message_id_to_ack: message_id_to_ack}, state) do
-        # Use message_id_to_ack (not command.message_id) for manual ACK/NACK
-        # This ensures batch messages are ACKed with the correct batch_index
-
+      def handle_message(%Pulsar.Message{payload: payload, message_id: message_id}, state) do
         consumer = self()
 
         # Send to async processor
         Task.start(fn ->
           case process_async(payload) do
-            :ok -> Pulsar.Consumer.ack(consumer, message_id_to_ack)
-            {:error, _} -> Pulsar.Consumer.nack(consumer, message_id_to_ack)
+            :ok -> Pulsar.Consumer.ack(consumer, message_id)
+            {:error, _} -> Pulsar.Consumer.nack(consumer, message_id)
           end
         end)
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -502,8 +502,7 @@ defmodule Pulsar.Consumer.Worker do
 
     nacked_ids =
       Enum.reduce(messages, [], fn %Pulsar.Message{} = message, nacked_acc ->
-        message_ids_list =
-          if is_list(message.message_id_to_ack), do: message.message_id_to_ack, else: [message.message_id_to_ack]
+        message_ids_list = List.wrap(message.message_id)
 
         case send_to_dead_letter(state, message.payload, List.first(message_ids_list)) do
           :ok ->
@@ -565,8 +564,7 @@ defmodule Pulsar.Consumer.Worker do
         state.callback_module.handle_invalid_message(message, callback_state)
       end
 
-    message_ids_list =
-      if is_list(message.message_id_to_ack), do: message.message_id_to_ack, else: [message.message_id_to_ack]
+    message_ids_list = List.wrap(message.message_id)
 
     case result do
       {:ok, new_callback_state} ->
@@ -900,7 +898,7 @@ defmodule Pulsar.Consumer.Worker do
     unwrapped_messages
     |> Enum.with_index()
     |> Enum.map(fn {{single_metadata, payload}, index} ->
-      message_id_to_ack =
+      message_id =
         if single_metadata == nil do
           base_message_id
         else
@@ -908,13 +906,15 @@ defmodule Pulsar.Consumer.Worker do
         end
 
       %Pulsar.Message{
-        command: command,
-        metadata: metadata,
         payload: payload,
-        single_metadata: single_metadata,
-        broker_metadata: broker_metadata,
-        message_id_to_ack: message_id_to_ack,
-        chunk_metadata: nil
+        message_id: message_id,
+        chunk_metadata: nil,
+        raw: %{
+          command: command,
+          metadata: metadata,
+          single_metadata: single_metadata,
+          broker_metadata: broker_metadata
+        }
       }
     end)
   end
@@ -930,26 +930,25 @@ defmodule Pulsar.Consumer.Worker do
   # cannot be tied back to its siblings; those expire as an incomplete message.
   defp build_invalid_message(command, bytes, validation_error) do
     %Pulsar.Message{
-      command: command,
-      metadata: nil,
       payload: bytes,
-      single_metadata: nil,
-      broker_metadata: nil,
-      message_id_to_ack: command.message_id,
+      message_id: command.message_id,
       chunk_metadata: nil,
-      validation_error: validation_error
+      validation_error: validation_error,
+      raw: %{command: command, metadata: nil, single_metadata: nil, broker_metadata: nil}
     }
   end
 
   defp build_message_from_chunk(chunk_metadata, payload) do
     %Pulsar.Message{
-      command: Map.get(chunk_metadata, :commands, []),
-      metadata: Map.get(chunk_metadata, :metadatas, []),
       payload: payload,
-      single_metadata: [],
-      broker_metadata: Map.get(chunk_metadata, :broker_metadatas, []),
-      message_id_to_ack: Map.get(chunk_metadata, :message_ids, []),
-      chunk_metadata: chunk_metadata
+      message_id: Map.get(chunk_metadata, :message_ids, []),
+      chunk_metadata: chunk_metadata,
+      raw: %{
+        command: Map.get(chunk_metadata, :commands, []),
+        metadata: Map.get(chunk_metadata, :metadatas, []),
+        single_metadata: [],
+        broker_metadata: Map.get(chunk_metadata, :broker_metadatas, [])
+      }
     }
   end
 

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -6,98 +6,176 @@ defmodule Pulsar.Message do
 
   ## Fields
 
-  - `command` - For non-chunked messages: single command struct. For chunked messages: list of
-    commands from all chunks.
-    Type: `struct() | [struct()]`
+  - `payload` - The message payload as a binary. For a chunked message, the assembled
+    complete payload.
 
-  - `metadata` - For non-chunked messages: single metadata struct. For chunked messages: list of
-    metadata from all chunks. `nil` for invalid messages, whose metadata is either
-    unreadable or not trustworthy.
-    Type: `struct() | [struct()] | nil`
+  - `message_id` - What to pass to `Pulsar.Consumer.ack/2` and `Pulsar.Consumer.nack/2`.
+    Treat it as opaque: it carries a batch index for a batched message and covers every
+    chunk of a chunked one.
 
-  - `payload` - The actual message payload as a binary. For chunked messages, this is the
-    assembled complete payload.
-
-  - `single_metadata` - For non-batch messages: nil. For batched messages: single message metadata.
-    For chunked messages: list of metadata from all chunks.
-    Type: `nil | struct() | [struct()]`
-
-  - `broker_metadata` - For non-chunked messages: single broker metadata. For chunked messages:
-    list of broker metadata from all chunks.
-    Type: `term() | [term()]`
-
-  - `message_id_to_ack` - For non-chunked messages: single message ID. For batch messages: message
-    ID with batch_index. For chunked messages: list of all chunk message IDs.
-    Type: `term() | [term()]`
-
-  - `chunk_metadata` - Metadata about chunked messages (nil for non-chunked messages).
+  - `chunk_metadata` - Metadata about chunked messages (`nil` for non-chunked messages).
     For complete chunked messages: `%{chunked: true, complete: true, uuid: "...", num_chunks: N}`
     For incomplete chunked messages: `%{chunked: true, complete: false, error: :reason, uuid: "..."}`
 
   - `validation_error` - `nil` for messages that arrived intact. Otherwise why the
-    frame could not be trusted, in which case `payload` holds unverified bytes and
-    `metadata` is `nil`. See `valid?/1`.
-    Type: `atom() | nil`
+    frame could not be trusted, in which case `payload` holds unverified bytes. See `valid?/1`.
+
+  - `raw` - The underlying protocol structs, as a map of `:command`, `:metadata`,
+    `:single_metadata` and `:broker_metadata`. **Unstable**: its shape follows the wire
+    protocol and changes with how the broker delivered the message. Use the accessors below
+    instead; reach for `raw` only for protocol details they do not cover.
+
+  ## Reading a message
+
+  Everything a callback normally needs has an accessor that answers the same way whether the
+  message arrived on its own, inside a batch, or split across chunks:
+
+  | Accessor | Returns |
+  | --- | --- |
+  | `producer_name/1` | The producer that published it |
+  | `publish_time/1` | Broker publish timestamp, in milliseconds |
+  | `event_time/1` | Application-set event time, or `nil` when unset |
+  | `key/1` | The partition key, or `nil` |
+  | `ordering_key/1` | The ordering key, or `nil` |
+  | `properties/1` | User properties as a map |
+  | `redelivery_count/1` | How many times the broker has redelivered it |
+
+  This matters because the same datum lives in different places depending on delivery: a
+  batched message carries its key and properties per message, a non-batched one carries them
+  in the message metadata, and a chunked one has a list of both. The accessors resolve that;
+  reading `raw` does not.
 
   ## Usage
 
-  Messages are received in the `handle_message/2` callback:
-
-      def handle_message(%Pulsar.Message{} = message, state) do
-        # Access fields directly
-        payload = message.payload
-
-        {:ok, state}
-      end
-
-  ## Pattern Matching Examples
-
-      # Match only the payload
       def handle_message(%Pulsar.Message{payload: payload}, state) do
         process(payload)
         {:ok, state}
       end
 
-      # Access all fields via the struct (non-chunked)
-      def handle_message(%Pulsar.Message{} = msg, state) do
-        redelivery_count = Pulsar.Message.redelivery_count(msg)
-        producer = msg.metadata.producer_name
+      def handle_message(%Pulsar.Message{} = message, state) do
+        Logger.info("from \#{Pulsar.Message.producer_name(message)}, key \#{Pulsar.Message.key(message)}")
         {:ok, state}
       end
 
-      # Manual acknowledgment using message_id_to_ack
-      def handle_message(%Pulsar.Message{message_id_to_ack: ack_id} = msg, state) do
+  Manual acknowledgement, where the id is captured for use after the callback returns:
+
+      def handle_message(%Pulsar.Message{message_id: message_id} = message, state) do
+        consumer = self()
+
         spawn(fn ->
-          case process_async(msg) do
-            :ok -> Pulsar.Consumer.ack(self(), ack_id)
-            {:error, _} -> Pulsar.Consumer.nack(self(), ack_id)
+          case process_async(message) do
+            :ok -> Pulsar.Consumer.ack(consumer, message_id)
+            {:error, _reason} -> Pulsar.Consumer.nack(consumer, message_id)
           end
         end)
+
         {:noreply, state}
       end
   """
 
-  @type t :: %__MODULE__{
+  @typedoc """
+  The protocol structs a message was built from. Unstable; see the `:raw` field.
+  """
+  @type raw :: %{
           command: struct() | [struct()],
           metadata: struct() | [struct()] | nil,
+          single_metadata: struct() | [struct()] | nil,
+          broker_metadata: term() | [term()]
+        }
+
+  @type t :: %__MODULE__{
           payload: binary(),
-          single_metadata: struct() | nil | [struct()],
-          broker_metadata: term() | [term()],
-          message_id_to_ack: term() | [term()],
+          message_id: term() | [term()],
           chunk_metadata: map() | nil,
-          validation_error: atom() | nil
+          validation_error: atom() | nil,
+          raw: raw()
         }
 
   defstruct [
-    :command,
-    :metadata,
     :payload,
-    :single_metadata,
-    :broker_metadata,
-    :message_id_to_ack,
+    :message_id,
     :chunk_metadata,
-    :validation_error
+    :validation_error,
+    :raw
   ]
+
+  @doc """
+  Returns the name of the producer that published the message.
+
+  ## Examples
+
+      iex> raw = %{metadata: %{producer_name: "orders-api"}}
+      iex> Pulsar.Message.producer_name(%Pulsar.Message{raw: raw})
+      "orders-api"
+  """
+  @spec producer_name(t()) :: String.t() | nil
+  def producer_name(%__MODULE__{} = message), do: message |> metadata() |> field(:producer_name)
+
+  @doc """
+  Returns the time the broker published the message, in milliseconds since the epoch.
+  """
+  @spec publish_time(t()) :: non_neg_integer() | nil
+  def publish_time(%__MODULE__{} = message), do: message |> metadata() |> field(:publish_time)
+
+  @doc """
+  Returns the event time the publishing application set, or `nil` when it set none.
+
+  Pulsar represents an unset event time as `0`, which this reports as `nil`.
+
+  ## Examples
+
+      iex> raw = %{metadata: %{event_time: 0}}
+      iex> Pulsar.Message.event_time(%Pulsar.Message{raw: raw})
+      nil
+  """
+  @spec event_time(t()) :: non_neg_integer() | nil
+  def event_time(%__MODULE__{} = message) do
+    case per_message(message, :event_time) do
+      0 -> nil
+      event_time -> event_time
+    end
+  end
+
+  @doc """
+  Returns the message's partition key, or `nil` when it has none.
+
+  A batched message carries its own key, so this reads the batch entry's key and falls back
+  to the key of the message that carried it.
+
+  ## Examples
+
+      iex> raw = %{metadata: %{partition_key: "batch"}, single_metadata: %{partition_key: "entry"}}
+      iex> Pulsar.Message.key(%Pulsar.Message{raw: raw})
+      "entry"
+  """
+  @spec key(t()) :: String.t() | nil
+  def key(%__MODULE__{} = message), do: per_message(message, :partition_key)
+
+  @doc """
+  Returns the message's ordering key, or `nil` when it has none.
+  """
+  @spec ordering_key(t()) :: binary() | nil
+  def ordering_key(%__MODULE__{} = message), do: per_message(message, :ordering_key)
+
+  @doc """
+  Returns the user properties published with the message, as a map.
+
+  ## Examples
+
+      iex> raw = %{metadata: %{properties: [%{key: "trace-id", value: "abc"}]}}
+      iex> Pulsar.Message.properties(%Pulsar.Message{raw: raw})
+      %{"trace-id" => "abc"}
+
+      iex> Pulsar.Message.properties(%Pulsar.Message{raw: %{metadata: nil}})
+      %{}
+  """
+  @spec properties(t()) :: %{String.t() => String.t()}
+  def properties(%__MODULE__{} = message) do
+    message
+    |> per_message(:properties)
+    |> List.wrap()
+    |> Map.new(&{&1.key, &1.value})
+  end
 
   @doc """
   Returns the maximum redelivery count across all commands.
@@ -107,23 +185,42 @@ defmodule Pulsar.Message do
 
   ## Examples
 
-      iex> Pulsar.Message.redelivery_count(%Pulsar.Message{command: %{redelivery_count: 3}})
+      iex> Pulsar.Message.redelivery_count(%Pulsar.Message{raw: %{command: %{redelivery_count: 3}}})
       3
 
       iex> chunks = [%{redelivery_count: 1}, %{redelivery_count: 3}]
-      iex> Pulsar.Message.redelivery_count(%Pulsar.Message{command: chunks})
+      iex> Pulsar.Message.redelivery_count(%Pulsar.Message{raw: %{command: chunks}})
       3
   """
   @spec redelivery_count(t()) :: non_neg_integer()
-  def redelivery_count(%__MODULE__{command: command}) when is_list(command) do
+  def redelivery_count(%__MODULE__{raw: %{command: command}}) when is_list(command) do
     command
     |> Enum.map(& &1.redelivery_count)
     |> Enum.max(fn -> 0 end)
   end
 
-  def redelivery_count(%__MODULE__{command: command}) do
-    command.redelivery_count
+  def redelivery_count(%__MODULE__{raw: %{command: command}}), do: command.redelivery_count
+
+  # A batch entry carries its own key, properties and times; a message delivered on its own
+  # carries them in the message metadata. Chunks of one message all repeat the same values.
+  defp per_message(message, key) do
+    case message |> single_metadata() |> field(key) do
+      nil -> message |> metadata() |> field(key)
+      value -> value
+    end
   end
+
+  defp metadata(%__MODULE__{raw: %{metadata: metadata}}), do: first(metadata)
+  defp metadata(%__MODULE__{}), do: nil
+
+  defp single_metadata(%__MODULE__{raw: %{single_metadata: single_metadata}}), do: first(single_metadata)
+  defp single_metadata(%__MODULE__{}), do: nil
+
+  defp first(values) when is_list(values), do: List.first(values)
+  defp first(value), do: value
+
+  defp field(nil, _key), do: nil
+  defp field(metadata, key), do: Map.get(metadata, key)
 
   @doc """
   Returns the number of broker messages (permits) consumed.

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -10,8 +10,8 @@ defmodule Pulsar.Message do
     complete payload.
 
   - `message_id` - What to pass to `Pulsar.Consumer.ack/2` and `Pulsar.Consumer.nack/2`.
-    Treat it as opaque: it carries a batch index for a batched message and covers every
-    chunk of a chunked one.
+    Treat it as opaque rather than pattern matching it: it carries a batch index for a
+    batched message, and for a chunked one it stands for every chunk, so it is a list there.
 
   - `chunk_metadata` - Metadata about chunked messages (`nil` for non-chunked messages).
     For complete chunked messages: `%{chunked: true, complete: true, uuid: "...", num_chunks: N}`
@@ -88,7 +88,7 @@ defmodule Pulsar.Message do
           message_id: term() | [term()],
           chunk_metadata: map() | nil,
           validation_error: atom() | nil,
-          raw: raw()
+          raw: raw() | nil
         }
 
   defstruct [
@@ -203,9 +203,13 @@ defmodule Pulsar.Message do
 
   # A batch entry carries its own key, properties and times; a message delivered on its own
   # carries them in the message metadata. Chunks of one message all repeat the same values.
+  #
+  # An entry that set nothing decodes to whatever proto2 renders for that field kind: nil for
+  # an optional with no default, 0 for one with a numeric default, [] for a repeated field. All
+  # three mean "not set here, ask the message that carried it", as they do in the Java client.
   defp per_message(message, key) do
     case message |> single_metadata() |> field(key) do
-      nil -> message |> metadata() |> field(key)
+      unset when unset in [nil, 0, []] -> message |> metadata() |> field(key)
       value -> value
     end
   end

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -137,7 +137,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
     [_message1, message2 | _] = @consumer_callback.get_messages(setup_consumer)
 
     # Start consumer from second message
-    message_id = {message2.command.message_id.ledgerId, message2.command.message_id.entryId}
+    message_id = {message2.raw.command.message_id.ledgerId, message2.raw.command.message_id.entryId}
 
     {:ok, message_id_group} =
       Pulsar.Consumer.start(
@@ -345,7 +345,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
 
     compacted_messages = @consumer_callback.get_messages(compacted_consumer)
 
-    compacted_messages_map = Map.new(compacted_messages, &{&1.metadata.partition_key, &1.payload})
+    compacted_messages_map = Map.new(compacted_messages, &{Pulsar.Message.key(&1), &1.payload})
 
     assert Enum.count(compacted_messages) == 4
 
@@ -366,7 +366,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
     ] ++ opts
   end
 
-  defp publish_time_from_message(%Pulsar.Message{metadata: metadata}) do
-    metadata.publish_time
+  defp publish_time_from_message(%Pulsar.Message{} = message) do
+    Pulsar.Message.publish_time(message)
   end
 end

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -113,7 +113,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
     # Extract partition keys to verify no key overlap
     extract_keys = fn messages ->
       messages
-      |> Enum.map(& &1.metadata.partition_key)
+      |> Enum.map(&Pulsar.Message.key(&1))
       |> Enum.filter(&(&1 != nil))
       |> MapSet.new()
     end

--- a/test/integration/consumer/validation_test.exs
+++ b/test/integration/consumer/validation_test.exs
@@ -55,8 +55,8 @@ defmodule Pulsar.Integration.Consumer.ValidationTest do
     refute Pulsar.Message.valid?(message)
     assert message.validation_error == :checksum_mismatch
     assert message.payload == <<255, 255, 255>>
-    assert message.metadata == nil
-    assert message.message_id_to_ack == command.message_id
+    assert message.raw.metadata == nil
+    assert message.message_id == command.message_id
   end
 
   test "a callback that does not opt in never sees it" do

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -40,6 +40,49 @@ defmodule Pulsar.Integration.Producer.BatchTest do
       assert Enum.all?(events, fn %{count: c} -> c == 3 end)
     end
 
+    # A batched message carries its key, properties and event time per entry rather than on the
+    # message that carried them, so this is the shape Pulsar.Message's accessors have to resolve.
+    @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
+    test "each message in a batch keeps its own key, properties and event time" do
+      {consumer_pid, producer_pid} =
+        setup_producer_consumer("per-entry-metadata", batch_size: 3, flush_interval: 30_000)
+
+      [producer] = Utils.wait_for(fn -> Topology.workers(producer_pid) end, until: &match?([_], &1))
+      producer_name = :sys.get_state(producer).producer_name
+
+      event_time = DateTime.utc_now()
+      event_time_ms = DateTime.to_unix(event_time, :millisecond)
+
+      sends =
+        Enum.map(1..3, fn i ->
+          Task.async(fn ->
+            Pulsar.Producer.send(producer_pid, "entry-#{i}",
+              partition_key: "key-#{i}",
+              properties: %{"entry" => "#{i}"},
+              event_time: event_time
+            )
+          end)
+        end)
+
+      assert Enum.all?(Task.await_many(sends, 10_000), &match?({:ok, _}, &1))
+
+      expected_payloads = Enum.map(1..3, &"entry-#{&1}")
+      assert_messages_received(consumer_pid, expected_payloads)
+
+      # The assertions below only mean anything if these arrived as one batch.
+      assert_batch_telemetry(count: 3, producer_name: producer_name)
+
+      by_payload = Map.new(DummyConsumer.get_messages(consumer_pid), &{&1.payload, &1})
+
+      for i <- 1..3 do
+        message = Map.fetch!(by_payload, "entry-#{i}")
+
+        assert Pulsar.Message.key(message) == "key-#{i}"
+        assert Pulsar.Message.properties(message) == %{"entry" => "#{i}"}
+        assert Pulsar.Message.event_time(message) == event_time_ms
+      end
+    end
+
     @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
     test "flushes single message batch on timer" do
       {consumer_pid, producer_pid} =

--- a/test/integration/producer/message_options_test.exs
+++ b/test/integration/producer/message_options_test.exs
@@ -54,7 +54,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
              Pulsar.Producer.send(producer, "payload with key", partition_key: "user-123", client: @client)
 
     message = wait_for_message(consumer, "payload with key")
-    assert message.metadata.partition_key == "user-123"
+    assert Pulsar.Message.key(message) == "user-123"
   end
 
   test "send message with ordering key", %{producer: producer, consumer: consumer} do
@@ -65,7 +65,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
              )
 
     message = wait_for_message(consumer, "payload with ordering key")
-    assert message.metadata.ordering_key == "order-456"
+    assert Pulsar.Message.ordering_key(message) == "order-456"
   end
 
   test "send message with properties map", %{producer: producer, consumer: consumer} do
@@ -83,10 +83,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
 
     message = wait_for_message(consumer, "payload with properties")
 
-    received_properties =
-      Map.new(message.metadata.properties, fn %{key: k, value: v} -> {k, v} end)
-
-    assert received_properties == properties
+    assert Pulsar.Message.properties(message) == properties
   end
 
   test "send message with event time", %{producer: producer, consumer: consumer} do
@@ -100,7 +97,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
              )
 
     message = wait_for_message(consumer, "payload with event time")
-    assert message.metadata.event_time == event_time_ms
+    assert Pulsar.Message.event_time(message) == event_time_ms
   end
 
   test "send message with deliver_at_time option", %{producer: producer, consumer: consumer} do
@@ -114,7 +111,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
              )
 
     message = wait_for_message(consumer, "deliver_at payload")
-    assert message.metadata.deliver_at_time == deliver_at_ms
+    assert message.raw.metadata.deliver_at_time == deliver_at_ms
   end
 
   test "send message with deliver_after option", %{producer: producer, consumer: consumer} do
@@ -128,7 +125,7 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
 
     message = wait_for_message(consumer, "deliver_after payload")
 
-    assert_in_delta message.metadata.deliver_at_time, before_send + 1000, 10
+    assert_in_delta message.raw.metadata.deliver_at_time, before_send + 1000, 10
   end
 
   test "send message with all options combined", %{producer: producer, consumer: consumer} do
@@ -152,14 +149,11 @@ defmodule Pulsar.Integration.Producer.MessageOptionsTest do
 
     message = wait_for_message(consumer, "complex payload")
 
-    assert message.metadata.partition_key == "user-999"
-    assert message.metadata.ordering_key == "order-888"
-    assert message.metadata.event_time == event_time_ms
+    assert Pulsar.Message.key(message) == "user-999"
+    assert Pulsar.Message.ordering_key(message) == "order-888"
+    assert Pulsar.Message.event_time(message) == event_time_ms
 
-    received_properties =
-      Map.new(message.metadata.properties, fn %{key: k, value: v} -> {k, v} end)
-
-    assert received_properties == properties
+    assert Pulsar.Message.properties(message) == properties
   end
 
   defp wait_for_message(consumer, payload) do

--- a/test/integration/producer/partitioned_topic_test.exs
+++ b/test/integration/producer/partitioned_topic_test.exs
@@ -102,13 +102,13 @@ defmodule Pulsar.Integration.Producer.PartitionedTopicTest do
     # All messages should have the same partition_key
     assert [^partition_key] =
              our_messages
-             |> Enum.map(fn msg -> msg.metadata.partition_key end)
+             |> Enum.map(fn msg -> Pulsar.Message.key(msg) end)
              |> Enum.uniq()
 
     # All messages should have been routed to the same partition
     assert [_single_partition] =
              our_messages
-             |> Enum.map(fn msg -> msg.command.message_id.partition end)
+             |> Enum.map(fn msg -> msg.raw.command.message_id.partition end)
              |> Enum.uniq()
 
     :ok = Pulsar.Producer.stop(producer_pid)
@@ -162,7 +162,7 @@ defmodule Pulsar.Integration.Producer.PartitionedTopicTest do
       consumers
       |> Enum.flat_map(&DummyConsumer.get_messages/1)
       |> Enum.filter(fn msg -> msg.payload in messages end)
-      |> Enum.map(fn msg -> msg.command.message_id.partition end)
+      |> Enum.map(fn msg -> msg.raw.command.message_id.partition end)
 
     # With 30 messages and 3 partitions, random distribution should hit all partitions
     assert partitions |> Enum.uniq() |> Enum.count() == 3

--- a/test/integration/producer/schema_test.exs
+++ b/test/integration/producer/schema_test.exs
@@ -128,7 +128,7 @@ defmodule Pulsar.Integration.Producer.SchemaTest do
     Utils.wait_for(fn -> DummyConsumer.count_messages(consumer_pid) >= 1 end)
 
     [message] = DummyConsumer.get_messages(consumer_pid)
-    assert message.metadata.schema_version
+    assert message.raw.metadata.schema_version
   end
 
   test "incompatible schema types are rejected on same topic" do

--- a/test/integration/reader/flow_control_test.exs
+++ b/test/integration/reader/flow_control_test.exs
@@ -52,7 +52,7 @@ defmodule Pulsar.Integration.Reader.FlowControlTest do
 
     assert length(messages) == @num_messages
 
-    consumer_id = hd(messages).command.consumer_id
+    consumer_id = hd(messages).raw.command.consumer_id
     consumer_stats = Map.fetch!(Utils.collect_flow_stats(), consumer_id)
 
     assert consumer_stats.event_count == 5
@@ -68,7 +68,7 @@ defmodule Pulsar.Integration.Reader.FlowControlTest do
 
     assert length(messages) == @num_messages
 
-    consumer_id = hd(messages).command.consumer_id
+    consumer_id = hd(messages).raw.command.consumer_id
     consumer_stats = Map.fetch!(Utils.collect_flow_stats(), consumer_id)
 
     assert consumer_stats.event_count == @num_messages + 1
@@ -84,7 +84,7 @@ defmodule Pulsar.Integration.Reader.FlowControlTest do
 
     assert length(messages) == @num_messages
 
-    consumer_id = hd(messages).command.consumer_id
+    consumer_id = hd(messages).raw.command.consumer_id
     consumer_stats = Map.fetch!(Utils.collect_flow_stats(), consumer_id)
 
     assert consumer_stats.event_count == 1

--- a/test/integration/reader/partitioned_topic_test.exs
+++ b/test/integration/reader/partitioned_topic_test.exs
@@ -58,7 +58,7 @@ defmodule Pulsar.Integration.Reader.PartitionedTopicTest do
 
     partitions =
       result
-      |> Enum.map(& &1.message_id_to_ack.partition)
+      |> Enum.map(& &1.message_id.partition)
       |> Enum.uniq()
       |> Enum.sort()
 

--- a/test/integration/reader/seek_test.exs
+++ b/test/integration/reader/seek_test.exs
@@ -49,7 +49,7 @@ defmodule Pulsar.Integration.Reader.SeekTest do
       messages
       |> Enum.with_index(1)
       |> Map.new(fn {msg, i} ->
-        {i, %{message_id: Map.new(message_ids)[i], publish_time: msg.metadata.publish_time}}
+        {i, %{message_id: Map.new(message_ids)[i], publish_time: Pulsar.Message.publish_time(msg)}}
       end)
 
     on_exit(fn ->

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -2,6 +2,9 @@ defmodule Pulsar.MessageTest do
   use ExUnit.Case, async: true
 
   alias Pulsar.Message
+  alias Pulsar.Protocol.Binary.Pulsar.Proto.KeyValue
+  alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageMetadata
+  alias Pulsar.Protocol.Binary.Pulsar.Proto.SingleMessageMetadata
 
   doctest Message
 
@@ -14,19 +17,22 @@ defmodule Pulsar.MessageTest do
   # The point of the accessors: the same question has one answer whether the broker delivered
   # the message on its own, inside a batch, or split across chunks.
   describe "accessors across delivery shapes" do
+    # Built from the generated structs rather than plain maps, so an unset field carries
+    # whatever proto2 decodes it to, which is what the fallback has to recognise.
     defp metadata(overrides) do
-      Map.merge(
-        %{
+      struct(
+        %MessageMetadata{
           producer_name: "orders-api",
-          publish_time: 1_700_000_000_000,
-          partition_key: nil,
-          ordering_key: nil,
-          event_time: 0,
-          properties: []
+          sequence_id: 1,
+          publish_time: 1_700_000_000_000
         },
-        Map.new(overrides)
+        overrides
       )
     end
+
+    defp entry(overrides), do: struct(%SingleMessageMetadata{payload_size: 3}, overrides)
+
+    defp properties(pairs), do: Enum.map(pairs, fn {key, value} -> %KeyValue{key: key, value: value} end)
 
     test "reads a plain message from its metadata" do
       message = %Message{raw: %{metadata: metadata(partition_key: "user-1"), single_metadata: nil}}
@@ -39,13 +45,13 @@ defmodule Pulsar.MessageTest do
     test "prefers a batch entry's own key, properties and event time" do
       message = %Message{
         raw: %{
-          metadata: metadata(partition_key: "batch", properties: [%{key: "from", value: "batch"}]),
-          single_metadata: %{
-            partition_key: "entry",
-            ordering_key: nil,
-            event_time: 42,
-            properties: [%{key: "from", value: "entry"}]
-          }
+          metadata: metadata(partition_key: "batch", properties: properties(%{"from" => "batch"})),
+          single_metadata:
+            entry(
+              partition_key: "entry",
+              event_time: 42,
+              properties: properties(%{"from" => "entry"})
+            )
         }
       }
 
@@ -56,15 +62,26 @@ defmodule Pulsar.MessageTest do
       assert Message.producer_name(message) == "orders-api"
     end
 
+    # proto2 renders "unset" as nil, 0 or [] depending on the field, and all three have to
+    # fall through to the message that carried the batch.
     test "falls back to the carrying message for what a batch entry does not set" do
       message = %Message{
         raw: %{
-          metadata: metadata(partition_key: "batch"),
-          single_metadata: %{partition_key: nil, ordering_key: nil, event_time: 0, properties: []}
+          metadata:
+            metadata(
+              partition_key: "batch",
+              ordering_key: "ordered",
+              event_time: 1_699_999_999_000,
+              properties: properties(%{"trace-id" => "abc"})
+            ),
+          single_metadata: entry([])
         }
       }
 
       assert Message.key(message) == "batch"
+      assert Message.ordering_key(message) == "ordered"
+      assert Message.event_time(message) == 1_699_999_999_000
+      assert Message.properties(message) == %{"trace-id" => "abc"}
     end
 
     test "reads a chunked message as one message rather than a list" do

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -10,4 +10,79 @@ defmodule Pulsar.MessageTest do
   test "num_broker_messages/1 counts an invalid message as one permit" do
     assert Message.num_broker_messages(%Message{validation_error: :checksum_mismatch}) == 1
   end
+
+  # The point of the accessors: the same question has one answer whether the broker delivered
+  # the message on its own, inside a batch, or split across chunks.
+  describe "accessors across delivery shapes" do
+    defp metadata(overrides) do
+      Map.merge(
+        %{
+          producer_name: "orders-api",
+          publish_time: 1_700_000_000_000,
+          partition_key: nil,
+          ordering_key: nil,
+          event_time: 0,
+          properties: []
+        },
+        Map.new(overrides)
+      )
+    end
+
+    test "reads a plain message from its metadata" do
+      message = %Message{raw: %{metadata: metadata(partition_key: "user-1"), single_metadata: nil}}
+
+      assert Message.producer_name(message) == "orders-api"
+      assert Message.publish_time(message) == 1_700_000_000_000
+      assert Message.key(message) == "user-1"
+    end
+
+    test "prefers a batch entry's own key, properties and event time" do
+      message = %Message{
+        raw: %{
+          metadata: metadata(partition_key: "batch", properties: [%{key: "from", value: "batch"}]),
+          single_metadata: %{
+            partition_key: "entry",
+            ordering_key: nil,
+            event_time: 42,
+            properties: [%{key: "from", value: "entry"}]
+          }
+        }
+      }
+
+      assert Message.key(message) == "entry"
+      assert Message.event_time(message) == 42
+      assert Message.properties(message) == %{"from" => "entry"}
+      # producer and publish time are per broker message, so they stay on the outer metadata
+      assert Message.producer_name(message) == "orders-api"
+    end
+
+    test "falls back to the carrying message for what a batch entry does not set" do
+      message = %Message{
+        raw: %{
+          metadata: metadata(partition_key: "batch"),
+          single_metadata: %{partition_key: nil, ordering_key: nil, event_time: 0, properties: []}
+        }
+      }
+
+      assert Message.key(message) == "batch"
+    end
+
+    test "reads a chunked message as one message rather than a list" do
+      chunk = metadata(partition_key: "user-9")
+      message = %Message{raw: %{metadata: [chunk, chunk, chunk], single_metadata: []}}
+
+      assert Message.producer_name(message) == "orders-api"
+      assert Message.key(message) == "user-9"
+      assert Message.properties(message) == %{}
+    end
+
+    test "answers nil rather than raising for an invalid message with no metadata" do
+      message = %Message{validation_error: :checksum_mismatch, raw: %{metadata: nil, single_metadata: nil}}
+
+      assert Message.producer_name(message) == nil
+      assert Message.key(message) == nil
+      assert Message.event_time(message) == nil
+      assert Message.properties(message) == %{}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Pulsar.Message`'s public shape no longer depends on how the broker happened to deliver the message. The struct keeps what is stable, the protocol structs move behind an unstable `raw` field, and accessors answer the same way whether a message arrived on its own, inside a batch, or split across chunks.

This is a breaking change to the most widely used struct in the library, so it belongs in 3.0 alongside the other breaks rather than costing users a second migration later.

## Motivation

Five of the struct's eight fields changed type depending on delivery, and neither of the two axes that reshaped them was visible at the call site.

| Delivery | What happened to the fields |
| --- | --- |
| Batched | Per-message data moved from `metadata` into `single_metadata` |
| Chunked | Every field became a list, one entry per chunk |

So the same question had a different answer shape in each case. The partition key lives at `metadata.partition_key` (`protocol/binary.ex:460`) for a message delivered on its own and at `single_metadata.partition_key` (`:547`) for a batch entry. `properties`, `event_time` and `ordering_key` are likewise duplicated across both structs, and under chunking both become lists.

Three signs this was a defect rather than a documentation gap:

1. **The module's own example was wrong.** It read `msg.metadata.producer_name` and carried the caveat "(non-chunked)", because on a chunked message `metadata` is a list and that line raises.
2. **The library had already discovered it needed accessors.** `redelivery_count/1` has two clauses, one guarded `when is_list(command)`, and `num_broker_messages/1` does the same. Two accessors existed and every other field was left for users to hand-roll. Two acknowledgement paths in the consumer worker hand-rolled `List.wrap/1` over `message_id_to_ack` for the same reason.
3. **It failed late.** Code written against a topic that is neither batched nor chunked worked in development and broke the first time a producer enabled batching or a payload crossed the frame limit. Nothing in the type or the callback signature warned about it.

`message_id_to_ack` was the symptom people noticed, since the docs had to tell readers to use it rather than the `command.message_id` they would reach for first, but renaming it alone would have left every other field exactly as sharp.

## The shape

| Before | After |
| --- | --- |
| `payload` | unchanged |
| `chunk_metadata` | unchanged |
| `validation_error` | unchanged |
| `message_id_to_ack` | `message_id`, what to pass to `ack/2` and `nack/2`, opaque |
| `command`, `metadata`, `single_metadata`, `broker_metadata` | `raw`, a map of the same four keys, documented as unstable |

Accessors resolve the delivery shape, so a callback never branches on it:

| Accessor | Returns |
| --- | --- |
| `producer_name/1` | The producer that published the message |
| `publish_time/1` | Broker publish timestamp, in milliseconds |
| `event_time/1` | Application-set event time, or `nil` when unset |
| `key/1` | Partition key, preferring the batch entry's own |
| `ordering_key/1` | Ordering key, or `nil` |
| `properties/1` | User properties as a map, not the wire's `KeyValue` list |
| `redelivery_count/1` | Unchanged, now reading through `raw` |

Where a value can live in two places, the batch entry wins and the message that carried it is the fallback, matching what the Java client does. This is subtler than it looks: proto2 renders an unset field as `nil`, `0` or `[]` depending on its kind, so "the entry did not set this" is not one value to test for, and treating only `nil` as unset silently drops batch-level properties and event times.

The test suite is the clearest evidence that these are the right seven: nearly every integration test that reached into `metadata` was reading exactly one of them, and two of them were reimplementing `properties/1` inline with `Map.new(message.metadata.properties, fn %{key: k, value: v} -> {k, v} end)`.

## Why accessors rather than flattening the fields onto the struct

Lifting `producer_name`, `key` and the rest into struct fields would read more directly, but it computes for every message what most callbacks never look at, on the delivery path, where the common callback reads `payload` alone. A function can also express the batch entry taking precedence over the carrying message's metadata, which a field can only do by resolving it eagerly.

Keeping `raw` rather than dropping the protocol structs preserves access to details the accessors do not cover, `deliver_at_time` and `schema_version` among them, while naming it honestly so nobody builds on it expecting stability.

## Breaking changes and migration

| Before | After |
| --- | --- |
| `msg.message_id_to_ack` | `msg.message_id` |
| `msg.metadata.producer_name` | `Pulsar.Message.producer_name(msg)` |
| `msg.metadata.publish_time` | `Pulsar.Message.publish_time(msg)` |
| `msg.single_metadata.partition_key \|\| msg.metadata.partition_key` | `Pulsar.Message.key(msg)` |
| `Map.new(msg.metadata.properties, &{&1.key, &1.value})` | `Pulsar.Message.properties(msg)` |
| `msg.command`, `msg.metadata`, `msg.single_metadata`, `msg.broker_metadata` | `msg.raw.command` and so on |

`%Pulsar.Message{payload: payload}`, the overwhelmingly common pattern match, is unaffected, as is `%Pulsar.Message{} = msg` with `msg.payload`.

## Follow-ups

- `deliver_at_time`, `schema_version`, the broker `consumer_id` and the message id's `partition` have no accessor and are reached through `raw` in the suite. They are candidates if they turn out to be commonly wanted, and cheap to add later since adding an accessor is not breaking.
- The other 3.0 breaking changes under consideration, removing the positional `start` variants and downcasing the protobuf-mirrored option atoms such as `:Key_Shared` and `:LZ4`, are independent of this one and can land in either order.
