### PR TITLE
refactor(options)!: downcase enum option atoms

### DIFF
--- a/examples/bingo.exs
+++ b/examples/bingo.exs
@@ -101,7 +101,7 @@ defmodule Main do
         name: name,
         topic: topic,
         subscription_name: name,
-        subscription_type: :Exclusive,
+        subscription_type: :exclusive,
         callback_module: BingoPlayer,
         durable: false,
         init_args: [self(), card_size]

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -38,8 +38,8 @@ defmodule Pulsar.Consumer.Callback do
   - `handle_call/3` - Handle synchronous calls (default: `{:reply, {:error, :not_implemented}, state}`)
   - `handle_cast/2` - Handle asynchronous casts (default: `{:noreply, state}`)
   - `handle_info/2` - Handle other messages (default: `{:noreply, state}`)
-  - `became_active/1` - Called when this consumer becomes the active consumer of a `:Failover` subscription (default: `{:noreply, state}`)
-  - `became_passive/1` - Called when this consumer becomes a passive (standby) consumer of a `:Failover` subscription (default: `{:noreply, state}`)
+  - `became_active/1` - Called when this consumer becomes the active consumer of a `:failover` subscription (default: `{:noreply, state}`)
+  - `became_passive/1` - Called when this consumer becomes a passive (standby) consumer of a `:failover` subscription (default: `{:noreply, state}`)
   - `handle_invalid_message/2` - Called instead of `handle_message/2` for a message whose
     bytes could not be trusted (default: log a warning and acknowledge it, so it is not
     redelivered). Override it to record or divert such messages; see `Pulsar.Message.valid?/1`
@@ -109,7 +109,7 @@ defmodule Pulsar.Consumer.Callback do
          [topic: topic,
           subscription_name: subscription,
           callback_module: MyCallback,
-          subscription_type: :Key_Shared,
+          subscription_type: :key_shared,
           consumer_count: 3,
           name: :orders]
        ]}
@@ -154,7 +154,7 @@ defmodule Pulsar.Consumer.Callback do
         base_topic: "persistent://public/default/orders",
         partition: 2,
         subscription_name: "order-service",
-        subscription_type: :Shared,
+        subscription_type: :shared,
         consumer_name: "orders-order-service-partition-2-1"
       }
 
@@ -187,7 +187,7 @@ defmodule Pulsar.Consumer.Callback do
 
   ## Failover Consumer Events
 
-  For `:Failover` subscriptions, `became_active/1` and `became_passive/1`
+  For `:failover` subscriptions, `became_active/1` and `became_passive/1`
   notify a consumer when the broker promotes it to (or demotes it from) the
   active role. Useful for metrics/alerting or warming up state before a
   takeover; not meaningful for other subscription types. A passive consumer

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -31,8 +31,8 @@ defmodule Pulsar.Consumer.Options do
       """
     ],
     subscription_type: [
-      type: {:in, [:Exclusive, :Shared, :Failover, :Key_Shared]},
-      default: :Shared,
+      type: {:in, [:exclusive, :shared, :failover, :key_shared]},
+      default: :shared,
       doc: "How the subscription is shared between consumers."
     ],
     consumer_count: [

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -10,6 +10,7 @@ defmodule Pulsar.Consumer.Worker do
   alias Pulsar.Consumer.ChunkedMessageContext
   alias Pulsar.Producer.Options, as: ProducerOptions
   alias Pulsar.Producer.Worker, as: ProducerWorker
+  alias Pulsar.Protocol
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
   alias Pulsar.Schema
   alias Pulsar.Topology.Resolver
@@ -211,7 +212,7 @@ defmodule Pulsar.Consumer.Worker do
         {:noreply, %{state | broker_pid: broker_pid}, {:continue, {:seek_subscription, init_args}}}
 
       # Errors a second attempt cannot change: bad credentials stay bad, a malformed topic
-      # stays malformed, and an :Exclusive subscription already taken stays taken. Stopping
+      # stays malformed, and an :exclusive subscription already taken stays taken. Stopping
       # with :shutdown leaves the worker down instead of restarting it into the same answer,
       # and the group follows once its last worker has gone.
       {:error, {code, _message} = reason} when code in @terminal_errors ->
@@ -714,7 +715,7 @@ defmodule Pulsar.Consumer.Worker do
       %Binary.CommandSubscribe{
         topic: topic,
         subscription: subscription_name,
-        subType: subscription_type,
+        subType: Protocol.to_subscription_type(subscription_type),
         consumer_id: consumer_id,
         consumer_name: consumer_name,
         request_id: request_id,

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -101,7 +101,7 @@ defmodule Pulsar.Producer do
   ## Options
 
   - `:partition_key` - decides the partition of a partitioned topic, and is carried
-    with the message so a `Key_Shared` subscription can use it
+    with the message so a `:key_shared` subscription can use it
   - `:properties` - a map of user properties carried with the message
   - `:event_time` - the message's event time, in milliseconds
   - `:deliver_at_time` / `:deliver_after` - delayed delivery

--- a/lib/pulsar/producer/epoch_store.ex
+++ b/lib/pulsar/producer/epoch_store.ex
@@ -2,7 +2,7 @@ defmodule Pulsar.Producer.EpochStore do
   @moduledoc false
 
   # Topic epochs per client, in ETS, so a restarting producer can tell whether a newer one
-  # fenced it under the :ExclusiveWithFencing access mode. The table belongs to the client.
+  # fenced it under the :exclusive_with_fencing access mode. The table belongs to the client.
 
   @doc "Returns the ETS table name for a client."
   @spec table_name(atom()) :: atom()

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -22,17 +22,17 @@ defmodule Pulsar.Producer.Options do
       doc: "Number of producer processes to start for the topic, or for each partition."
     ],
     access_mode: [
-      type: {:in, [:Shared, :Exclusive, :WaitForExclusive, :ExclusiveWithFencing]},
-      default: :Shared,
+      type: {:in, [:shared, :exclusive, :wait_for_exclusive, :exclusive_with_fencing]},
+      default: :shared,
       doc: """
-      How the topic is shared with other producers. `:Shared` allows several,
-      `:Exclusive` fails if one is already connected, `:WaitForExclusive` waits for
-      it to disconnect, and `:ExclusiveWithFencing` evicts it.
+      How the topic is shared with other producers. `:shared` allows several,
+      `:exclusive` fails if one is already connected, `:wait_for_exclusive` waits for
+      it to disconnect, and `:exclusive_with_fencing` evicts it.
       """
     ],
     compression: [
-      type: {:in, [:NONE, :LZ4, :ZLIB, :SNAPPY, :ZSTD]},
-      default: :NONE,
+      type: {:in, [:none, :lz4, :zlib, :snappy, :zstd]},
+      default: :none,
       doc: "Compression applied to the payload."
     ],
     batch_enabled: [

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -60,7 +60,7 @@ defmodule Pulsar.Producer.Worker do
           sequence_id: integer(),
           pending_sends: %{integer() => {GenServer.from(), map()}},
           access_mode: atom(),
-          compression: :NONE | :LZ4 | :ZLIB | :SNAPPY | :ZSTD,
+          compression: :none | :lz4 | :zlib | :snappy | :zstd,
           ready: boolean(),
           registration_request_id: integer() | nil,
           topic_epoch: integer() | nil,
@@ -251,7 +251,7 @@ defmodule Pulsar.Producer.Worker do
           sequence_id: sequence_id,
           publish_time: System.system_time(:millisecond),
           uncompressed_size: byte_size(chunk_payload),
-          compression: acc_state.compression,
+          compression: Protocol.to_compression(acc_state.compression),
           partition_key: Keyword.get(opts, :partition_key),
           ordering_key: Keyword.get(opts, :ordering_key),
           properties: Protocol.to_key_value_list(Keyword.get(opts, :properties)),
@@ -451,7 +451,7 @@ defmodule Pulsar.Producer.Worker do
       producer_name: state.producer_name,
       sequence_id: sequence_id,
       publish_time: System.system_time(:millisecond),
-      compression: state.compression,
+      compression: Protocol.to_compression(state.compression),
       uncompressed_size: uncompressed_size,
       num_messages_in_batch: messages_count,
       schema_version: state.schema_version
@@ -611,7 +611,7 @@ defmodule Pulsar.Producer.Worker do
       topic: state.topic,
       producer_id: state.producer_id,
       producer_name: producer_name,
-      producer_access_mode: state.access_mode,
+      producer_access_mode: Protocol.to_producer_access_mode(state.access_mode),
       topic_epoch: state.topic_epoch,
       schema: Schema.to_binary(state.schema)
     }

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -103,7 +103,7 @@ defmodule Pulsar.Producer.Worker do
   `Pulsar.Producer.send/3`, which documents the message options.
 
   Two are not part of that public surface: `:timeout`, the call timeout in milliseconds
-  (default 5000), and `:ordering_key`, which orders within a `Key_Shared` subscription
+  (default 5000), and `:ordering_key`, which orders within a `:key_shared` subscription
   without affecting which partition the message lands on.
   """
   @spec send_message(pid(), binary(), keyword()) :: {:ok, map()} | {:error, term()}

--- a/lib/pulsar/protocol.ex
+++ b/lib/pulsar/protocol.ex
@@ -347,4 +347,38 @@ defmodule Pulsar.Protocol do
   def to_key_value_list(props) when is_map(props) do
     Enum.map(props, fn {k, v} -> %Binary.KeyValue{key: to_string(k), value: to_string(v)} end)
   end
+
+  @subscription_types %{
+    exclusive: :Exclusive,
+    shared: :Shared,
+    failover: :Failover,
+    key_shared: :Key_Shared
+  }
+
+  @access_modes %{
+    shared: :Shared,
+    exclusive: :Exclusive,
+    wait_for_exclusive: :WaitForExclusive,
+    exclusive_with_fencing: :ExclusiveWithFencing
+  }
+
+  @compressions %{none: :NONE, lz4: :LZ4, zlib: :ZLIB, zstd: :ZSTD, snappy: :SNAPPY}
+
+  @doc """
+  Translates a `:subscription_type` option to the wire's subscription type.
+  """
+  @spec to_subscription_type(atom()) :: atom()
+  def to_subscription_type(subscription_type), do: Map.fetch!(@subscription_types, subscription_type)
+
+  @doc """
+  Translates an `:access_mode` option to the wire's producer access mode.
+  """
+  @spec to_producer_access_mode(atom()) :: atom()
+  def to_producer_access_mode(access_mode), do: Map.fetch!(@access_modes, access_mode)
+
+  @doc """
+  Translates a `:compression` option to the wire's compression type.
+  """
+  @spec to_compression(atom()) :: atom()
+  def to_compression(compression), do: Map.fetch!(@compressions, compression)
 end

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -188,7 +188,7 @@ defmodule Pulsar.Reader do
 
     consumer_opts = [
       client: client_name,
-      subscription_type: :Exclusive,
+      subscription_type: :exclusive,
       durable: false,
       consumer_count: 1,
       initial_position: start_position,

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -95,7 +95,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         init_args: [fail_all: true],
         client: @client,
         initial_position: :earliest,
-        subscription_type: :Shared,
+        subscription_type: :shared,
         redelivery_interval: 100,
         dead_letter_policy: [
           max_redelivery: max_redelivery,
@@ -112,7 +112,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         "dlq-consumer",
         DummyConsumer,
         client: @client,
-        subscription_type: :Shared,
+        subscription_type: :shared,
         initial_position: :earliest
       )
 
@@ -151,7 +151,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         init_args: [fail_all: true],
         client: @client,
         initial_position: :earliest,
-        subscription_type: :Shared,
+        subscription_type: :shared,
         redelivery_interval: 100
       )
 
@@ -182,7 +182,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         init_args: [fail_all: true],
         client: @client,
         initial_position: :earliest,
-        subscription_type: :Shared,
+        subscription_type: :shared,
         redelivery_interval: 100,
         dead_letter_policy: [
           max_redelivery: 2
@@ -198,7 +198,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         "dlq-default-monitor",
         DummyConsumer,
         client: @client,
-        subscription_type: :Shared,
+        subscription_type: :shared,
         initial_position: :earliest
       )
 

--- a/test/integration/consumer/partitioned_topic_test.exs
+++ b/test/integration/consumer/partitioned_topic_test.exs
@@ -175,7 +175,7 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
       assert context.base_topic == @topic
       assert context.topic == Pulsar.Topic.partition(@topic, context.partition)
       assert context.subscription_name == "init-context"
-      assert context.subscription_type == :Shared
+      assert context.subscription_type == :shared
       assert context.consumer_name =~ "-partition-#{context.partition}-"
     end
 

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -361,7 +361,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
   defp subscription_options(initial_position, opts \\ []) do
     [
       client: @client,
-      subscription_type: :Exclusive,
+      subscription_type: :exclusive,
       initial_position: initial_position
     ] ++ opts
   end

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -56,7 +56,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
         @topic,
         "shared",
         @consumer_callback,
-        manual_flow_options(:Shared, 2)
+        manual_flow_options(:shared, 2)
       )
 
     [consumer1, consumer2] = Utils.wait_for_consumer_ready(2)
@@ -87,7 +87,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
         @topic,
         "key-shared",
         @consumer_callback,
-        manual_flow_options(:Key_Shared, 2)
+        manual_flow_options(:key_shared, 2)
       )
 
     [consumer1, consumer2] = Utils.wait_for_consumer_ready(2)
@@ -130,7 +130,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
         @topic,
         "failover",
         @consumer_callback,
-        subscription_options(:Failover, 2)
+        subscription_options(:failover, 2)
       )
 
     [consumer1, consumer2] = Utils.wait_for_consumer_ready(2)
@@ -161,7 +161,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
         @topic,
         "exclusive",
         @consumer_callback,
-        subscription_options(:Exclusive, 1)
+        subscription_options(:exclusive, 1)
       )
 
     [consumer] = Utils.wait_for_consumer_ready(1)
@@ -174,16 +174,16 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
     assert count == expected_count
   end
 
-  # An :Exclusive subscription admits one consumer, so the workers past the first are refused
+  # An :exclusive subscription admits one consumer, so the workers past the first are refused
   # and stop instead of restarting against a slot that will not free up. The one that got the
-  # subscription keeps running. Use :Failover if the others should stand by.
+  # subscription keeps running. Use :failover if the others should stand by.
   test "exclusive subscription keeps only the consumer that got the subscription" do
     {:ok, exclusive_multi_group} =
       Pulsar.Consumer.start(
         @topic,
         "exclusive-multi",
         @consumer_callback,
-        subscription_options(:Exclusive, 2)
+        subscription_options(:exclusive, 2)
       )
 
     assert Process.alive?(exclusive_multi_group)

--- a/test/integration/producer/access_modes_test.exs
+++ b/test/integration/producer/access_modes_test.exs
@@ -35,14 +35,14 @@ defmodule Pulsar.Integration.AccessModesTest do
 
   setup [:telemetry_listen]
 
-  test "multiple producers can publish with :Shared access mode" do
-    # Start two separate producer groups with :Shared mode on same topic
+  test "multiple producers can publish with :shared access mode" do
+    # Start two separate producer groups with :shared mode on same topic
     assert {:ok, group_pid_1} =
-             Pulsar.Producer.start(@shared_topic, access_mode: :Shared, client: @client)
+             Pulsar.Producer.start(@shared_topic, access_mode: :shared, client: @client)
 
     assert {:ok, group_pid_2} =
              Pulsar.Producer.start(@shared_topic,
-               access_mode: :Shared,
+               access_mode: :shared,
                name: "shared-producer-2",
                client: @client
              )
@@ -63,10 +63,10 @@ defmodule Pulsar.Integration.AccessModesTest do
   end
 
   @tag telemetry_listen: [[:pulsar, :producer, :opened, :stop]]
-  test "only one producer can connect with :Exclusive access mode" do
-    # Start first producer with :Exclusive
+  test "only one producer can connect with :exclusive access mode" do
+    # Start first producer with :exclusive
     assert {:ok, group_pid_1} =
-             Pulsar.Producer.start(@exclusive_topic, access_mode: :Exclusive, client: @client)
+             Pulsar.Producer.start(@exclusive_topic, access_mode: :exclusive, client: @client)
 
     [producer_1] = Utils.wait_for(fn -> Topology.workers(group_pid_1) end, until: &match?([_], &1))
 
@@ -76,7 +76,7 @@ defmodule Pulsar.Integration.AccessModesTest do
 
     assert {:ok, group_pid_2} =
              Pulsar.Producer.start(@exclusive_topic,
-               access_mode: :Exclusive,
+               access_mode: :exclusive,
                name: "exclusive-2",
                client: @client
              )
@@ -110,7 +110,7 @@ defmodule Pulsar.Integration.AccessModesTest do
     # New exclusive producer should now succeed
     assert {:ok, group_pid_2} =
              Pulsar.Producer.start(@exclusive_topic,
-               access_mode: :Exclusive,
+               access_mode: :exclusive,
                name: "exclusive-3",
                client: @client
              )
@@ -123,13 +123,13 @@ defmodule Pulsar.Integration.AccessModesTest do
     Pulsar.Producer.stop(group_pid_2)
   end
 
-  test ":WaitForExclusive waits for exclusive access " do
+  test ":wait_for_exclusive waits for exclusive access " do
     # See: https://github.com/apache/pulsar/blob/master/pip/pip-68.md
 
-    # Start first producer with :Exclusive - becomes the exclusive producer immediately
+    # Start first producer with :exclusive - becomes the exclusive producer immediately
     assert {:ok, group_pid_1} =
              Pulsar.Producer.start(@wait_exclusive_topic,
-               access_mode: :Exclusive,
+               access_mode: :exclusive,
                name: "producer-1",
                client: @client
              )
@@ -137,10 +137,10 @@ defmodule Pulsar.Integration.AccessModesTest do
     [producer_1] = Utils.wait_for(fn -> Topology.workers(group_pid_1) end, until: &match?([_], &1))
     Utils.wait_for(fn -> :sys.get_state(producer_1).ready end)
 
-    # Start second producer with :WaitForExclusive. It should not be ready
+    # Start second producer with :wait_for_exclusive. It should not be ready
     {:ok, group_pid_2} =
       Pulsar.Producer.start(@wait_exclusive_topic,
-        access_mode: :WaitForExclusive,
+        access_mode: :wait_for_exclusive,
         name: "waiting-producer-2",
         client: @client
       )
@@ -174,10 +174,10 @@ defmodule Pulsar.Integration.AccessModesTest do
   end
 
   @tag telemetry_listen: [[:pulsar, :producer, :opened, :stop]]
-  test ":ExclusiveWithFencing takes over and fences old producer" do
+  test ":exclusive_with_fencing takes over and fences old producer" do
     {:ok, group_pid_1} =
       Pulsar.Producer.start(@exclusive_with_fencing_topic,
-        access_mode: :Exclusive,
+        access_mode: :exclusive,
         name: "original-exclusive",
         client: @client
       )
@@ -188,10 +188,10 @@ defmodule Pulsar.Integration.AccessModesTest do
     assert :sys.get_state(producer_1).topic_epoch == 0
     assert {:ok, _} = Pulsar.Producer.send(group_pid_1, "Message from original producer", client: @client)
 
-    # Step 2: Start second producer with :ExclusiveWithFencing. It should fence out first
+    # Step 2: Start second producer with :exclusive_with_fencing. It should fence out first
     {:ok, group_pid_2} =
       Pulsar.Producer.start(@exclusive_with_fencing_topic,
-        access_mode: :ExclusiveWithFencing,
+        access_mode: :exclusive_with_fencing,
         name: "fencing-takeover",
         client: @client
       )

--- a/test/integration/producer/compression_test.exs
+++ b/test/integration/producer/compression_test.exs
@@ -30,31 +30,31 @@ defmodule Pulsar.Integration.Producer.CompressionTest do
     {:ok, _} =
       Pulsar.Producer.start(
         @topic,
-        producer_options("none", :NONE)
+        producer_options("none", :none)
       )
 
     {:ok, _} =
       Pulsar.Producer.start(
         @topic,
-        producer_options("lz4", :LZ4)
+        producer_options("lz4", :lz4)
       )
 
     {:ok, _} =
       Pulsar.Producer.start(
         @topic,
-        producer_options("zlib", :ZLIB)
+        producer_options("zlib", :zlib)
       )
 
     {:ok, _} =
       Pulsar.Producer.start(
         @topic,
-        producer_options("zstd", :ZSTD)
+        producer_options("zstd", :zstd)
       )
 
     {:ok, _} =
       Pulsar.Producer.start(
         @topic,
-        producer_options("snappy", :SNAPPY)
+        producer_options("snappy", :snappy)
       )
 
     {:ok, consumer_pid} =

--- a/test/unit/consumer_callback_test.exs
+++ b/test/unit/consumer_callback_test.exs
@@ -25,7 +25,7 @@ defmodule Pulsar.Consumer.CallbackTest do
     base_topic: "persistent://public/default/orders",
     partition: 2,
     subscription_name: "order-service",
-    subscription_type: :Shared,
+    subscription_type: :shared,
     consumer_name: "orders-order-service-partition-2-1"
   }
 

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -12,7 +12,7 @@ defmodule Pulsar.Consumer.OptionsTest do
       opts = validate!([])
 
       assert opts[:client] == :default
-      assert opts[:subscription_type] == :Shared
+      assert opts[:subscription_type] == :shared
       assert opts[:consumer_count] == 1
       assert opts[:flow_initial] == 100
       assert opts[:initial_position] == :latest

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -22,7 +22,7 @@ defmodule Pulsar.Consumer.WorkerTest do
       base_topic: @topic,
       partition: 2,
       subscription_name: "order-service",
-      subscription_type: :Shared,
+      subscription_type: :shared,
       consumer_name: "orders-order-service-partition-2-1",
       callback_module: Callback
     )
@@ -39,7 +39,7 @@ defmodule Pulsar.Consumer.WorkerTest do
                base_topic: @topic,
                partition: 2,
                subscription_name: "order-service",
-               subscription_type: :Shared,
+               subscription_type: :shared,
                consumer_name: "orders-order-service-partition-2-1"
              }
     end

--- a/test/unit/producer_epoch_store_test.exs
+++ b/test/unit/producer_epoch_store_test.exs
@@ -7,22 +7,22 @@ defmodule Pulsar.Producer.EpochStoreTest do
     EpochStore.init(:epoch_a)
     EpochStore.init(:epoch_b)
 
-    :ok = EpochStore.put(:epoch_a, "t", "p", :Exclusive, 7)
+    :ok = EpochStore.put(:epoch_a, "t", "p", :exclusive, 7)
 
-    assert EpochStore.get(:epoch_a, "t", "p", :Exclusive) == {:ok, 7}
-    assert EpochStore.get(:epoch_b, "t", "p", :Exclusive) == :error
+    assert EpochStore.get(:epoch_a, "t", "p", :exclusive) == {:ok, 7}
+    assert EpochStore.get(:epoch_b, "t", "p", :exclusive) == :error
   end
 
   test "a client that was never started reports no epoch rather than raising" do
-    assert EpochStore.get(:epoch_never, "t", "p", :Exclusive) == :error
-    assert EpochStore.put(:epoch_never, "t", "p", :Exclusive, 1) == :error
+    assert EpochStore.get(:epoch_never, "t", "p", :exclusive) == :error
+    assert EpochStore.put(:epoch_never, "t", "p", :exclusive, 1) == :error
   end
 
   test "deletes a stored epoch" do
     EpochStore.init(:epoch_delete)
-    :ok = EpochStore.put(:epoch_delete, "t", "p", :Exclusive, 7)
+    :ok = EpochStore.put(:epoch_delete, "t", "p", :exclusive, 7)
 
-    assert EpochStore.delete(:epoch_delete, "t", "p", :Exclusive) == :ok
-    assert EpochStore.get(:epoch_delete, "t", "p", :Exclusive) == :error
+    assert EpochStore.delete(:epoch_delete, "t", "p", :exclusive) == :ok
+    assert EpochStore.get(:epoch_delete, "t", "p", :exclusive) == :error
   end
 end

--- a/test/unit/producer_options_test.exs
+++ b/test/unit/producer_options_test.exs
@@ -13,8 +13,8 @@ defmodule Pulsar.Producer.OptionsTest do
 
       assert opts[:client] == :default
       assert opts[:producer_count] == 1
-      assert opts[:access_mode] == :Shared
-      assert opts[:compression] == :NONE
+      assert opts[:access_mode] == :shared
+      assert opts[:compression] == :none
       assert opts[:batch_enabled] == false
     end
 


### PR DESCRIPTION
## Summary

`:subscription_type`, `:access_mode` and `:compression` take snake_case atoms instead of the protobuf enum spelling, and the translation to the wire happens where the values reach the wire rather than in the caller's config.

This is a breaking change to options every consumer and producer sets, so it belongs in 3.0 alongside the other breaks rather than costing users a second migration later.

## Motivation

Configuring a consumer meant writing the protocol's vocabulary in Elixir code:

```elixir
Pulsar.Consumer.start(topic, "orders", MyCallback, subscription_type: :Key_Shared)
Pulsar.Producer.start(topic, compression: :LZ4, access_mode: :WaitForExclusive)
```

`:Key_Shared` mixes two conventions in one atom, `:LZ4` is a wire constant, and neither is how Elixir spells an atom. These are the values the protobuf enums use, and the only reason they reached user code is that nothing translated them on the way in.

They are also an **output**, not just an input. The consumer context added in #169 hands `subscription_type` to `c:Pulsar.Consumer.Callback.init/2`, so before this change a caller configured `:Shared` and read back `:Shared`, in the protocol's spelling, in their own callback. Downcasing only the input would have left the two halves disagreeing.

## The mapping

| Option | Before | After |
| --- | --- | --- |
| `:subscription_type` | `:Exclusive`, `:Shared`, `:Failover`, `:Key_Shared` | `:exclusive`, `:shared`, `:failover`, `:key_shared` |
| `:access_mode` | `:Shared`, `:Exclusive`, `:WaitForExclusive`, `:ExclusiveWithFencing` | `:shared`, `:exclusive`, `:wait_for_exclusive`, `:exclusive_with_fencing` |
| `:compression` | `:NONE`, `:LZ4`, `:ZLIB`, `:SNAPPY`, `:ZSTD` | `:none`, `:lz4`, `:zlib`, `:snappy`, `:zstd` |

## Where the translation happens

`Pulsar.Protocol` gains `to_subscription_type/1`, `to_producer_access_mode/1` and `to_compression/1`, applied at the four points where a value crosses to the wire: the Subscribe command, the Producer command, and the two `MessageMetadata` builds.

Worker state keeps the option exactly as the caller wrote it, which is what makes this more than a rename. `Pulsar.Producer.EpochStore` keys, producer telemetry and the callback context all report the caller's spelling rather than the broker's, and no part of the library outside `Pulsar.Protocol` has to know both.

The protocol-level pattern matches in `maybe_compress/2` and `maybe_uncompress/2` still match the enum atoms, correctly: they run against metadata that was decoded from the wire, not against an option.

`Pulsar.Reader` hardcoded `subscription_type: :Exclusive`, which the new schema rejects, so every reader would have failed to start. It is fixed here rather than separately, since it is only a bug under this change.

## Why snake_case only, rather than accepting both spellings

Accepting the old atoms alongside the new ones would make this non-breaking, at the cost of two ways to spell every value, forever, plus the validation and documentation to explain which is which. The point of the change is that the wire's vocabulary should not be in the caller's config, and a schema that still accepts it has not achieved that. A major version is when this costs nothing extra.

## Breaking changes and migration

| Before | After |
| --- | --- |
| `subscription_type: :Key_Shared` | `subscription_type: :key_shared` |
| `access_mode: :WaitForExclusive` | `access_mode: :wait_for_exclusive` |
| `compression: :LZ4` | `compression: :lz4` |

Anything reading `subscription_type` back out, from the `init/2` context or from producer telemetry, now sees the snake_case value too. The defaults are unchanged in meaning: `:shared` for both `:subscription_type` and `:access_mode`, `:none` for `:compression`.

An unmigrated value fails at startup with a `NimbleOptions.ValidationError` naming the option and listing what it accepts, so this does not fail silently.

## Follow-ups

- The other 3.0 change previously under consideration, removing the positional `start` variants listed in #164's follow-ups, has been **reconsidered and dropped**. The suite uses both the positional and keyword forms heavily, roughly 34 sites against 50, so the "two ways to call one thing" premise does not hold up: `Consumer.start/4` and `Consumer.start/1` are different arities, which is the ordinary Elixir pattern rather than an ambiguity. #164's follow-up list should not be read as still pending on that point.
