### PR TITLE
fix(consumer): supervise the dead letter producer under its consumer

### DIFF
--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -252,6 +252,10 @@ per delivery rather than per message — and `%{topic:, subscription_name:, cons
 The two dead letter events add `:dead_letter_topic` and `:redelivery_count`; `:failed` also carries
 `:reason`.
 
+`:nacked` reports that a callback rejected a message, whether or not anything will redeliver it. With no
+`:redelivery_interval` configured you will see it with no `:redelivery, :requested` behind it and nothing
+ever reaching the dead letter topic, which is the shape of the mistake the warning above describes.
+
 `:failed` is the one to alert on. It means messages are neither being processed nor parked, and their
 redelivery counts are climbing with nothing to stop them. A steady `:diverted` rate is the ordinary
 signal that a policy is doing its job; a rising one means something upstream changed.

--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -1,0 +1,245 @@
+# Dead Letter Policies
+
+## What is a Dead Letter Policy?
+
+A [dead letter topic](https://pulsar.apache.org/docs/next/concepts-messaging/#dead-letter-topic) is where
+messages go when a subscription has tried and failed to process them enough times. Without one, a message
+your callback keeps rejecting is redelivered forever: it consumes flow permits on every attempt, and on an
+ordered subscription it holds up everything behind it.
+
+A dead letter policy sets the point at which the consumer stops retrying, publishes the message to another
+topic, and acknowledges it. The subscription moves on, and the message is still there to inspect or replay.
+
+## How Dead Lettering Works
+
+### Consumer Side
+
+Every delivery carries a redelivery count from the broker. When it reaches `:max_redelivery`, that delivery
+is diverted to the dead letter topic instead of being handed to your callback:
+
+```elixir
+{:ok, consumer} = Pulsar.Consumer.start(
+  "orders",
+  "billing",
+  MyConsumer,
+  redelivery_interval: 5_000,
+  dead_letter_policy: [max_redelivery: 3]
+)
+```
+
+With `max_redelivery: 3`, a message your callback keeps rejecting is delivered three times. The fourth
+delivery is diverted, and the callback never sees it:
+
+1. **Deliveries 1 to 3**: `handle_message/2` runs and returns `{:error, reason, state}`, so the message is
+   negatively acknowledged and redelivered
+2. **Delivery 4**: the count has reached the threshold, so the message is published to the dead letter topic
+3. **Acknowledged**: once the publish succeeds, the message is acknowledged and leaves the subscription
+
+Diverting replaces delivery rather than accompanying it, so neither `handle_message/2` nor
+`handle_invalid_message/2` runs for a message that reaches the threshold.
+
+### The Dead Letter Producer
+
+Publishing needs a producer, and the consumer owns it:
+
+- It is created with the consumer, whether or not a message ever fails
+- It does not need the dead letter topic to be reachable at startup; discovery retries in the background
+- A partitioned consumer has **one** producer for the whole subscription, not one per partition
+- It is not registered, so it cannot be reached with `Pulsar.Producer.send/3` or stopped by name
+
+## Configuration Options
+
+> #### Warning {: .warning}
+>
+> A dead letter policy needs `:redelivery_interval` to be set. It is absent by default, and without it the
+> library never asks the broker to redeliver a negatively acknowledged message. The redelivery count never
+> grows, the threshold is never reached, and nothing is ever diverted.
+
+### Consumer Configuration
+
+```elixir
+{Pulsar.Client,
+ host: "pulsar://localhost:6650",
+ consumers: [
+   [topic: "orders",
+    subscription_name: "billing",
+    callback_module: MyConsumer,
+
+    redelivery_interval: 5_000,        # Required for a dead letter policy to ever trigger
+
+    dead_letter_policy: [
+      max_redelivery: 3,               # Deliveries to attempt before diverting
+      topic: "orders-parked"           # Optional; defaults to "<topic>-<subscription>-DLQ"
+    ]
+   ]
+ ]}
+```
+
+#### Configuration Details
+
+- **`max_redelivery`**: Required, a positive integer. How many times the callback sees a message before the
+  next delivery is diverted. It is the point at which diverting starts, not a cap on how many times a message
+  can be delivered — see [When the Dead Letter Topic Is Unavailable](#when-the-dead-letter-topic-is-unavailable).
+
+- **`topic`**: Where to divert to. Defaults to `"<topic>-<subscription>-DLQ"`, so two subscriptions on the
+  same topic get their own dead letter topics. Point several subscriptions at one topic by setting it
+  explicitly; each still publishes through its own producer.
+
+- **`redelivery_interval`**: Not part of the policy, but a policy does nothing without it. Milliseconds
+  between redelivery requests for negatively acknowledged messages.
+
+- **`producer`**: Options for the producer that publishes to the dead letter topic — `:compression`,
+  `:batch_enabled`, `:schema` and the rest of `Pulsar.Producer`'s options. It takes their defaults
+  otherwise. Its `:topic`, `:client` and `:name` come from the consumer and are rejected here.
+
+```elixir
+dead_letter_policy: [
+  max_redelivery: 3,
+  producer: [compression: :lz4, batch_enabled: false]
+]
+```
+
+## What a Diverted Message Carries
+
+A diverted message is republished rather than moved, so it is a new message on a new topic. What identifies
+it is carried across:
+
+| | Value |
+| --- | --- |
+| Payload | Unchanged |
+| Key and ordering key | The origin's, so a `:key_shared` dead letter consumer partitions as the origin did |
+| Properties | The origin's, plus the two below |
+| Event time | The origin's |
+| `REAL_TOPIC` | The topic the message was consumed from, spelled as the consumer was configured; the partition for a partitioned consumer |
+| `ORIGIN_MESSAGE_ID` | The origin's id, as `Pulsar.Message.message_id_string/1` prints it |
+
+The two property names are the ones the Java client uses, so a dead letter topic can be consumed by either
+client and read the same way.
+
+Reading them back:
+
+```elixir
+def handle_message(%Pulsar.Message{} = message, state) do
+  properties = Pulsar.Message.properties(message)
+
+  Logger.warning(
+    "parked message from #{properties["REAL_TOPIC"]} " <>
+      "(origin id #{properties["ORIGIN_MESSAGE_ID"]})"
+  )
+
+  {:ok, state}
+end
+```
+
+## Creating the Dead Letter Topic
+
+A consumer can ask the broker to create its topic on subscribe — that is what `:force_create_topic`
+does, and it defaults to `true`. **A producer cannot.** `CommandProducer` has no equivalent field, so
+the asymmetry is in the Pulsar protocol rather than in this library.
+
+The dead letter producer therefore relies on the broker's `allowTopicAutoCreation`, which is enabled by
+default. Where it has been turned off, create the dead letter topic before diverting into it, either with
+`pulsar-admin topics create` or by starting the consumer that reads it — subscribing creates it.
+
+## Partitioned Topics
+
+A partitioned consumer runs one worker per partition, but the dead letter topic belongs to the subscription
+rather than the partition. Every partition of `orders` diverts into the same `orders-billing-DLQ`, and
+`REAL_TOPIC` records which partition a message actually came from.
+
+The dead letter topic may itself be partitioned. It is discovered like any other topic, and messages are
+routed across its partitions honouring the key carried over from the origin.
+
+## When the Dead Letter Topic Is Unavailable
+
+A dead letter topic that cannot be published to — it does not exist and auto-creation is off, the broker is
+unreachable, the payload exceeds its maximum message size — does not disturb the subscription:
+
+- The message is left negatively acknowledged and retried on the next redelivery
+- The consumer stays subscribed; a failed publish is logged, not fatal
+- Its redelivery count keeps climbing past `:max_redelivery`, since the threshold decides when diverting
+  starts and nothing acknowledges the message until it lands
+
+This is deliberate. Dropping the message or acknowledging it without it arriving anywhere both lose data, so
+the consumer keeps trying. Watch for `Failed to send message to dead letter topic` in the logs; a message
+whose redelivery count climbs without bound is the symptom.
+
+## Example: Complete Dead Letter Flow
+
+Odd numbers are rejected and end up on the dead letter topic; even numbers are processed normally.
+Runs as-is against a broker on `localhost:6650`:
+
+```elixir
+Mix.install([:pulsar])
+
+defmodule Orders do
+  use Pulsar.Consumer.Callback
+
+  # Odd payloads never succeed, so they exhaust the policy and are parked.
+  def handle_message(%Pulsar.Message{payload: payload}, state) do
+    case String.to_integer(payload) do
+      n when rem(n, 2) == 0 ->
+        IO.puts("processed #{n}")
+        {:ok, state}
+
+      n ->
+        {:error, {:odd, n}, state}
+    end
+  end
+end
+
+defmodule Parked do
+  use Pulsar.Consumer.Callback
+
+  def handle_message(%Pulsar.Message{payload: payload} = message, state) do
+    properties = Pulsar.Message.properties(message)
+
+    IO.puts("parked #{payload} from #{properties["REAL_TOPIC"]} (#{properties["ORIGIN_MESSAGE_ID"]})")
+
+    {:ok, state}
+  end
+end
+
+{:ok, _client} = Pulsar.Client.start_link(host: "pulsar://localhost:6650")
+
+# Subscribing creates the dead letter topic, so the producer never races the broker for it.
+{:ok, parked} =
+  Pulsar.Consumer.start("numbers-billing-DLQ", "inspection", Parked, initial_position: :earliest)
+
+{:ok, orders} =
+  Pulsar.Consumer.start("numbers", "billing", Orders,
+    redelivery_interval: 500,
+    dead_letter_policy: [max_redelivery: 3]
+  )
+
+:ok = Pulsar.Consumer.await_ready(orders)
+:ok = Pulsar.Consumer.await_ready(parked)
+
+{:ok, producer} = Pulsar.Producer.start("numbers")
+:ok = Pulsar.Producer.await_ready(producer)
+
+for n <- 1..6, do: {:ok, _id} = Pulsar.Producer.send(producer, Integer.to_string(n))
+
+Process.sleep(5_000)
+```
+
+Each odd number is delivered to `handle_message/2` three times, then diverted on the fourth:
+
+```
+processed 2
+processed 4
+processed 6
+parked 1 from numbers (3:0:-1)
+parked 3 from numbers (3:2:-1)
+parked 5 from numbers (3:4:-1)
+```
+
+`examples/odds_even_dlq.exs` in the repository is the same flow declared on the client rather than
+started by hand, and exits once every odd number has been parked.
+
+## Telemetry Events
+
+There are no dead-letter-specific events. The dead letter producer is an ordinary producer, so it emits the
+`[:pulsar, :producer, …]` events — `:opened`, `:message, :published`, `:closed` and the rest — and its
+`producer_name` metadata is `"<consumer name>-dead-letter-producer"`, which is how to tell it apart from the
+producers you started yourself.

--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -239,7 +239,22 @@ started by hand, and exits once every odd number has been parked.
 
 ## Telemetry Events
 
-There are no dead-letter-specific events. The dead letter producer is an ordinary producer, so it emits the
-`[:pulsar, :producer, …]` events — `:opened`, `:message, :published`, `:closed` and the rest — and its
-`producer_name` metadata is `"<consumer name>-dead-letter-producer"`, which is how to tell it apart from the
-producers you started yourself.
+The consumer reports each stage of giving up on a message. All four carry `%{count: n}` — one event
+per delivery rather than per message — and `%{topic:, subscription_name:, consumer_id:}`:
+
+| Event | When |
+| --- | --- |
+| `[:pulsar, :consumer, :message, :nacked]` | A callback returned `{:error, …}`, or `Pulsar.Consumer.nack/2` was called |
+| `[:pulsar, :consumer, :redelivery, :requested]` | The redelivery interval asked the broker for the nacked messages back |
+| `[:pulsar, :consumer, :dead_letter, :diverted]` | Messages reached the threshold and were published to the dead letter topic |
+| `[:pulsar, :consumer, :dead_letter, :failed]` | Publishing to the dead letter topic failed, so the messages stay nacked |
+
+The two dead letter events add `:dead_letter_topic` and `:redelivery_count`; `:failed` also carries
+`:reason`.
+
+`:failed` is the one to alert on. It means messages are neither being processed nor parked, and their
+redelivery counts are climbing with nothing to stop them. A steady `:diverted` rate is the ordinary
+signal that a policy is doing its job; a rising one means something upstream changed.
+
+The dead letter producer is otherwise an ordinary producer, so the `[:pulsar, :producer, …]` events
+fire for it too, with `producer_name` set to `"<consumer name>-dead-letter-producer"`.

--- a/examples/odds_even_dlq.exs
+++ b/examples/odds_even_dlq.exs
@@ -1,0 +1,130 @@
+defmodule Accountant do
+  @moduledoc false
+  use Pulsar.Consumer.Callback
+
+  def init([reporter], _context) do
+    Process.send(reporter, {:consumer_ready, self()}, [])
+    {:ok, reporter}
+  end
+
+  def handle_message(%Pulsar.Message{payload: payload}, reporter) do
+    case String.to_integer(payload) do
+      number when rem(number, 2) == 0 ->
+        IO.puts("balanced #{number}")
+        {:ok, reporter}
+
+      number ->
+        {:error, {:does_not_balance, number}, reporter}
+    end
+  end
+end
+
+defmodule Auditor do
+  @moduledoc false
+  use Pulsar.Consumer.Callback
+
+  def init([reporter], _context) do
+    Process.send(reporter, {:consumer_ready, self()}, [])
+    {:ok, reporter}
+  end
+
+  def handle_message(%Pulsar.Message{payload: payload} = message, reporter) do
+    properties = Pulsar.Message.properties(message)
+
+    IO.puts(
+      "parked #{payload} from #{properties["REAL_TOPIC"]} " <>
+        "(origin #{properties["ORIGIN_MESSAGE_ID"]})"
+    )
+
+    Process.send(reporter, {:parked, String.to_integer(payload)}, [])
+    {:ok, reporter}
+  end
+end
+
+defmodule Main do
+  @moduledoc false
+
+  @broker "pulsar://broker1:6650"
+  @topic "persistent://public/default/ledger"
+  @subscription "accounting"
+  @dead_letter "#{@topic}-#{@subscription}-DLQ"
+
+  @numbers 1..6
+  @max_redelivery 3
+
+  def run do
+    {:ok, _pid} =
+      Pulsar.Client.start_link(
+        host: @broker,
+        producers: [[topic: @topic, name: :ledger]],
+        consumers: [accountant(), auditor()]
+      )
+
+    # Both subscriptions have to exist before anything is published: the accountant's starts at
+    # :latest and would miss what came before it, and the auditor's is what creates the dead
+    # letter topic, so the producer diverting into it never races the broker.
+    await_consumers(2)
+
+    Enum.each(@numbers, &publish/1)
+
+    odds = Enum.filter(@numbers, &(rem(&1, 2) == 1))
+    await_parked(MapSet.new(odds))
+  end
+
+  defp accountant do
+    [
+      topic: @topic,
+      subscription_name: @subscription,
+      callback_module: Accountant,
+      init_args: [self()],
+      # Without a redelivery interval a rejected message is never redelivered, its redelivery
+      # count never grows, and the policy below never triggers.
+      redelivery_interval: 500,
+      dead_letter_policy: [max_redelivery: @max_redelivery]
+    ]
+  end
+
+  defp auditor do
+    [
+      topic: @dead_letter,
+      subscription_name: "audit",
+      callback_module: Auditor,
+      init_args: [self()],
+      initial_position: :earliest
+    ]
+  end
+
+  # A producer answers {:error, :not_ready} until its topic has been discovered.
+  defp publish(number) do
+    case Pulsar.Producer.send(:ledger, Integer.to_string(number)) do
+      {:ok, _message_id} ->
+        :ok
+
+      {:error, _reason} ->
+        Process.sleep(100)
+        publish(number)
+    end
+  end
+
+  defp await_consumers(0), do: :ok
+
+  defp await_consumers(remaining) do
+    receive do
+      {:consumer_ready, _pid} -> await_consumers(remaining - 1)
+    end
+  end
+
+  defp await_parked(expected) do
+    if MapSet.size(expected) == 0 do
+      IO.puts("every odd number reached the dead letter topic after #{@max_redelivery} attempts")
+    else
+      receive do
+        {:parked, number} -> await_parked(MapSet.delete(expected, number))
+      end
+    end
+  end
+end
+
+Logger.configure(level: :warning)
+
+Main.run()

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -176,8 +176,12 @@ defmodule Pulsar.Client do
 
   # Separate branches isolate consumer and producer failures. OTP's default intensity at this
   # boundary remains the final escalation path above the wider resource-level budget.
+  #
+  # Producers come first because a consumer can own one: a dead letter producer runs under its
+  # consumer's topology but still registers in the producer registry, which has to exist by then.
+  # The branches stay independent, so this is start order only and not a restart dependency.
   defp resources_spec(opts) do
-    branches = Enum.map([:consumers, :producers], &branch_spec(&1, opts))
+    branches = Enum.map([:producers, :consumers], &branch_spec(&1, opts))
 
     %{
       id: :resources,

--- a/lib/pulsar/client.ex
+++ b/lib/pulsar/client.ex
@@ -176,12 +176,8 @@ defmodule Pulsar.Client do
 
   # Separate branches isolate consumer and producer failures. OTP's default intensity at this
   # boundary remains the final escalation path above the wider resource-level budget.
-  #
-  # Producers come first because a consumer can own one: a dead letter producer runs under its
-  # consumer's topology but still registers in the producer registry, which has to exist by then.
-  # The branches stay independent, so this is start order only and not a restart dependency.
   defp resources_spec(opts) do
-    branches = Enum.map([:producers, :consumers], &branch_spec(&1, opts))
+    branches = Enum.map([:consumers, :producers], &branch_spec(&1, opts))
 
     %{
       id: :resources,

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -21,6 +21,7 @@ defmodule Pulsar.Consumer do
   """
 
   alias Pulsar.Client
+  alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Consumer.Options
   alias Pulsar.Consumer.Worker
   alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
@@ -41,9 +42,11 @@ defmodule Pulsar.Consumer do
     client = Keyword.fetch!(opts, :client)
 
     opts =
-      Keyword.put_new_lazy(opts, :name, fn ->
+      opts
+      |> Keyword.put_new_lazy(:name, fn ->
         default_name(topic, Keyword.fetch!(opts, :subscription_name))
       end)
+      |> Keyword.put(:companions, &DeadLetter.attach/2)
 
     Topology.start_link(Worker, Client.registry(:consumers, client), :consumer_count, opts)
   end

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -6,6 +6,9 @@ defmodule Pulsar.Consumer.DeadLetter do
 
   alias Pulsar.Message
   alias Pulsar.Producer
+  alias Pulsar.Producer.Options, as: ProducerOptions
+
+  @managed_producer_options [:topic, :client, :name]
 
   # The Java client's names, so both ends of a dead letter topic agree on them.
   @real_topic_property "REAL_TOPIC"
@@ -35,7 +38,11 @@ defmodule Pulsar.Consumer.DeadLetter do
         []
 
       topic ->
-        producer_opts = [topic: topic, client: Keyword.fetch!(opts, :client), name: producer_name(opts)]
+        producer_opts =
+          opts
+          |> policy()
+          |> Keyword.get(:producer, [])
+          |> Keyword.merge(topic: topic, client: Keyword.fetch!(opts, :client), name: producer_name(opts))
 
         [
           %{
@@ -104,10 +111,32 @@ defmodule Pulsar.Consumer.DeadLetter do
     end
   end
 
+  @doc false
+  @spec validate_producer_options(term()) :: {:ok, keyword()} | {:error, String.t()}
+  def validate_producer_options(opts) when is_list(opts) do
+    case Enum.filter(@managed_producer_options, &Keyword.has_key?(opts, &1)) do
+      [] -> validate_against_producer_schema(opts)
+      managed -> {:error, "#{inspect(managed)} belongs to the consumer and cannot be set here"}
+    end
+  end
+
+  def validate_producer_options(other), do: {:error, "expected a keyword list, got: #{inspect(other)}"}
+
+  # :topic is required of a producer and supplied by the consumer, so it stands in here only to
+  # let the rest be checked while the caller is still holding the consumer's options.
+  defp validate_against_producer_schema(opts) do
+    case ProducerOptions.validate(Keyword.put(opts, :topic, "validation")) do
+      {:ok, _validated} -> {:ok, opts}
+      {:error, error} -> {:error, Exception.message(error)}
+    end
+  end
+
+  defp policy(opts), do: Keyword.get(opts, :dead_letter_policy)
+
   # Defaults to the base topic rather than the partition a worker happens to hold, so every
   # partition of a partitioned consumer diverts into one dead letter topic.
   defp topic(opts) do
-    case Keyword.get(opts, :dead_letter_policy) do
+    case policy(opts) do
       nil ->
         nil
 

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -7,6 +7,8 @@ defmodule Pulsar.Consumer.DeadLetter do
 
   alias Pulsar.Message
   alias Pulsar.Producer
+  alias Pulsar.Producer.Options, as: ProducerOptions
+  alias Pulsar.Producer.Worker, as: ProducerWorker
 
   # Read by a consumer of the dead letter topic to trace a message back to where it failed.
   # The names match the Java client's, so both ends agree on them.
@@ -42,14 +44,21 @@ defmodule Pulsar.Consumer.DeadLetter do
         []
 
       topic ->
-        # Only the three options that tie it to this consumer; Pulsar.Producer validates the
-        # rest, so the dead letter producer gets the same defaults as any other.
-        producer_opts = [topic: topic, client: Keyword.fetch!(opts, :client), name: producer_name(opts)]
+        # Validated here rather than started through Pulsar.Producer, which registers what it
+        # starts in the client's producer registry. This one is reached through the consumer
+        # that owns it, so registering would only couple it to a branch it does not belong to.
+        # Everything below the root is an ordinary producer, defaults included.
+        producer_opts =
+          ProducerOptions.validate!(
+            topic: topic,
+            client: Keyword.fetch!(opts, :client),
+            name: producer_name(opts)
+          )
 
         [
           %{
             id: {:dead_letter, topic},
-            start: {Producer, :start_link, [producer_opts]},
+            start: {Pulsar.Topology, :start_link, [ProducerWorker, nil, :producer_count, producer_opts]},
             restart: :permanent,
             type: :supervisor
           }
@@ -132,7 +141,7 @@ defmodule Pulsar.Consumer.DeadLetter do
   end
 
   # Named after the consumer, not the dead letter topic: two subscriptions may be configured to
-  # divert into the same topic, and each still needs its own registered producer.
+  # divert into the same topic, and the name keys this one's producer epochs and telemetry.
   defp producer_name(opts) do
     case topic(opts) do
       nil -> nil

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -28,7 +28,7 @@ defmodule Pulsar.Consumer.DeadLetter do
   defp annotate(opts, root) do
     case topic(opts) do
       nil -> opts
-      _topic -> Keyword.put(opts, :dead_letter_root, root)
+      topic -> Keyword.merge(opts, dead_letter_root: root, dead_letter_topic: topic)
     end
   end
 
@@ -55,14 +55,14 @@ defmodule Pulsar.Consumer.DeadLetter do
     end
   end
 
-  @spec producer(pid() | nil) :: {:ok, pid(), String.t()} | {:error, :no_dead_letter_producer}
+  @spec producer(pid() | nil) :: {:ok, pid()} | {:error, :no_dead_letter_producer}
   def producer(nil), do: {:error, :no_dead_letter_producer}
 
   def producer(root) do
     root
     |> Supervisor.which_children()
     |> Enum.find_value({:error, :no_dead_letter_producer}, fn
-      {{:dead_letter, topic}, pid, :supervisor, _modules} when is_pid(pid) -> {:ok, pid, topic}
+      {{:dead_letter, _topic}, pid, :supervisor, _modules} when is_pid(pid) -> {:ok, pid}
       _child -> false
     end)
   catch

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -7,8 +7,6 @@ defmodule Pulsar.Consumer.DeadLetter do
 
   alias Pulsar.Message
   alias Pulsar.Producer
-  alias Pulsar.Producer.Options, as: ProducerOptions
-  alias Pulsar.Producer.Worker, as: ProducerWorker
 
   # Read by a consumer of the dead letter topic to trace a message back to where it failed.
   # The names match the Java client's, so both ends agree on them.
@@ -43,21 +41,12 @@ defmodule Pulsar.Consumer.DeadLetter do
         []
 
       topic ->
-        # Validated here rather than started through Pulsar.Producer, which registers what it
-        # starts in the client's producer registry. This one is reached through the consumer
-        # that owns it, so registering would only couple it to a branch it does not belong to.
-        # Everything below the root is an ordinary producer, defaults included.
-        producer_opts =
-          ProducerOptions.validate!(
-            topic: topic,
-            client: Keyword.fetch!(opts, :client),
-            name: producer_name(opts)
-          )
+        producer_opts = [topic: topic, client: Keyword.fetch!(opts, :client), name: producer_name(opts)]
 
         [
           %{
             id: {:dead_letter, topic},
-            start: {Pulsar.Topology, :start_link, [ProducerWorker, nil, :producer_count, producer_opts]},
+            start: {Producer, :start_link_unregistered, [producer_opts]},
             restart: :permanent,
             type: :supervisor
           }
@@ -66,33 +55,15 @@ defmodule Pulsar.Consumer.DeadLetter do
   end
 
   @doc """
-  Publishes one message to the dead letter topic, carrying what identifies it.
+  The dead letter producer a consumer attached, given the root the workers were told about.
 
-  The key is preserved so a `Key_Shared` dead letter consumer sees the same partitioning as the
-  origin, and the origin's coordinates are added to the properties rather than replacing them.
+  Resolved once per diverted delivery rather than once per message: this is a call into the
+  topology root, which is also the supervisor discovery adds partitions to.
   """
-  @spec divert(map(), Message.t()) :: :ok | {:error, term()}
-  def divert(state, %Message{} = message) do
-    opts = [
-      client: state.client,
-      partition_key: Message.key(message),
-      ordering_key: Message.ordering_key(message),
-      properties: origin_properties(state, message),
-      event_time: Message.event_time(message)
-    ]
+  @spec producer(pid() | nil) :: {:ok, pid()} | {:error, :no_dead_letter_producer}
+  def producer(nil), do: {:error, :no_dead_letter_producer}
 
-    # Pulsar.Producer.send/3 answers {:error, :not_ready} while the dead letter topic is still
-    # being discovered and turns a worker dying mid-send into an error, so a dead letter topic
-    # that is unavailable or slow leaves the message nacked instead of reaching the consumer.
-    with {:ok, producer} <- producer(state.dead_letter_root),
-         {:ok, _message_id} <- Producer.send(producer, message.payload, opts) do
-      :ok
-    end
-  end
-
-  defp producer(nil), do: {:error, :no_dead_letter_producer}
-
-  defp producer(root) do
+  def producer(root) do
     root
     |> Supervisor.which_children()
     |> Enum.find_value({:error, :no_dead_letter_producer}, fn
@@ -103,28 +74,51 @@ defmodule Pulsar.Consumer.DeadLetter do
     :exit, _reason -> {:error, :no_dead_letter_producer}
   end
 
-  defp origin_properties(state, message) do
-    message
-    |> Message.properties()
-    |> Map.put(@real_topic_property, state.topic)
-    |> put_origin_message_id(message)
-  end
+  @doc """
+  Publishes one message to the dead letter topic, carrying what identifies it.
 
-  # A chunked message answers with a list of ids, one per chunk; the first is where it began.
-  defp put_origin_message_id(properties, message) do
-    case message.message_id |> List.wrap() |> List.first() do
-      nil -> properties
-      message_id -> Map.put(properties, @origin_message_id_property, format_message_id(message_id))
+  `origin` is the consumer this message failed on: its `:client` and the `:topic` it was consumed
+  from, which is the partition for a partitioned consumer.
+
+  The key is preserved so a `Key_Shared` dead letter consumer sees the same partitioning as the
+  origin, and the origin's coordinates are added to the properties rather than replacing them.
+  """
+  @spec divert(pid(), Message.t(), keyword()) :: :ok | {:error, term()}
+  def divert(producer, %Message{} = message, origin) do
+    opts = [
+      client: Keyword.fetch!(origin, :client),
+      partition_key: Message.key(message),
+      ordering_key: Message.ordering_key(message),
+      properties: origin_properties(Keyword.fetch!(origin, :topic), message),
+      event_time: Message.event_time(message)
+    ]
+
+    # Pulsar.Producer.send/3 answers {:error, :not_ready} while the dead letter topic is still
+    # being discovered and turns a worker dying mid-send into an error, so a dead letter topic
+    # that is unavailable or slow leaves the message nacked instead of reaching the consumer.
+    case Producer.send(producer, message.payload, opts) do
+      {:ok, _message_id} -> :ok
+      {:error, _reason} = error -> error
     end
   end
 
-  # The Java client's MessageId.toString(), which is what reads this property. Its partition is
-  # already -1 when the origin topic was not partitioned.
-  defp format_message_id(%{ledgerId: ledger_id, entryId: entry_id, partition: partition}) do
-    "#{ledger_id}:#{entry_id}:#{partition}"
+  @doc false
+  @spec origin_properties(String.t(), Message.t()) :: %{optional(String.t()) => String.t()}
+  def origin_properties(origin_topic, message) do
+    message
+    |> Message.properties()
+    |> Map.put(@real_topic_property, origin_topic)
+    |> put_origin_message_id(message)
   end
 
-  defp format_message_id(message_id), do: inspect(message_id)
+  # Pulsar.Message owns how an id is read and printed, batch entries and chunks included, and
+  # the string it answers is the one the Java client writes into this property.
+  defp put_origin_message_id(properties, message) do
+    case Message.message_id_string(message) do
+      nil -> properties
+      message_id -> Map.put(properties, @origin_message_id_property, message_id)
+    end
+  end
 
   # Defaults to the base topic rather than the partition a worker happens to hold, so every
   # partition of a partitioned consumer diverts into one dead letter topic.

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -72,18 +72,15 @@ defmodule Pulsar.Consumer.DeadLetter do
   @doc """
   Publishes one message to the dead letter topic, carrying what identifies it.
 
-  `origin` is the consumer this message failed on: its `:client` and the `:topic` it was consumed
-  from, which is the partition for a partitioned consumer.
-
-  The key is preserved, so a `:key_shared` dead letter consumer partitions as the origin did.
+  `origin_topic` is where the message was consumed from, which is the partition for a partitioned
+  consumer. The key is preserved, so a `:key_shared` dead letter consumer partitions as it did.
   """
-  @spec divert(pid(), Message.t(), keyword()) :: :ok | {:error, term()}
-  def divert(producer, %Message{} = message, origin) do
+  @spec divert(pid(), Message.t(), String.t()) :: :ok | {:error, term()}
+  def divert(producer, %Message{} = message, origin_topic) do
     opts = [
-      client: Keyword.fetch!(origin, :client),
       partition_key: Message.key(message),
       ordering_key: Message.ordering_key(message),
-      properties: origin_properties(Keyword.fetch!(origin, :topic), message),
+      properties: origin_properties(origin_topic, message),
       event_time: Message.event_time(message)
     ]
 

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -55,14 +55,14 @@ defmodule Pulsar.Consumer.DeadLetter do
     end
   end
 
-  @spec producer(pid() | nil) :: {:ok, pid()} | {:error, :no_dead_letter_producer}
+  @spec producer(pid() | nil) :: {:ok, pid(), String.t()} | {:error, :no_dead_letter_producer}
   def producer(nil), do: {:error, :no_dead_letter_producer}
 
   def producer(root) do
     root
     |> Supervisor.which_children()
     |> Enum.find_value({:error, :no_dead_letter_producer}, fn
-      {{:dead_letter, _topic}, pid, :supervisor, _modules} when is_pid(pid) -> {:ok, pid}
+      {{:dead_letter, topic}, pid, :supervisor, _modules} when is_pid(pid) -> {:ok, pid, topic}
       _child -> false
     end)
   catch

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -1,0 +1,142 @@
+defmodule Pulsar.Consumer.DeadLetter do
+  @moduledoc false
+
+  # The dead letter producer belongs to the consumer that diverts into it, so it hangs off that
+  # consumer's Pulsar.Topology root rather than the client's producer branch. It is a producer
+  # like any other below that point: its own topology, its own discovery, its own partitions.
+
+  alias Pulsar.Message
+  alias Pulsar.Producer
+
+  # Read by a consumer of the dead letter topic to trace a message back to where it failed.
+  # The names match the Java client's, so both ends agree on them.
+  @real_topic_property "REAL_TOPIC"
+  @origin_message_id_property "ORIGIN_MESSAGE_ID"
+
+  @doc """
+  Tells a consumer's workers where to find the dead letter producer.
+
+  Called with the logical consumer's options, before `Pulsar.Topology.Group` rewrites `:name`
+  and `:topic` per partition and per worker, so what every worker inherits describes the whole
+  consumer rather than the one partition it happens to hold.
+
+  What they inherit is the topology root, not a pid or a registered name. The producer is a
+  child of that root, so resolving through it is what makes a restart of the producer invisible
+  to the workers, and keeps them off a registry owned by a branch that restarts separately.
+  """
+  @spec annotate(keyword(), pid()) :: keyword()
+  def annotate(opts, root) do
+    case topic(opts) do
+      nil -> opts
+      _topic -> Keyword.put(opts, :dead_letter_root, root)
+    end
+  end
+
+  @doc """
+  The dead letter producer to run under a consumer's topology, or none when it has no policy.
+  """
+  @spec child_specs(keyword()) :: [Supervisor.child_spec()]
+  def child_specs(opts) do
+    case topic(opts) do
+      nil ->
+        []
+
+      topic ->
+        # Only the three options that tie it to this consumer; Pulsar.Producer validates the
+        # rest, so the dead letter producer gets the same defaults as any other.
+        producer_opts = [topic: topic, client: Keyword.fetch!(opts, :client), name: producer_name(opts)]
+
+        [
+          %{
+            id: {:dead_letter, topic},
+            start: {Producer, :start_link, [producer_opts]},
+            restart: :permanent,
+            type: :supervisor
+          }
+        ]
+    end
+  end
+
+  @doc """
+  Publishes one message to the dead letter topic, carrying what identifies it.
+
+  The key is preserved so a `Key_Shared` dead letter consumer sees the same partitioning as the
+  origin, and the origin's coordinates are added to the properties rather than replacing them.
+  """
+  @spec divert(map(), Message.t()) :: :ok | {:error, term()}
+  def divert(state, %Message{} = message) do
+    opts = [
+      client: state.client,
+      partition_key: Message.key(message),
+      ordering_key: Message.ordering_key(message),
+      properties: origin_properties(state, message),
+      event_time: Message.event_time(message)
+    ]
+
+    # Pulsar.Producer.send/3 answers {:error, :not_ready} while the dead letter topic is still
+    # being discovered and turns a worker dying mid-send into an error, so a dead letter topic
+    # that is unavailable or slow leaves the message nacked instead of reaching the consumer.
+    with {:ok, producer} <- producer(state.dead_letter_root),
+         {:ok, _message_id} <- Producer.send(producer, message.payload, opts) do
+      :ok
+    end
+  end
+
+  defp producer(nil), do: {:error, :no_dead_letter_producer}
+
+  defp producer(root) do
+    root
+    |> Supervisor.which_children()
+    |> Enum.find_value({:error, :no_dead_letter_producer}, fn
+      {{:dead_letter, _topic}, pid, :supervisor, _modules} when is_pid(pid) -> {:ok, pid}
+      _child -> false
+    end)
+  catch
+    :exit, _reason -> {:error, :no_dead_letter_producer}
+  end
+
+  defp origin_properties(state, message) do
+    message
+    |> Message.properties()
+    |> Map.put(@real_topic_property, state.topic)
+    |> put_origin_message_id(message)
+  end
+
+  # A chunked message answers with a list of ids, one per chunk; the first is where it began.
+  defp put_origin_message_id(properties, message) do
+    case message.message_id |> List.wrap() |> List.first() do
+      nil -> properties
+      message_id -> Map.put(properties, @origin_message_id_property, format_message_id(message_id))
+    end
+  end
+
+  # The Java client's MessageId.toString(), which is what reads this property. Its partition is
+  # already -1 when the origin topic was not partitioned.
+  defp format_message_id(%{ledgerId: ledger_id, entryId: entry_id, partition: partition}) do
+    "#{ledger_id}:#{entry_id}:#{partition}"
+  end
+
+  defp format_message_id(message_id), do: inspect(message_id)
+
+  # Defaults to the base topic rather than the partition a worker happens to hold, so every
+  # partition of a partitioned consumer diverts into one dead letter topic.
+  defp topic(opts) do
+    case Keyword.get(opts, :dead_letter_policy) do
+      nil ->
+        nil
+
+      policy ->
+        Keyword.get(policy, :topic) ||
+          "#{Keyword.fetch!(opts, :topic)}-#{Keyword.fetch!(opts, :subscription_name)}-DLQ"
+    end
+  end
+
+  # Named after the consumer, not the dead letter topic: two subscriptions may be configured to
+  # divert into the same topic, and each still needs its own registered producer.
+  defp producer_name(opts) do
+    case topic(opts) do
+      nil -> nil
+      _topic -> "#{Keyword.fetch!(opts, :name)}-dead-letter-producer"
+    end
+  end
+end

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -2,32 +2,26 @@ defmodule Pulsar.Consumer.DeadLetter do
   @moduledoc false
 
   # The dead letter producer belongs to the consumer that diverts into it, so it hangs off that
-  # consumer's Pulsar.Topology root rather than the client's producer branch. It is a producer
-  # like any other below that point: its own topology, its own discovery, its own partitions.
+  # consumer's Pulsar.Topology root rather than the client's producer branch.
 
   alias Pulsar.Message
   alias Pulsar.Producer
 
-  # Read by a consumer of the dead letter topic to trace a message back to where it failed.
-  # The names match the Java client's, so both ends agree on them.
+  # The Java client's names, so both ends of a dead letter topic agree on them.
   @real_topic_property "REAL_TOPIC"
   @origin_message_id_property "ORIGIN_MESSAGE_ID"
 
   @doc """
   Attaches a dead letter producer to a consumer's topology. `Pulsar.Topology`'s `:companions`.
 
-  Called with the logical consumer's options, before `Pulsar.Topology.Group` rewrites `:name`
-  and `:topic` per partition and per worker, so both the producer and what the workers are told
-  about it describe the whole consumer rather than the one partition a worker happens to hold.
-
-  A consumer with no dead letter policy attaches nothing.
+  Called with the logical consumer's options, before `Pulsar.Topology.Group` rewrites `:name` and
+  `:topic` per partition, so what it builds describes the whole consumer rather than one partition.
   """
   @spec attach(keyword(), pid()) :: {keyword(), [Supervisor.child_spec()]}
   def attach(opts, root), do: {annotate(opts, root), child_specs(opts)}
 
-  # What the workers inherit is the topology root, not a pid or a registered name. The producer
-  # is a child of that root, so resolving through it is what makes a restart of the producer
-  # invisible to them, and keeps them off a registry owned by a branch that restarts separately.
+  # Workers inherit the topology root rather than a pid, and find the producer among its children
+  # when they need it, so a producer that restarts under them goes unnoticed.
   defp annotate(opts, root) do
     case topic(opts) do
       nil -> opts
@@ -54,12 +48,6 @@ defmodule Pulsar.Consumer.DeadLetter do
     end
   end
 
-  @doc """
-  The dead letter producer a consumer attached, given the root the workers were told about.
-
-  Resolved once per diverted delivery rather than once per message: this is a call into the
-  topology root, which is also the supervisor discovery adds partitions to.
-  """
   @spec producer(pid() | nil) :: {:ok, pid()} | {:error, :no_dead_letter_producer}
   def producer(nil), do: {:error, :no_dead_letter_producer}
 
@@ -80,8 +68,7 @@ defmodule Pulsar.Consumer.DeadLetter do
   `origin` is the consumer this message failed on: its `:client` and the `:topic` it was consumed
   from, which is the partition for a partitioned consumer.
 
-  The key is preserved so a `Key_Shared` dead letter consumer sees the same partitioning as the
-  origin, and the origin's coordinates are added to the properties rather than replacing them.
+  The key is preserved, so a `:key_shared` dead letter consumer partitions as the origin did.
   """
   @spec divert(pid(), Message.t(), keyword()) :: :ok | {:error, term()}
   def divert(producer, %Message{} = message, origin) do
@@ -93,9 +80,8 @@ defmodule Pulsar.Consumer.DeadLetter do
       event_time: Message.event_time(message)
     ]
 
-    # Pulsar.Producer.send/3 answers {:error, :not_ready} while the dead letter topic is still
-    # being discovered and turns a worker dying mid-send into an error, so a dead letter topic
-    # that is unavailable or slow leaves the message nacked instead of reaching the consumer.
+    # send/3 already answers {:error, :not_ready} during discovery and turns a worker dying
+    # mid-send into an error, so an unavailable dead letter topic never reaches the consumer.
     case Producer.send(producer, message.payload, opts) do
       {:ok, _message_id} -> :ok
       {:error, _reason} = error -> error
@@ -111,8 +97,6 @@ defmodule Pulsar.Consumer.DeadLetter do
     |> put_origin_message_id(message)
   end
 
-  # Pulsar.Message owns how an id is read and printed, batch entries and chunks included, and
-  # the string it answers is the one the Java client writes into this property.
   defp put_origin_message_id(properties, message) do
     case Message.message_id_string(message) do
       nil -> properties

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -16,29 +16,28 @@ defmodule Pulsar.Consumer.DeadLetter do
   @origin_message_id_property "ORIGIN_MESSAGE_ID"
 
   @doc """
-  Tells a consumer's workers where to find the dead letter producer.
+  Attaches a dead letter producer to a consumer's topology. `Pulsar.Topology`'s `:companions`.
 
   Called with the logical consumer's options, before `Pulsar.Topology.Group` rewrites `:name`
-  and `:topic` per partition and per worker, so what every worker inherits describes the whole
-  consumer rather than the one partition it happens to hold.
+  and `:topic` per partition and per worker, so both the producer and what the workers are told
+  about it describe the whole consumer rather than the one partition a worker happens to hold.
 
-  What they inherit is the topology root, not a pid or a registered name. The producer is a
-  child of that root, so resolving through it is what makes a restart of the producer invisible
-  to the workers, and keeps them off a registry owned by a branch that restarts separately.
+  A consumer with no dead letter policy attaches nothing.
   """
-  @spec annotate(keyword(), pid()) :: keyword()
-  def annotate(opts, root) do
+  @spec attach(keyword(), pid()) :: {keyword(), [Supervisor.child_spec()]}
+  def attach(opts, root), do: {annotate(opts, root), child_specs(opts)}
+
+  # What the workers inherit is the topology root, not a pid or a registered name. The producer
+  # is a child of that root, so resolving through it is what makes a restart of the producer
+  # invisible to them, and keeps them off a registry owned by a branch that restarts separately.
+  defp annotate(opts, root) do
     case topic(opts) do
       nil -> opts
       _topic -> Keyword.put(opts, :dead_letter_root, root)
     end
   end
 
-  @doc """
-  The dead letter producer to run under a consumer's topology, or none when it has no policy.
-  """
-  @spec child_specs(keyword()) :: [Supervisor.child_spec()]
-  def child_specs(opts) do
+  defp child_specs(opts) do
     case topic(opts) do
       nil ->
         []

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -110,6 +110,14 @@ defmodule Pulsar.Consumer.Options do
         topic: [
           type: :string,
           doc: "Topic to divert to. Defaults to `\"<topic>-<subscription>-DLQ\"`."
+        ],
+        producer: [
+          type: {:custom, Pulsar.Consumer.DeadLetter, :validate_producer_options, []},
+          doc: """
+          Options for the producer that publishes to the dead letter topic, such as
+          `:compression` or `:batch_enabled`. Takes `Pulsar.Producer`'s defaults otherwise.
+          Its `:topic`, `:client` and `:name` come from the consumer and cannot be set here.
+          """
         ]
       ],
       doc: """
@@ -123,8 +131,10 @@ defmodule Pulsar.Consumer.Options do
       A diverted message keeps its key, ordering key, properties and event time, and gains
       `REAL_TOPIC` and `ORIGIN_MESSAGE_ID` properties naming where it came from.
 
-      Diverting replaces delivery rather than accompanying it, so neither `c:handle_message/2`
-      nor `c:handle_invalid_message/2` is called for a message that reaches the threshold.
+      Diverting replaces delivery rather than accompanying it, so neither
+      `c:Pulsar.Consumer.Callback.handle_message/2` nor
+      `c:Pulsar.Consumer.Callback.handle_invalid_message/2` is called for a message that
+      reaches the threshold.
       """
     ],
     max_pending_chunked_messages: [

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -120,8 +120,11 @@ defmodule Pulsar.Consumer.Options do
       letter topic that is unavailable leaves the message nacked rather than disturbing the
       subscription. A partitioned consumer diverts every partition into one dead letter topic.
 
-      A diverted message keeps its key, properties and event time, and gains `REAL_TOPIC` and
-      `ORIGIN_MESSAGE_ID` properties naming where it came from.
+      A diverted message keeps its key, ordering key, properties and event time, and gains
+      `REAL_TOPIC` and `ORIGIN_MESSAGE_ID` properties naming where it came from.
+
+      Diverting replaces delivery rather than accompanying it, so neither `c:handle_message/2`
+      nor `c:handle_invalid_message/2` is called for a message that reaches the threshold.
       """
     ],
     max_pending_chunked_messages: [

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -115,6 +115,13 @@ defmodule Pulsar.Consumer.Options do
       doc: """
       Diverts a message to another topic once it has been redelivered too often.
       Omit it entirely for no dead letter topic.
+
+      The producer this needs runs under the consumer, so it restarts on its own and a dead
+      letter topic that is unavailable leaves the message nacked rather than disturbing the
+      subscription. A partitioned consumer diverts every partition into one dead letter topic.
+
+      A diverted message keeps its key, properties and event time, and gains `REAL_TOPIC` and
+      `ORIGIN_MESSAGE_ID` properties naming where it came from.
       """
     ],
     max_pending_chunked_messages: [

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -389,10 +389,17 @@ defmodule Pulsar.Consumer.Worker do
     permits_consumed = Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
     new_state = decrement_permits(new_state, permits_consumed)
 
-    new_state = process_messages_normally(new_state, messages)
-    new_state = maybe_send_batch_to_dead_letter(new_state, messages)
+    # A delivery the policy is done with is diverted instead of delivered, not as well as. Both
+    # ran before, so the callback kept seeing a message for as long as diverting failed, and one
+    # that succeeded on that delivery had its message acknowledged and dead lettered both.
+    new_state =
+      if divert?(new_state, messages) do
+        send_batch_to_dead_letter(new_state, messages)
+      else
+        process_messages_normally(new_state, messages)
+      end
 
-    {:noreply, new_state}
+    {:noreply, check_and_refill_permits(new_state)}
   end
 
   @impl true
@@ -461,23 +468,25 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp maybe_send_batch_to_dead_letter(state, messages) do
-    max_redelivery_count =
-      messages
-      |> Enum.map(&Pulsar.Message.redelivery_count/1)
-      |> Enum.max(fn -> 0 end)
-
-    if is_nil(state.max_redelivery) or state.max_redelivery < 1 or
-         max_redelivery_count < state.max_redelivery or is_nil(state.dead_letter_root) do
-      state
-    else
-      do_send_batch_to_dead_letter(state, messages, max_redelivery_count)
-    end
+  # One delivery diverts as a whole: a batch arrives as a single broker command and a chunked
+  # message answers the maximum across its chunks, so every message built from it carries the
+  # same redelivery count.
+  defp divert?(state, messages) do
+    not is_nil(state.max_redelivery) and state.max_redelivery >= 1 and
+      not is_nil(state.dead_letter_root) and
+      batch_redelivery_count(messages) >= state.max_redelivery
   end
 
-  defp do_send_batch_to_dead_letter(state, messages, redelivery_count) do
+  defp batch_redelivery_count(messages) do
+    messages
+    |> Enum.map(&Pulsar.Message.redelivery_count/1)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp send_batch_to_dead_letter(state, messages) do
     Logger.warning(
-      "Redelivery count of #{redelivery_count} exceeds max redelivery of #{state.max_redelivery}, sending batch to DLQ "
+      "Redelivery count of #{batch_redelivery_count(messages)} reached max redelivery of " <>
+        "#{state.max_redelivery}, diverting to the dead letter topic"
     )
 
     nacked_ids =
@@ -502,14 +511,7 @@ defmodule Pulsar.Consumer.Worker do
         end
       end)
 
-    new_nacked_messages =
-      if state.redelivery_interval do
-        MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))
-      else
-        state.nacked_messages
-      end
-
-    %{state | nacked_messages: new_nacked_messages}
+    track_nacked(state, nacked_ids)
   end
 
   defp process_messages_normally(state, messages) when is_list(messages) do
@@ -518,20 +520,16 @@ defmodule Pulsar.Consumer.Worker do
         process_single_message(state, message, callback_state, nacked_acc)
       end)
 
-    state = check_and_refill_permits(state)
+    %{track_nacked(state, nacked_ids) | callback_state: final_callback_state}
+  end
 
-    new_nacked_messages =
-      if state.redelivery_interval do
-        MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))
-      else
-        state.nacked_messages
-      end
+  # :trigger_redelivery drains this set and only fires when a redelivery interval is configured,
+  # so without one an id is deliberately not tracked rather than left in a set nothing empties.
+  defp track_nacked(state, []), do: state
+  defp track_nacked(%{redelivery_interval: nil} = state, _nacked_ids), do: state
 
-    %{
-      state
-      | callback_state: final_callback_state,
-        nacked_messages: new_nacked_messages
-    }
+  defp track_nacked(state, nacked_ids) do
+    %{state | nacked_messages: MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))}
   end
 
   defp process_single_message(state, %Pulsar.Message{} = message, callback_state, nacked_acc) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -389,9 +389,7 @@ defmodule Pulsar.Consumer.Worker do
     permits_consumed = Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
     new_state = decrement_permits(new_state, permits_consumed)
 
-    # A delivery the policy is done with is diverted instead of delivered, not as well as. Both
-    # ran before, so the callback kept seeing a message for as long as diverting failed, and one
-    # that succeeded on that delivery had its message acknowledged and dead lettered both.
+    # A delivery the policy is done with is diverted instead of delivered, not as well as.
     new_state =
       if divert?(new_state, messages) do
         send_batch_to_dead_letter(new_state, messages)

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -390,9 +390,11 @@ defmodule Pulsar.Consumer.Worker do
     new_state = decrement_permits(new_state, permits_consumed)
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
+    redelivery_count = batch_redelivery_count(messages)
+
     new_state =
-      if divert?(new_state, messages) do
-        send_batch_to_dead_letter(new_state, messages)
+      if divert?(new_state, redelivery_count) do
+        send_batch_to_dead_letter(new_state, messages, redelivery_count)
       else
         process_messages_normally(new_state, messages)
       end
@@ -473,23 +475,22 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
+  defp divert?(%__MODULE__{max_redelivery: nil}, _redelivery_count), do: false
+  defp divert?(%__MODULE__{dead_letter_root: nil}, _redelivery_count), do: false
+  defp divert?(state, redelivery_count), do: redelivery_count >= state.max_redelivery
+
   # One delivery diverts as a whole: a batch arrives as a single broker command and a chunked
   # message answers the maximum across its chunks, so every message built from it carries the
   # same redelivery count.
-  defp divert?(%__MODULE__{max_redelivery: nil}, _messages), do: false
-  defp divert?(%__MODULE__{dead_letter_root: nil}, _messages), do: false
-
-  defp divert?(state, messages), do: batch_redelivery_count(messages) >= state.max_redelivery
-
   defp batch_redelivery_count(messages) do
     messages
     |> Enum.map(&Pulsar.Message.redelivery_count/1)
     |> Enum.max(fn -> 0 end)
   end
 
-  defp send_batch_to_dead_letter(state, messages) do
+  defp send_batch_to_dead_letter(state, messages, redelivery_count) do
     Logger.warning(
-      "Redelivery count of #{batch_redelivery_count(messages)} reached max redelivery of " <>
+      "Redelivery count of #{redelivery_count} reached max redelivery of " <>
         "#{state.max_redelivery}, diverting to the dead letter topic"
     )
 
@@ -520,7 +521,7 @@ defmodule Pulsar.Consumer.Worker do
         end
       end)
 
-    metadata = dead_letter_metadata(state, producer, batch_redelivery_count(messages))
+    metadata = dead_letter_metadata(state, dead_letter_topic(producer), redelivery_count)
 
     if diverted > 0 do
       :telemetry.execute([:pulsar, :consumer, :dead_letter, :diverted], %{count: diverted}, metadata)
@@ -540,13 +541,10 @@ defmodule Pulsar.Consumer.Worker do
   defp divert({:ok, producer, _topic}, message, origin), do: DeadLetter.divert(producer, message, origin)
   defp divert({:error, _reason} = error, _message, _origin), do: error
 
-  defp dead_letter_metadata(state, producer, redelivery_count) do
-    dead_letter_topic =
-      case producer do
-        {:ok, _pid, topic} -> topic
-        {:error, _reason} -> nil
-      end
+  defp dead_letter_topic({:ok, _producer, topic}), do: topic
+  defp dead_letter_topic({:error, _reason}), do: nil
 
+  defp dead_letter_metadata(state, dead_letter_topic, redelivery_count) do
     state
     |> consumer_metadata()
     |> Map.merge(%{dead_letter_topic: dead_letter_topic, redelivery_count: redelivery_count})
@@ -580,7 +578,11 @@ defmodule Pulsar.Consumer.Worker do
   # :trigger_redelivery drains this set and only fires when a redelivery interval is configured,
   # so without one an id is deliberately not tracked rather than left in a set nothing empties.
   defp track_nacked(state, []), do: state
-  defp track_nacked(%{redelivery_interval: nil} = state, _nacked_ids), do: state
+
+  defp track_nacked(%__MODULE__{redelivery_interval: nil} = state, nacked_ids) do
+    Logger.debug("NACKed #{length(nacked_ids)} message(s), but no redelivery_interval configured")
+    state
+  end
 
   defp track_nacked(state, nacked_ids) do
     %{state | nacked_messages: MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))}
@@ -680,11 +682,15 @@ defmodule Pulsar.Consumer.Worker do
     #   from the broker. The DLQ will only trigger on subsequent redeliveries when the message
     #   comes back through handle_message with an updated redelivery_count.
 
-    :telemetry.execute([:pulsar, :consumer, :message, :nacked], %{count: length(message_ids)}, consumer_metadata(state))
+    if message_ids != [] do
+      :telemetry.execute(
+        [:pulsar, :consumer, :message, :nacked],
+        %{count: length(message_ids)},
+        consumer_metadata(state)
+      )
+    end
 
-    new_nacked_messages = track_nacked(state, message_ids).nacked_messages
-
-    {:reply, :ok, %{state | nacked_messages: new_nacked_messages}}
+    {:reply, :ok, track_nacked(state, message_ids)}
   end
 
   def handle_call(request, from, state) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -413,6 +413,13 @@ defmodule Pulsar.Consumer.Worker do
 
         :ok = Pulsar.Broker.send_command(state.broker_pid, redeliver_command)
         Logger.warning("Requested redelivery of #{length(nacked_list)} NACKed messages")
+
+        :telemetry.execute(
+          [:pulsar, :consumer, :redelivery, :requested],
+          %{count: length(nacked_list)},
+          consumer_metadata(state)
+        )
+
         %{state | nacked_messages: MapSet.new()}
       else
         state
@@ -491,8 +498,8 @@ defmodule Pulsar.Consumer.Worker do
     producer = DeadLetter.producer(state.dead_letter_root)
     origin = [client: state.client, topic: state.topic]
 
-    nacked_ids =
-      Enum.reduce(messages, [], fn %Pulsar.Message{} = message, nacked_acc ->
+    {diverted, nacked_ids, reason} =
+      Enum.reduce(messages, {0, [], nil}, fn %Pulsar.Message{} = message, {diverted, nacked_acc, reason} ->
         message_ids_list = List.wrap(message.message_id)
 
         case divert(producer, message, origin) do
@@ -505,25 +512,67 @@ defmodule Pulsar.Consumer.Worker do
             }
 
             :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
-            nacked_acc
+            {diverted + 1, nacked_acc, reason}
 
           {:error, dlq_reason} ->
             Logger.error("Failed to send message to dead letter topic: #{inspect(dlq_reason)}, leaving as nacked")
-            message_ids_list ++ nacked_acc
+            {diverted, message_ids_list ++ nacked_acc, reason || dlq_reason}
         end
       end)
+
+    metadata = dead_letter_metadata(state, producer, batch_redelivery_count(messages))
+
+    if diverted > 0 do
+      :telemetry.execute([:pulsar, :consumer, :dead_letter, :diverted], %{count: diverted}, metadata)
+    end
+
+    if nacked_ids != [] do
+      :telemetry.execute(
+        [:pulsar, :consumer, :dead_letter, :failed],
+        %{count: length(nacked_ids)},
+        Map.put(metadata, :reason, reason)
+      )
+    end
 
     track_nacked(state, nacked_ids)
   end
 
-  defp divert({:ok, producer}, message, origin), do: DeadLetter.divert(producer, message, origin)
+  defp divert({:ok, producer, _topic}, message, origin), do: DeadLetter.divert(producer, message, origin)
   defp divert({:error, _reason} = error, _message, _origin), do: error
+
+  defp dead_letter_metadata(state, producer, redelivery_count) do
+    dead_letter_topic =
+      case producer do
+        {:ok, _pid, topic} -> topic
+        {:error, _reason} -> nil
+      end
+
+    state
+    |> consumer_metadata()
+    |> Map.merge(%{dead_letter_topic: dead_letter_topic, redelivery_count: redelivery_count})
+  end
+
+  defp consumer_metadata(state) do
+    %{
+      topic: state.topic,
+      subscription_name: state.subscription_name,
+      consumer_id: state.consumer_id
+    }
+  end
 
   defp process_messages_normally(state, messages) when is_list(messages) do
     {final_callback_state, nacked_ids} =
       Enum.reduce(messages, {state.callback_state, []}, fn message, {callback_state, nacked_acc} ->
         process_single_message(state, message, callback_state, nacked_acc)
       end)
+
+    if nacked_ids != [] do
+      :telemetry.execute(
+        [:pulsar, :consumer, :message, :nacked],
+        %{count: length(nacked_ids)},
+        consumer_metadata(state)
+      )
+    end
 
     %{track_nacked(state, nacked_ids) | callback_state: final_callback_state}
   end
@@ -631,15 +680,9 @@ defmodule Pulsar.Consumer.Worker do
     #   from the broker. The DLQ will only trigger on subsequent redeliveries when the message
     #   comes back through handle_message with an updated redelivery_count.
 
-    new_nacked_messages =
-      if state.redelivery_interval do
-        Enum.reduce(message_ids, state.nacked_messages, fn message_id, acc ->
-          MapSet.put(acc, message_id)
-        end)
-      else
-        Logger.debug("NACKed #{length(message_ids)} message(s), but no redelivery_interval configured")
-        state.nacked_messages
-      end
+    :telemetry.execute([:pulsar, :consumer, :message, :nacked], %{count: length(message_ids)}, consumer_metadata(state))
+
+    new_nacked_messages = track_nacked(state, message_ids).nacked_messages
 
     {:reply, :ok, %{state | nacked_messages: new_nacked_messages}}
   end

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -55,6 +55,7 @@ defmodule Pulsar.Consumer.Worker do
     :redelivery_interval,
     :max_redelivery,
     :dead_letter_root,
+    :dead_letter_topic,
     {:chunked_message_contexts, %{}},
     :max_pending_chunked_messages,
     :expire_incomplete_chunked_message_after,
@@ -88,6 +89,7 @@ defmodule Pulsar.Consumer.Worker do
           redelivery_interval: non_neg_integer() | nil,
           max_redelivery: non_neg_integer() | nil,
           dead_letter_root: pid() | nil,
+          dead_letter_topic: String.t() | nil,
           chunked_message_contexts: %{optional(String.t()) => ChunkedMessageContext.t()},
           max_pending_chunked_messages: non_neg_integer(),
           expire_incomplete_chunked_message_after: non_neg_integer(),
@@ -390,13 +392,10 @@ defmodule Pulsar.Consumer.Worker do
     new_state = decrement_permits(new_state, permits_consumed)
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
-    redelivery_count = batch_redelivery_count(messages)
-
     new_state =
-      if divert?(new_state, redelivery_count) do
-        send_batch_to_dead_letter(new_state, messages, redelivery_count)
-      else
-        process_messages_normally(new_state, messages)
+      case divert(new_state, messages) do
+        {:divert, redelivery_count} -> send_batch_to_dead_letter(new_state, messages, redelivery_count)
+        :deliver -> process_messages_normally(new_state, messages)
       end
 
     {:noreply, check_and_refill_permits(new_state)}
@@ -475,9 +474,15 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp divert?(%__MODULE__{max_redelivery: nil}, _redelivery_count), do: false
-  defp divert?(%__MODULE__{dead_letter_root: nil}, _redelivery_count), do: false
-  defp divert?(state, redelivery_count), do: redelivery_count >= state.max_redelivery
+  # Answered before counting, so a consumer with no dead letter policy never walks a delivery.
+  defp divert(%__MODULE__{max_redelivery: nil}, _messages), do: :deliver
+  defp divert(%__MODULE__{dead_letter_root: nil}, _messages), do: :deliver
+
+  defp divert(state, messages) do
+    redelivery_count = batch_redelivery_count(messages)
+
+    if redelivery_count >= state.max_redelivery, do: {:divert, redelivery_count}, else: :deliver
+  end
 
   # One delivery diverts as a whole: a batch arrives as a single broker command and a chunked
   # message answers the maximum across its chunks, so every message built from it carries the
@@ -503,7 +508,7 @@ defmodule Pulsar.Consumer.Worker do
       Enum.reduce(messages, {0, [], nil}, fn %Pulsar.Message{} = message, {diverted, nacked_acc, reason} ->
         message_ids_list = List.wrap(message.message_id)
 
-        case divert(producer, message, origin) do
+        case publish_to_dead_letter(producer, message, origin) do
           :ok ->
             ack_command = %Binary.CommandAck{
               consumer_id: state.consumer_id,
@@ -521,7 +526,7 @@ defmodule Pulsar.Consumer.Worker do
         end
       end)
 
-    metadata = dead_letter_metadata(state, dead_letter_topic(producer), redelivery_count)
+    metadata = dead_letter_metadata(state, redelivery_count)
 
     if diverted > 0 do
       :telemetry.execute([:pulsar, :consumer, :dead_letter, :diverted], %{count: diverted}, metadata)
@@ -538,16 +543,13 @@ defmodule Pulsar.Consumer.Worker do
     track_nacked(state, nacked_ids)
   end
 
-  defp divert({:ok, producer, _topic}, message, origin), do: DeadLetter.divert(producer, message, origin)
-  defp divert({:error, _reason} = error, _message, _origin), do: error
+  defp publish_to_dead_letter({:ok, producer}, message, origin), do: DeadLetter.divert(producer, message, origin)
+  defp publish_to_dead_letter({:error, _reason} = error, _message, _origin), do: error
 
-  defp dead_letter_topic({:ok, _producer, topic}), do: topic
-  defp dead_letter_topic({:error, _reason}), do: nil
-
-  defp dead_letter_metadata(state, dead_letter_topic, redelivery_count) do
+  defp dead_letter_metadata(state, redelivery_count) do
     state
     |> consumer_metadata()
-    |> Map.merge(%{dead_letter_topic: dead_letter_topic, redelivery_count: redelivery_count})
+    |> Map.merge(%{dead_letter_topic: state.dead_letter_topic, redelivery_count: redelivery_count})
   end
 
   defp consumer_metadata(state) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -478,7 +478,7 @@ defmodule Pulsar.Consumer.Worker do
   defp divert(%__MODULE__{max_redelivery: nil}, _messages), do: :deliver
   defp divert(%__MODULE__{dead_letter_root: nil}, _messages), do: :deliver
 
-  defp divert(state, messages) do
+  defp divert(%__MODULE__{} = state, messages) do
     redelivery_count = batch_redelivery_count(messages)
 
     if redelivery_count >= state.max_redelivery, do: {:divert, redelivery_count}, else: :deliver
@@ -502,13 +502,12 @@ defmodule Pulsar.Consumer.Worker do
     # Resolved once for the delivery: this is a call into the topology root, which is also the
     # supervisor discovery adds partitions to.
     producer = DeadLetter.producer(state.dead_letter_root)
-    origin = [client: state.client, topic: state.topic]
 
     {diverted, nacked_ids, reason} =
       Enum.reduce(messages, {0, [], nil}, fn %Pulsar.Message{} = message, {diverted, nacked_acc, reason} ->
         message_ids_list = List.wrap(message.message_id)
 
-        case publish_to_dead_letter(producer, message, origin) do
+        case publish_to_dead_letter(producer, message, state.topic) do
           :ok ->
             ack_command = %Binary.CommandAck{
               consumer_id: state.consumer_id,
@@ -543,8 +542,11 @@ defmodule Pulsar.Consumer.Worker do
     track_nacked(state, nacked_ids)
   end
 
-  defp publish_to_dead_letter({:ok, producer}, message, origin), do: DeadLetter.divert(producer, message, origin)
-  defp publish_to_dead_letter({:error, _reason} = error, _message, _origin), do: error
+  defp publish_to_dead_letter({:ok, producer}, message, origin_topic) do
+    DeadLetter.divert(producer, message, origin_topic)
+  end
+
+  defp publish_to_dead_letter({:error, _reason} = error, _message, _origin_topic), do: error
 
   defp dead_letter_metadata(state, redelivery_count) do
     state
@@ -586,7 +588,7 @@ defmodule Pulsar.Consumer.Worker do
     state
   end
 
-  defp track_nacked(state, nacked_ids) do
+  defp track_nacked(%__MODULE__{} = state, nacked_ids) do
     %{state | nacked_messages: MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))}
   end
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -471,11 +471,10 @@ defmodule Pulsar.Consumer.Worker do
   # One delivery diverts as a whole: a batch arrives as a single broker command and a chunked
   # message answers the maximum across its chunks, so every message built from it carries the
   # same redelivery count.
-  defp divert?(state, messages) do
-    not is_nil(state.max_redelivery) and state.max_redelivery >= 1 and
-      not is_nil(state.dead_letter_root) and
-      batch_redelivery_count(messages) >= state.max_redelivery
-  end
+  defp divert?(%__MODULE__{max_redelivery: nil}, _messages), do: false
+  defp divert?(%__MODULE__{dead_letter_root: nil}, _messages), do: false
+
+  defp divert?(state, messages), do: batch_redelivery_count(messages) >= state.max_redelivery
 
   defp batch_redelivery_count(messages) do
     messages
@@ -489,11 +488,16 @@ defmodule Pulsar.Consumer.Worker do
         "#{state.max_redelivery}, diverting to the dead letter topic"
     )
 
+    # Resolved once for the delivery: this is a call into the topology root, which is also the
+    # supervisor discovery adds partitions to.
+    producer = DeadLetter.producer(state.dead_letter_root)
+    origin = [client: state.client, topic: state.topic]
+
     nacked_ids =
       Enum.reduce(messages, [], fn %Pulsar.Message{} = message, nacked_acc ->
         message_ids_list = List.wrap(message.message_id)
 
-        case DeadLetter.divert(state, message) do
+        case divert(producer, message, origin) do
           :ok ->
             ack_command = %Binary.CommandAck{
               consumer_id: state.consumer_id,
@@ -513,6 +517,9 @@ defmodule Pulsar.Consumer.Worker do
 
     track_nacked(state, nacked_ids)
   end
+
+  defp divert({:ok, producer}, message, origin), do: DeadLetter.divert(producer, message, origin)
+  defp divert({:error, _reason} = error, _message, _origin), do: error
 
   defp process_messages_normally(state, messages) when is_list(messages) do
     {final_callback_state, nacked_ids} =
@@ -804,14 +811,9 @@ defmodule Pulsar.Consumer.Worker do
     :ok
   end
 
+  # Pulsar.Consumer.Options requires a positive integer here, so a policy always carries one.
   defp max_redelivery(nil), do: nil
-
-  defp max_redelivery(policy) when is_list(policy) do
-    case Keyword.get(policy, :max_redelivery) do
-      n when is_integer(n) and n >= 1 -> n
-      _invalid -> nil
-    end
-  end
+  defp max_redelivery(policy) when is_list(policy), do: Keyword.fetch!(policy, :max_redelivery)
 
   defp maybe_uncompress(%Binary.MessageMetadata{compression: :NONE}, payload) do
     payload

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -8,8 +8,7 @@ defmodule Pulsar.Consumer.Worker do
 
   alias Pulsar.Backoff
   alias Pulsar.Consumer.ChunkedMessageContext
-  alias Pulsar.Producer.Options, as: ProducerOptions
-  alias Pulsar.Producer.Worker, as: ProducerWorker
+  alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Protocol
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
   alias Pulsar.Schema
@@ -55,8 +54,7 @@ defmodule Pulsar.Consumer.Worker do
     {:nacked_messages, MapSet.new()},
     :redelivery_interval,
     :max_redelivery,
-    :dead_letter_topic,
-    :dead_letter_producer_pid,
+    :dead_letter_root,
     {:chunked_message_contexts, %{}},
     :max_pending_chunked_messages,
     :expire_incomplete_chunked_message_after,
@@ -89,8 +87,7 @@ defmodule Pulsar.Consumer.Worker do
           nacked_messages: MapSet.t(),
           redelivery_interval: non_neg_integer() | nil,
           max_redelivery: non_neg_integer() | nil,
-          dead_letter_topic: String.t() | nil,
-          dead_letter_producer_pid: pid() | nil,
+          dead_letter_root: pid() | nil,
           chunked_message_contexts: %{optional(String.t()) => ChunkedMessageContext.t()},
           max_pending_chunked_messages: non_neg_integer(),
           expire_incomplete_chunked_message_after: non_neg_integer(),
@@ -170,17 +167,15 @@ defmodule Pulsar.Consumer.Worker do
 
   @impl true
   def init(opts) do
-    {max_redelivery, dead_letter_topic} = parse_dead_letter_policy(Keyword.get(opts, :dead_letter_policy))
-
     # Option names and struct field names are the same, so struct/2 carries them across
-    # and ignores the group-level options that are not part of a consumer's state.
+    # and ignores the group-level options that are not part of a consumer's state. That
+    # includes :dead_letter_root, resolved once for the whole consumer by Pulsar.Topology.
     state = %{
       struct(__MODULE__, opts)
       | consumer_id: System.unique_integer([:positive, :monotonic]),
         consumer_name: Keyword.get(opts, :name),
         schema: build_schema(Keyword.get(opts, :schema)),
-        max_redelivery: max_redelivery,
-        dead_letter_topic: dead_letter_topic
+        max_redelivery: max_redelivery(Keyword.get(opts, :dead_letter_policy))
     }
 
     Logger.debug("Starting consumer for topic #{state.topic}")
@@ -293,26 +288,10 @@ defmodule Pulsar.Consumer.Worker do
            state
            | broker_monitor: broker_monitor,
              flow_outstanding_permits: state.flow_initial
-         }, {:continue, {:init_dead_letter_producer, init_args}}}
+         }, {:continue, {:init_callback, init_args}}}
 
       {:error, reason} ->
         {:stop, reason, state}
-    end
-  end
-
-  def handle_continue({:init_dead_letter_producer, init_args}, state) do
-    if should_init_dead_letter_producer?(state) do
-      case start_dead_letter_producer(state) do
-        {:ok, producer_pid} ->
-          Logger.info("Started dead letter producer for consumer on topic #{state.topic}")
-          {:noreply, %{state | dead_letter_producer_pid: producer_pid}, {:continue, {:init_callback, init_args}}}
-
-        {:error, reason} ->
-          Logger.error("Failed to start dead letter producer: #{inspect(reason)}")
-          {:stop, reason, state}
-      end
-    else
-      {:noreply, state, {:continue, {:init_callback, init_args}}}
     end
   end
 
@@ -489,7 +468,7 @@ defmodule Pulsar.Consumer.Worker do
       |> Enum.max(fn -> 0 end)
 
     if is_nil(state.max_redelivery) or state.max_redelivery < 1 or
-         max_redelivery_count < state.max_redelivery or is_nil(state.dead_letter_producer_pid) do
+         max_redelivery_count < state.max_redelivery or is_nil(state.dead_letter_root) do
       state
     else
       do_send_batch_to_dead_letter(state, messages, max_redelivery_count)
@@ -505,7 +484,7 @@ defmodule Pulsar.Consumer.Worker do
       Enum.reduce(messages, [], fn %Pulsar.Message{} = message, nacked_acc ->
         message_ids_list = List.wrap(message.message_id)
 
-        case send_to_dead_letter(state, message.payload, List.first(message_ids_list)) do
+        case DeadLetter.divert(state, message) do
           :ok ->
             ack_command = %Binary.CommandAck{
               consumer_id: state.consumer_id,
@@ -827,47 +806,12 @@ defmodule Pulsar.Consumer.Worker do
     :ok
   end
 
-  defp parse_dead_letter_policy(nil), do: {nil, nil}
+  defp max_redelivery(nil), do: nil
 
-  defp parse_dead_letter_policy(policy) when is_list(policy) do
-    max_redelivery = Keyword.get(policy, :max_redelivery)
-    topic = Keyword.get(policy, :topic)
-
-    validated_max_redelivery =
-      case max_redelivery do
-        n when is_integer(n) and n >= 1 -> n
-        _ -> nil
-      end
-
-    {validated_max_redelivery, topic}
-  end
-
-  defp should_init_dead_letter_producer?(state) do
-    state.max_redelivery != nil and state.max_redelivery >= 1
-  end
-
-  defp start_dead_letter_producer(state) do
-    dead_letter_topic =
-      state.dead_letter_topic ||
-        "#{state.topic}-#{state.subscription_name}-DLQ"
-
-    # Through the schema, so the dead letter producer gets the same defaults as any other.
-    [topic: dead_letter_topic, client: state.client]
-    |> ProducerOptions.validate!()
-    |> ProducerWorker.start_link()
-  end
-
-  defp send_to_dead_letter(state, payload, _message_id) do
-    if state.dead_letter_producer_pid == nil do
-      {:error, :no_dead_letter_producer}
-    else
-      case ProducerWorker.send_message(state.dead_letter_producer_pid, payload) do
-        {:ok, _dlq_message_id} ->
-          :ok
-
-        {:error, _reason} = error ->
-          error
-      end
+  defp max_redelivery(policy) when is_list(policy) do
+    case Keyword.get(policy, :max_redelivery) do
+      n when is_integer(n) and n >= 1 -> n
+      _invalid -> nil
     end
   end
 

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -39,6 +39,7 @@ defmodule Pulsar.Message do
   | `ordering_key/1` | The ordering key, or `nil` |
   | `properties/1` | User properties as a map |
   | `redelivery_count/1` | How many times the broker has redelivered it |
+  | `message_id_string/1` | Its id as Pulsar prints it, for logging and correlation |
 
   This matters because the same datum lives in different places depending on delivery: a
   batched message carries its key and properties per message, a non-batched one carries them
@@ -200,6 +201,44 @@ defmodule Pulsar.Message do
   end
 
   def redelivery_count(%__MODULE__{raw: %{command: command}}), do: command.redelivery_count
+
+  @doc """
+  Returns the message's id as Pulsar prints it, or `nil` when it has none.
+
+  The shape is `ledgerId:entryId:partition`, with a batch entry's index appended, which is what
+  the Java client's `MessageId.toString()` produces. It is what to log or carry when a message
+  has to be correlated with one seen elsewhere; `message_id` itself stays opaque.
+
+  A chunked message answers for the chunk it began at.
+
+  ## Examples
+
+      iex> id = %{ledgerId: 7, entryId: 42, partition: -1, batch_index: -1}
+      iex> Pulsar.Message.message_id_string(%Pulsar.Message{message_id: id})
+      "7:42:-1"
+
+  A batch entry appends its index, so two entries of one batch stay distinguishable:
+
+      iex> id = %{ledgerId: 7, entryId: 42, partition: 3, batch_index: 1}
+      iex> Pulsar.Message.message_id_string(%Pulsar.Message{message_id: id})
+      "7:42:3:1"
+  """
+  @spec message_id_string(t()) :: String.t() | nil
+  def message_id_string(%__MODULE__{message_id: message_id}), do: format_message_id(message_id)
+
+  # A chunked message carries one id per chunk; the first is where it began.
+  defp format_message_id([message_id | _rest]), do: format_message_id(message_id)
+  defp format_message_id([]), do: nil
+  defp format_message_id(nil), do: nil
+
+  defp format_message_id(%{ledgerId: ledger_id, entryId: entry_id, partition: partition} = message_id) do
+    base = "#{ledger_id}:#{entry_id}:#{partition}"
+
+    case Map.get(message_id, :batch_index) do
+      index when is_integer(index) and index >= 0 -> "#{base}:#{index}"
+      _not_batched -> base
+    end
+  end
 
   # A batch entry carries its own key, properties and times; a message delivered on its own
   # carries them in the message metadata. Chunks of one message all repeat the same values.

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -45,11 +45,8 @@ defmodule Pulsar.Producer do
   end
 
   @doc false
-  # A producer owned by another resource is reached through its owner's tree rather than by name,
-  # so it registers nowhere: nothing outside that owner should resolve or stop it, and it must not
-  # depend on a registry belonging to a branch that restarts separately from its owner. It is a
-  # producer in every other respect, which is what starting it from here rather than assembling
-  # the topology at the call site keeps true.
+  # For a producer owned by another resource: nothing outside that owner should resolve or stop it,
+  # and it must not depend on a registry belonging to a branch that restarts separately from it.
   @spec start_link_unregistered(keyword()) :: Supervisor.on_start()
   def start_link_unregistered(opts), do: opts |> Options.validate!() |> start_topology(nil)
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -39,12 +39,25 @@ defmodule Pulsar.Producer do
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     opts = Options.validate!(opts)
-    topic = Keyword.fetch!(opts, :topic)
     client = Keyword.fetch!(opts, :client)
 
+    start_topology(opts, Client.registry(:producers, client))
+  end
+
+  @doc false
+  # A producer owned by another resource is reached through its owner's tree rather than by name,
+  # so it registers nowhere: nothing outside that owner should resolve or stop it, and it must not
+  # depend on a registry belonging to a branch that restarts separately from its owner. It is a
+  # producer in every other respect, which is what starting it from here rather than assembling
+  # the topology at the call site keeps true.
+  @spec start_link_unregistered(keyword()) :: Supervisor.on_start()
+  def start_link_unregistered(opts), do: opts |> Options.validate!() |> start_topology(nil)
+
+  defp start_topology(opts, registry) do
+    topic = Keyword.fetch!(opts, :topic)
     opts = Keyword.put_new_lazy(opts, :name, fn -> default_name(topic) end)
 
-    Topology.start_link(Worker, Client.registry(:producers, client), :producer_count, opts)
+    Topology.start_link(Worker, registry, :producer_count, opts)
   end
 
   @doc """

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -100,4 +100,7 @@ defmodule Pulsar.Producer.Options do
   """
   @spec validate!(keyword()) :: keyword()
   def validate!(opts), do: NimbleOptions.validate!(opts, @schema)
+
+  @spec validate(keyword()) :: {:ok, keyword()} | {:error, NimbleOptions.ValidationError.t()}
+  def validate(opts), do: NimbleOptions.validate(opts, @schema)
 end

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -6,7 +6,6 @@ defmodule Pulsar.Topology do
   @behaviour Supervisor
 
   alias Pulsar.Backoff
-  alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Consumer.Worker, as: ConsumerWorker
   alias Pulsar.Producer.Worker, as: ProducerWorker
   alias Pulsar.Topic
@@ -379,7 +378,7 @@ defmodule Pulsar.Topology do
 
   @impl true
   def init({config, controller_opts}) do
-    config = annotate(config, self())
+    {config, companions} = attach_companions(config, self())
     %{worker: worker, opts: opts} = config
     topic = Keyword.fetch!(opts, :topic)
 
@@ -392,22 +391,27 @@ defmodule Pulsar.Topology do
 
     # Companions start before discovery so a worker never observes the tree without them. They
     # resolve their own brokers asynchronously, so none of them delays this root coming up.
-    children = companion_specs(config) ++ [discovery]
+    children = companions ++ [discovery]
 
     Supervisor.init(children, [strategy: :one_for_one] ++ restart_intensity())
   end
 
-  # A consumer's dead letter producer is scoped to the consumer that diverts into it, so it is
-  # owned here rather than by the client's producer branch. Workers are told this root so they
-  # can resolve it as a child, which survives it restarting under them.
-  defp annotate(%{worker: ConsumerWorker, opts: opts} = config, root) do
-    %{config | opts: DeadLetter.annotate(opts, root)}
+  # A resource that owns another declares it through `:companions`, a function of this root's
+  # options and the root itself. It answers the options its workers inherit, so it can tell them
+  # where to find what it attached, together with the children to run alongside them.
+  #
+  # The function is taken out of the options rather than read from them, since it configures
+  # this root and is not part of what a worker is started with.
+  defp attach_companions(config, root) do
+    case Keyword.pop(config.opts, :companions) do
+      {nil, opts} ->
+        {%{config | opts: opts}, []}
+
+      {attach, opts} ->
+        {opts, specs} = attach.(opts, root)
+        {%{config | opts: opts}, specs}
+    end
   end
-
-  defp annotate(config, _root), do: config
-
-  defp companion_specs(%{worker: ConsumerWorker, opts: opts}), do: DeadLetter.child_specs(opts)
-  defp companion_specs(_config), do: []
 
   defp resource_kind_for_config(%{count_key: :consumer_count}), do: :consumers
   defp resource_kind_for_config(%{count_key: :producer_count}), do: :producers

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -58,9 +58,6 @@ defmodule Pulsar.Topology do
     Supervisor.start_link(__MODULE__, {config, controller_opts}, start_options(registry, name))
   end
 
-  # A resource owned by another resource is reached through its owner's tree, so it registers
-  # nowhere: nothing outside that owner should be able to resolve it, and it must not depend on
-  # a registry that belongs to a branch restarting separately from the one that owns it.
   defp start_options(nil, _name), do: []
   defp start_options(registry, name), do: [name: {:via, Registry, {registry, name}}]
 
@@ -396,12 +393,8 @@ defmodule Pulsar.Topology do
     Supervisor.init(children, [strategy: :one_for_one] ++ restart_intensity())
   end
 
-  # A resource that owns another declares it through `:companions`, a function of this root's
-  # options and the root itself. It answers the options its workers inherit, so it can tell them
-  # where to find what it attached, together with the children to run alongside them.
-  #
-  # The function is taken out of the options rather than read from them, since it configures
-  # this root and is not part of what a worker is started with.
+  # Popped rather than read: `:companions` configures this root and is not part of what a worker
+  # is started with.
   defp attach_companions(config, root) do
     case Keyword.pop(config.opts, :companions) do
       {nil, opts} ->

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -43,7 +43,7 @@ defmodule Pulsar.Topology do
     }
   end
 
-  @spec start_link(module(), atom(), atom(), keyword()) :: Supervisor.on_start()
+  @spec start_link(module(), atom() | nil, atom(), keyword()) :: Supervisor.on_start()
   def start_link(worker, registry, count_key, opts) do
     start_link(worker, registry, count_key, opts, [])
   end
@@ -51,13 +51,19 @@ defmodule Pulsar.Topology do
   # The fifth argument is an internal seam for exercising asynchronous discovery without a
   # broker. Consumer and Producer deliberately expose only start_link/1.
   @doc false
-  @spec start_link(module(), atom(), atom(), keyword(), keyword()) :: Supervisor.on_start()
+  @spec start_link(module(), atom() | nil, atom(), keyword(), keyword()) :: Supervisor.on_start()
   def start_link(worker, registry, count_key, opts, controller_opts) do
     name = Keyword.fetch!(opts, :name)
     config = %{worker: worker, count_key: count_key, opts: opts}
 
-    Supervisor.start_link(__MODULE__, {config, controller_opts}, name: {:via, Registry, {registry, name}})
+    Supervisor.start_link(__MODULE__, {config, controller_opts}, start_options(registry, name))
   end
+
+  # A resource owned by another resource is reached through its owner's tree, so it registers
+  # nowhere: nothing outside that owner should be able to resolve it, and it must not depend on
+  # a registry that belongs to a branch restarting separately from the one that owns it.
+  defp start_options(nil, _name), do: []
+  defp start_options(registry, name), do: [name: {:via, Registry, {registry, name}}]
 
   @typedoc false
   @type status :: :initializing | {:ready, :non_partitioned | {:partitioned, pos_integer()}}

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -48,7 +48,7 @@ defmodule Pulsar.Topology do
   end
 
   # The fifth argument is an internal seam for exercising asynchronous discovery without a
-  # broker. Consumer and Producer deliberately expose only start_link/1.
+  # broker. Consumer and Producer deliberately keep it out of the API they document.
   @doc false
   @spec start_link(module(), atom() | nil, atom(), keyword(), keyword()) :: Supervisor.on_start()
   def start_link(worker, registry, count_key, opts, controller_opts) do

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -6,6 +6,7 @@ defmodule Pulsar.Topology do
   @behaviour Supervisor
 
   alias Pulsar.Backoff
+  alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Consumer.Worker, as: ConsumerWorker
   alias Pulsar.Producer.Worker, as: ProducerWorker
   alias Pulsar.Topic
@@ -244,8 +245,10 @@ defmodule Pulsar.Topology do
       {_id, pid, :worker, [module]} when module in @worker_modules ->
         if is_pid(pid), do: [pid], else: []
 
+      # A nested topology root owns its own workers, which are not this resource's. A consumer's
+      # dead letter producer is one, and its producer workers must not read as consumer workers.
       {_id, pid, :supervisor, _modules} when is_pid(pid) ->
-        workers(pid)
+        if kind(pid) == :topology, do: [], else: workers(pid)
 
       _child ->
         []
@@ -370,6 +373,7 @@ defmodule Pulsar.Topology do
 
   @impl true
   def init({config, controller_opts}) do
+    config = annotate(config, self())
     %{worker: worker, opts: opts} = config
     topic = Keyword.fetch!(opts, :topic)
 
@@ -380,8 +384,24 @@ defmodule Pulsar.Topology do
       |> Discovery.child_spec()
       |> Map.put(:id, {Discovery, resource_kind_for_config(config), topic})
 
-    Supervisor.init([discovery], [strategy: :one_for_one] ++ restart_intensity())
+    # Companions start before discovery so a worker never observes the tree without them. They
+    # resolve their own brokers asynchronously, so none of them delays this root coming up.
+    children = companion_specs(config) ++ [discovery]
+
+    Supervisor.init(children, [strategy: :one_for_one] ++ restart_intensity())
   end
+
+  # A consumer's dead letter producer is scoped to the consumer that diverts into it, so it is
+  # owned here rather than by the client's producer branch. Workers are told this root so they
+  # can resolve it as a child, which survives it restarting under them.
+  defp annotate(%{worker: ConsumerWorker, opts: opts} = config, root) do
+    %{config | opts: DeadLetter.annotate(opts, root)}
+  end
+
+  defp annotate(config, _root), do: config
+
+  defp companion_specs(%{worker: ConsumerWorker, opts: opts}), do: DeadLetter.child_specs(opts)
+  defp companion_specs(_config), do: []
 
   defp resource_kind_for_config(%{count_key: :consumer_count}), do: :consumers
   defp resource_kind_for_config(%{count_key: :producer_count}), do: :producers

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule Pulsar.MixProject do
           "README.md",
           "docs/architecture.md",
           "docs/chunking.md",
+          "docs/dead_letter_policies.md",
           "docs/schemas.md",
           "docs/reader.md"
         ],

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -1,11 +1,15 @@
 defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
   use ExUnit.Case, async: true
 
+  import TelemetryTest
+
   alias Pulsar.Protocol.Binary.Pulsar.Proto
   alias Pulsar.Test.Support.DummyConsumer
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
   alias Pulsar.Topology
+
+  setup [:telemetry_listen]
 
   @moduletag :integration
   @client :dead_letter_policy_test_client
@@ -213,5 +217,98 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
 
     dlq_messages = DummyConsumer.get_messages(dlq_consumer)
     assert length(dlq_messages) == length(@messages)
+  end
+
+  @tag telemetry_listen: [
+         [:pulsar, :consumer, :message, :nacked],
+         [:pulsar, :consumer, :redelivery, :requested],
+         [:pulsar, :consumer, :dead_letter, :diverted]
+       ]
+  test "reports rejecting, retrying and parking a message" do
+    topic = "#{@topic}-telemetry"
+    subscription = "telemetry"
+    dead_letter_topic = "#{topic}-#{subscription}-DLQ"
+
+    {:ok, group} =
+      Pulsar.Consumer.start(topic, subscription, DummyConsumer,
+        init_args: [fail_all: true],
+        client: @client,
+        initial_position: :earliest,
+        redelivery_interval: 100,
+        dead_letter_policy: [max_redelivery: 1]
+      )
+
+    [_consumer] = Utils.wait_for(fn -> Topology.workers(group) end, until: &match?([_], &1))
+
+    {:ok, producer} = Pulsar.Producer.start(topic, client: @client)
+    :ok = Pulsar.Producer.await_ready(producer, client: @client)
+    {:ok, _id} = Pulsar.Producer.send(producer, "doomed")
+
+    assert_receive {:telemetry_event,
+                    %{
+                      event: [:pulsar, :consumer, :message, :nacked],
+                      measurements: %{count: 1},
+                      metadata: %{topic: ^topic, subscription_name: ^subscription}
+                    }},
+                   5_000
+
+    assert_receive {:telemetry_event,
+                    %{
+                      event: [:pulsar, :consumer, :redelivery, :requested],
+                      measurements: %{count: 1}
+                    }},
+                   5_000
+
+    assert_receive {:telemetry_event,
+                    %{
+                      event: [:pulsar, :consumer, :dead_letter, :diverted],
+                      measurements: %{count: 1},
+                      metadata: %{
+                        topic: ^topic,
+                        subscription_name: ^subscription,
+                        dead_letter_topic: ^dead_letter_topic,
+                        redelivery_count: 1
+                      }
+                    }},
+                   5_000
+  end
+
+  @tag telemetry_listen: [[:pulsar, :consumer, :dead_letter, :failed]]
+  test "reports a dead letter topic it cannot publish to" do
+    topic = "#{@topic}-telemetry-failed"
+    subscription = "telemetry-failed"
+
+    {:ok, group} =
+      Pulsar.Consumer.start(topic, subscription, DummyConsumer,
+        init_args: [fail_all: true],
+        client: @client,
+        initial_position: :earliest,
+        redelivery_interval: 100,
+        dead_letter_policy: [max_redelivery: 1]
+      )
+
+    [consumer] = Utils.wait_for(fn -> Topology.workers(group) end, until: &match?([_], &1))
+
+    # A root with no dead letter child, so the producer cannot be resolved and diverting fails
+    # the way it does against a dead letter topic that is unavailable. Pointing the worker at
+    # nil instead would stop it diverting at all, which is a different path.
+    {:ok, empty_root} = Supervisor.start_link([], strategy: :one_for_one)
+    :sys.replace_state(consumer, &%{&1 | dead_letter_root: empty_root})
+
+    command = %Proto.CommandMessage{
+      consumer_id: 1,
+      message_id: %Proto.MessageIdData{ledgerId: 1, entryId: 1},
+      redelivery_count: 5
+    }
+
+    send(consumer, {:broker_message, {:invalid, command, "corrupt", :checksum_mismatch}})
+
+    assert_receive {:telemetry_event,
+                    %{
+                      event: [:pulsar, :consumer, :dead_letter, :failed],
+                      measurements: %{count: 1},
+                      metadata: %{topic: ^topic, reason: :no_dead_letter_producer}
+                    }},
+                   5_000
   end
 end

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -312,6 +312,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
   test "reports a dead letter topic it cannot publish to" do
     topic = "#{@topic}-telemetry-failed"
     subscription = "telemetry-failed"
+    dead_letter_topic = "#{topic}-#{subscription}-DLQ"
 
     {:ok, group} =
       Pulsar.Consumer.start(topic, subscription, DummyConsumer,
@@ -342,7 +343,13 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
                     %{
                       event: [:pulsar, :consumer, :dead_letter, :failed],
                       measurements: %{count: 1},
-                      metadata: %{topic: ^topic, reason: :no_dead_letter_producer}
+                      # Named even though the producer could not be resolved, which is when
+                      # an alert on this event most needs to say which topic is affected.
+                      metadata: %{
+                        topic: ^topic,
+                        dead_letter_topic: ^dead_letter_topic,
+                        reason: :no_dead_letter_producer
+                      }
                     }},
                    5_000
   end

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -195,7 +195,7 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
         ]
       )
 
-    [_failing_consumer] =
+    [failing_consumer] =
       Utils.wait_for(fn -> Topology.workers(consumer_group) end, until: &match?([_], &1))
 
     {:ok, dlq_consumer_group} =
@@ -217,6 +217,41 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
 
     dlq_messages = DummyConsumer.get_messages(dlq_consumer)
     assert length(dlq_messages) == length(@messages)
+
+    assert DummyConsumer.count_messages(failing_consumer) == length(@messages) * 2
+  end
+
+  test "producer options configure the running dead letter producer" do
+    topic = "#{@topic}-producer-options"
+    subscription = "producer-options"
+
+    {:ok, consumer_group} =
+      Pulsar.Consumer.start(topic, subscription, DummyConsumer,
+        client: @client,
+        redelivery_interval: 100,
+        dead_letter_policy: [max_redelivery: 1, producer: [compression: :lz4, batch_enabled: true]]
+      )
+
+    dead_letter_root =
+      Utils.wait_for(
+        fn ->
+          consumer_group
+          |> Supervisor.which_children()
+          |> Enum.find_value(fn
+            {{:dead_letter, _topic}, pid, :supervisor, _modules} when is_pid(pid) -> pid
+            _child -> nil
+          end)
+        end,
+        until: &is_pid/1
+      )
+
+    [producer] = Utils.wait_for(fn -> Topology.workers(dead_letter_root) end, until: &match?([_], &1))
+
+    producer_state = :sys.get_state(producer)
+
+    # Both differ from the schema defaults, :none and false, so a default cannot satisfy them.
+    assert producer_state.compression == :lz4
+    assert producer_state.batch_enabled == true
   end
 
   @tag telemetry_listen: [

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -125,7 +125,9 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
 
     failing_consumer_count = DummyConsumer.count_messages(failing_consumer)
 
-    assert failing_consumer_count == length(@messages) * (max_redelivery + 1)
+    # The delivery that reaches the threshold is diverted rather than delivered, so the callback
+    # sees a message on every attempt below it and never on the one that dead letters it.
+    assert failing_consumer_count == length(@messages) * max_redelivery
 
     Utils.wait_for(fn ->
       DummyConsumer.count_messages(dlq_consumer) == length(@messages)

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -4,6 +4,8 @@ defmodule Pulsar.Consumer.DeadLetterTest do
   alias Pulsar.Client
   alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Consumer.Worker, as: ConsumerWorker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Proto
+  alias Pulsar.Test.Support.Utils
   alias Pulsar.Topology
 
   @topic "persistent://public/default/orders"
@@ -43,7 +45,7 @@ defmodule Pulsar.Consumer.DeadLetterTest do
 
     test "defaults the topic to the base topic and subscription" do
       assert {_opts, [%{id: {:dead_letter, @default_dlq}} = spec]} = attach()
-      assert {Topology, :start_link, [_worker, _registry, _count_key, producer_opts]} = spec.start
+      assert {Pulsar.Producer, :start_link_unregistered, [producer_opts]} = spec.start
       assert Keyword.fetch!(producer_opts, :topic) == @default_dlq
     end
 
@@ -61,13 +63,47 @@ defmodule Pulsar.Consumer.DeadLetterTest do
 
       names =
         for name <- [@consumer_name, "#{@consumer_name}-other"] do
-          {_opts, [%{start: {_module, _fun, [_worker, _registry, _count_key, producer_opts]}}]} =
+          {_opts, [%{start: {_module, _fun, [producer_opts]}}]} =
             attach(name: name, dead_letter_policy: explicit)
 
           Keyword.fetch!(producer_opts, :name)
         end
 
       assert names == Enum.uniq(names)
+    end
+  end
+
+  describe "origin_properties/2" do
+    defp message(message_id, properties \\ []) do
+      %Pulsar.Message{
+        payload: "payload",
+        message_id: message_id,
+        raw: %{metadata: %{properties: Enum.map(properties, fn {k, v} -> %Proto.KeyValue{key: k, value: v} end)}}
+      }
+    end
+
+    defp message_id(overrides \\ []) do
+      struct(%Proto.MessageIdData{ledgerId: 7, entryId: 42, partition: -1, batch_index: -1}, overrides)
+    end
+
+    test "names the topic the message was consumed from" do
+      properties = DeadLetter.origin_properties("orders-partition-2", message(message_id()))
+
+      assert properties["REAL_TOPIC"] == "orders-partition-2"
+    end
+
+    # Pulsar.Message owns the format; this only pins that the property carries it.
+    test "names the message it came from" do
+      properties = DeadLetter.origin_properties("orders", message(message_id(partition: 3)))
+
+      assert properties["ORIGIN_MESSAGE_ID"] == "7:42:3"
+    end
+
+    test "adds to the origin's properties rather than replacing them" do
+      properties = DeadLetter.origin_properties("orders", message(message_id(), [{"tenant", "acme"}]))
+
+      assert properties["tenant"] == "acme"
+      assert Map.has_key?(properties, "REAL_TOPIC")
     end
   end
 
@@ -80,27 +116,43 @@ defmodule Pulsar.Consumer.DeadLetterTest do
     end
 
     test "runs the dead letter producer as a child of the consumer it belongs to" do
-      root = start_consumer_topology()
-
-      assert {_id, dlq, :supervisor, _modules} =
-               root
-               |> Supervisor.which_children()
-               |> List.keyfind({:dead_letter, @default_dlq}, 0)
+      dlq = dead_letter_producer(root())
 
       assert is_pid(dlq)
       assert Topology.kind(dlq) == :topology
       assert Topology.resource?(dlq, :producers)
     end
 
+    # The point of owning it: nothing else restarts a producer hanging off a consumer.
+    test "restarts the dead letter producer when it dies" do
+      root = root()
+      dlq = dead_letter_producer(root)
+      ref = Process.monitor(dlq)
+
+      Process.exit(dlq, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^dlq, :killed}
+
+      restarted = Utils.wait_for(fn -> dead_letter_producer(root) end, until: &(is_pid(&1) and &1 != dlq))
+
+      assert is_pid(restarted)
+      assert Topology.resource?(restarted, :producers)
+    end
+
+    # The other half of owning it: it does not outlive the consumer that diverts into it.
+    test "goes down with the consumer that owns it" do
+      root = root()
+      dlq = dead_letter_producer(root)
+      ref = Process.monitor(dlq)
+
+      Supervisor.stop(root)
+
+      assert_receive {:DOWN, ^ref, :process, ^dlq, _reason}
+    end
+
     # It comes up even though the consumer's own discovery never resolves here, so it is not
     # sequenced behind it and does not wait on a broker.
     test "the dead letter producer is reached through its consumer, not the producer registry" do
-      root = start_consumer_topology()
-
-      assert {_id, dlq, :supervisor, _modules} =
-               root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0)
-
-      assert is_pid(dlq)
+      assert root() |> dead_letter_producer() |> is_pid()
 
       # Registering would tie a consumer's startup to a branch that restarts separately from it.
       assert Client.lookup(:producers, "#{@consumer_name}-dead-letter-producer", :test) ==
@@ -108,19 +160,25 @@ defmodule Pulsar.Consumer.DeadLetterTest do
     end
 
     test "a consumer without a dead letter policy has no such child" do
-      root = start_consumer_topology(dead_letter_policy: nil)
+      assert [dead_letter_policy: nil] |> root() |> dead_letter_producer() == nil
+    end
 
-      assert root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0) == nil
+    defp dead_letter_producer(root) do
+      case root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0) do
+        {_id, pid, :supervisor, _modules} when is_pid(pid) -> pid
+        _absent -> nil
+      end
     end
 
     # Discovery never resolves, so no consumer worker is started and none of this needs a broker.
-    defp start_consumer_topology(overrides \\ []) do
+    defp root(overrides \\ []) do
       registry = :"consumer-topology-#{System.unique_integer([:positive])}"
       start_supervised!({Registry, keys: :unique, name: registry})
 
       start_supervised!(%{
         id: {:root, System.unique_integer([:positive])},
         type: :supervisor,
+        restart: :temporary,
         start:
           {Topology, :start_link,
            [

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -1,0 +1,136 @@
+defmodule Pulsar.Consumer.DeadLetterTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Client
+  alias Pulsar.Consumer.DeadLetter
+  alias Pulsar.Consumer.Worker, as: ConsumerWorker
+  alias Pulsar.Topology
+
+  @topic "persistent://public/default/orders"
+  @subscription "billing"
+  @consumer_name "#{@topic}-#{@subscription}"
+  @default_dlq "#{@topic}-#{@subscription}-DLQ"
+
+  defp opts(overrides \\ []) do
+    Keyword.merge(
+      [
+        topic: @topic,
+        name: @consumer_name,
+        client: :test,
+        subscription_name: @subscription,
+        consumer_count: 1,
+        partition_discovery_interval_ms: false,
+        dead_letter_policy: [max_redelivery: 3]
+      ],
+      overrides
+    )
+  end
+
+  describe "child_specs/1" do
+    test "a consumer without a dead letter policy owns no producer" do
+      assert DeadLetter.child_specs(opts(dead_letter_policy: nil)) == []
+    end
+
+    test "defaults the topic to the base topic and subscription" do
+      assert [%{id: {:dead_letter, @default_dlq}} = spec] = DeadLetter.child_specs(opts())
+      assert {Pulsar.Producer, :start_link, [producer_opts]} = spec.start
+      assert Keyword.fetch!(producer_opts, :topic) == @default_dlq
+    end
+
+    test "honours an explicit dead letter topic" do
+      explicit = "persistent://public/default/parked"
+      specs = DeadLetter.child_specs(opts(dead_letter_policy: [max_redelivery: 3, topic: explicit]))
+
+      assert [%{id: {:dead_letter, ^explicit}}] = specs
+    end
+
+    # Two subscriptions may be configured to divert into the same topic, and each still needs
+    # its own registered producer.
+    test "names the producer after the consumer rather than the dead letter topic" do
+      explicit = [max_redelivery: 3, topic: "persistent://public/default/parked"]
+
+      names =
+        for name <- [@consumer_name, "#{@consumer_name}-other"] do
+          [%{start: {_module, _fun, [producer_opts]}}] =
+            DeadLetter.child_specs(opts(name: name, dead_letter_policy: explicit))
+
+          Keyword.fetch!(producer_opts, :name)
+        end
+
+      assert names == Enum.uniq(names)
+    end
+  end
+
+  describe "annotate/2" do
+    test "tells the workers which root owns their dead letter producer" do
+      root = self()
+
+      assert opts() |> DeadLetter.annotate(root) |> Keyword.fetch!(:dead_letter_root) == root
+    end
+
+    test "leaves a consumer without a dead letter policy alone" do
+      annotated = [dead_letter_policy: nil] |> opts() |> DeadLetter.annotate(self())
+
+      refute Keyword.has_key?(annotated, :dead_letter_root)
+    end
+  end
+
+  describe "under a consumer topology" do
+    setup do
+      start_supervised!({Registry, keys: :unique, name: Client.registry(:producers, :test)})
+      start_supervised!({Registry, keys: :unique, name: Client.registry(:consumers, :test)})
+
+      :ok
+    end
+
+    test "runs the dead letter producer as a child of the consumer it belongs to" do
+      root = start_consumer_topology()
+
+      assert {_id, dlq, :supervisor, _modules} =
+               root
+               |> Supervisor.which_children()
+               |> List.keyfind({:dead_letter, @default_dlq}, 0)
+
+      assert is_pid(dlq)
+      assert Topology.kind(dlq) == :topology
+      assert Topology.resource?(dlq, :producers)
+    end
+
+    test "the dead letter producer comes up without waiting on a broker" do
+      root = start_consumer_topology()
+
+      # The consumer's own discovery never resolves here, so this also shows the producer is
+      # not sequenced behind it.
+      assert {_id, dlq, :supervisor, _modules} =
+               root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0)
+
+      assert Client.lookup(:producers, "#{@consumer_name}-dead-letter-producer", :test) == {:ok, dlq}
+    end
+
+    test "a consumer without a dead letter policy has no such child" do
+      root = start_consumer_topology(dead_letter_policy: nil)
+
+      assert root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0) == nil
+    end
+
+    # Discovery never resolves, so no consumer worker is started and none of this needs a broker.
+    defp start_consumer_topology(overrides \\ []) do
+      registry = :"consumer-topology-#{System.unique_integer([:positive])}"
+      start_supervised!({Registry, keys: :unique, name: registry})
+
+      start_supervised!(%{
+        id: {:root, System.unique_integer([:positive])},
+        type: :supervisor,
+        start:
+          {Topology, :start_link,
+           [
+             ConsumerWorker,
+             registry,
+             :consumer_count,
+             opts(overrides),
+             [resolver: fn _topic, _opts -> Process.sleep(:infinity) end]
+           ]}
+      })
+    end
+  end
+end

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -26,22 +26,32 @@ defmodule Pulsar.Consumer.DeadLetterTest do
     )
   end
 
-  describe "child_specs/1" do
-    test "a consumer without a dead letter policy owns no producer" do
-      assert DeadLetter.child_specs(opts(dead_letter_policy: nil)) == []
+  defp attach(overrides \\ []), do: DeadLetter.attach(opts(overrides), self())
+
+  describe "attach/2" do
+    test "a consumer without a dead letter policy attaches nothing" do
+      assert {annotated, []} = attach(dead_letter_policy: nil)
+      refute Keyword.has_key?(annotated, :dead_letter_root)
+    end
+
+    test "tells the workers which root owns the producer it attached" do
+      root = self()
+
+      assert {annotated, [_spec]} = DeadLetter.attach(opts(), root)
+      assert Keyword.fetch!(annotated, :dead_letter_root) == root
     end
 
     test "defaults the topic to the base topic and subscription" do
-      assert [%{id: {:dead_letter, @default_dlq}} = spec] = DeadLetter.child_specs(opts())
+      assert {_opts, [%{id: {:dead_letter, @default_dlq}} = spec]} = attach()
       assert {Topology, :start_link, [_worker, _registry, _count_key, producer_opts]} = spec.start
       assert Keyword.fetch!(producer_opts, :topic) == @default_dlq
     end
 
     test "honours an explicit dead letter topic" do
       explicit = "persistent://public/default/parked"
-      specs = DeadLetter.child_specs(opts(dead_letter_policy: [max_redelivery: 3, topic: explicit]))
 
-      assert [%{id: {:dead_letter, ^explicit}}] = specs
+      assert {_opts, [%{id: {:dead_letter, ^explicit}}]} =
+               attach(dead_letter_policy: [max_redelivery: 3, topic: explicit])
     end
 
     # Two subscriptions may be configured to divert into the same topic, and each still gets
@@ -51,27 +61,13 @@ defmodule Pulsar.Consumer.DeadLetterTest do
 
       names =
         for name <- [@consumer_name, "#{@consumer_name}-other"] do
-          [%{start: {_module, _fun, [_worker, _registry, _count_key, producer_opts]}}] =
-            DeadLetter.child_specs(opts(name: name, dead_letter_policy: explicit))
+          {_opts, [%{start: {_module, _fun, [_worker, _registry, _count_key, producer_opts]}}]} =
+            attach(name: name, dead_letter_policy: explicit)
 
           Keyword.fetch!(producer_opts, :name)
         end
 
       assert names == Enum.uniq(names)
-    end
-  end
-
-  describe "annotate/2" do
-    test "tells the workers which root owns their dead letter producer" do
-      root = self()
-
-      assert opts() |> DeadLetter.annotate(root) |> Keyword.fetch!(:dead_letter_root) == root
-    end
-
-    test "leaves a consumer without a dead letter policy alone" do
-      annotated = [dead_letter_policy: nil] |> opts() |> DeadLetter.annotate(self())
-
-      refute Keyword.has_key?(annotated, :dead_letter_root)
     end
   end
 
@@ -131,7 +127,7 @@ defmodule Pulsar.Consumer.DeadLetterTest do
              ConsumerWorker,
              registry,
              :consumer_count,
-             opts(overrides),
+             Keyword.put(opts(overrides), :companions, &DeadLetter.attach/2),
              [resolver: fn _topic, _opts -> Process.sleep(:infinity) end]
            ]}
       })

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -56,6 +56,23 @@ defmodule Pulsar.Consumer.DeadLetterTest do
                attach(dead_letter_policy: [max_redelivery: 3, topic: explicit])
     end
 
+    test "passes producer options through to the producer it attaches" do
+      policy = [max_redelivery: 3, producer: [compression: :lz4, batch_enabled: false]]
+
+      assert {_opts, [%{start: {_module, _fun, [producer_opts]}}]} = attach(dead_letter_policy: policy)
+      assert Keyword.fetch!(producer_opts, :compression) == :lz4
+      assert Keyword.fetch!(producer_opts, :batch_enabled) == false
+    end
+
+    test "the consumer still decides the topic, client and name" do
+      policy = [max_redelivery: 3, producer: [compression: :lz4]]
+
+      assert {_opts, [%{start: {_module, _fun, [producer_opts]}}]} = attach(dead_letter_policy: policy)
+      assert Keyword.fetch!(producer_opts, :topic) == @default_dlq
+      assert Keyword.fetch!(producer_opts, :client) == :test
+      assert Keyword.fetch!(producer_opts, :name) == "#{@consumer_name}-dead-letter-producer"
+    end
+
     # Two subscriptions may be configured to divert into the same topic, and each still gets
     # its own producer with its own identity.
     test "names the producer after the consumer rather than the dead letter topic" do

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -33,7 +33,7 @@ defmodule Pulsar.Consumer.DeadLetterTest do
 
     test "defaults the topic to the base topic and subscription" do
       assert [%{id: {:dead_letter, @default_dlq}} = spec] = DeadLetter.child_specs(opts())
-      assert {Pulsar.Producer, :start_link, [producer_opts]} = spec.start
+      assert {Topology, :start_link, [_worker, _registry, _count_key, producer_opts]} = spec.start
       assert Keyword.fetch!(producer_opts, :topic) == @default_dlq
     end
 
@@ -44,14 +44,14 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert [%{id: {:dead_letter, ^explicit}}] = specs
     end
 
-    # Two subscriptions may be configured to divert into the same topic, and each still needs
-    # its own registered producer.
+    # Two subscriptions may be configured to divert into the same topic, and each still gets
+    # its own producer with its own identity.
     test "names the producer after the consumer rather than the dead letter topic" do
       explicit = [max_redelivery: 3, topic: "persistent://public/default/parked"]
 
       names =
         for name <- [@consumer_name, "#{@consumer_name}-other"] do
-          [%{start: {_module, _fun, [producer_opts]}}] =
+          [%{start: {_module, _fun, [_worker, _registry, _count_key, producer_opts]}}] =
             DeadLetter.child_specs(opts(name: name, dead_letter_policy: explicit))
 
           Keyword.fetch!(producer_opts, :name)
@@ -96,15 +96,19 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert Topology.resource?(dlq, :producers)
     end
 
-    test "the dead letter producer comes up without waiting on a broker" do
+    # It comes up even though the consumer's own discovery never resolves here, so it is not
+    # sequenced behind it and does not wait on a broker.
+    test "the dead letter producer is reached through its consumer, not the producer registry" do
       root = start_consumer_topology()
 
-      # The consumer's own discovery never resolves here, so this also shows the producer is
-      # not sequenced behind it.
       assert {_id, dlq, :supervisor, _modules} =
                root |> Supervisor.which_children() |> List.keyfind({:dead_letter, @default_dlq}, 0)
 
-      assert Client.lookup(:producers, "#{@consumer_name}-dead-letter-producer", :test) == {:ok, dlq}
+      assert is_pid(dlq)
+
+      # Registering would tie a consumer's startup to a branch that restarts separately from it.
+      assert Client.lookup(:producers, "#{@consumer_name}-dead-letter-producer", :test) ==
+               {:error, :not_found}
     end
 
     test "a consumer without a dead letter policy has no such child" do

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -92,7 +92,6 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert properties["REAL_TOPIC"] == "orders-partition-2"
     end
 
-    # Pulsar.Message owns the format; this only pins that the property carries it.
     test "names the message it came from" do
       properties = DeadLetter.origin_properties("orders", message(message_id(partition: 3)))
 
@@ -123,7 +122,6 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert Topology.resource?(dlq, :producers)
     end
 
-    # The point of owning it: nothing else restarts a producer hanging off a consumer.
     test "restarts the dead letter producer when it dies" do
       root = root()
       dlq = dead_letter_producer(root)
@@ -138,7 +136,6 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert Topology.resource?(restarted, :producers)
     end
 
-    # The other half of owning it: it does not outlive the consumer that diverts into it.
     test "goes down with the consumer that owns it" do
       root = root()
       dlq = dead_letter_producer(root)

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -95,4 +95,34 @@ defmodule Pulsar.Consumer.OptionsTest do
       end
     end
   end
+
+  describe "validate!/1 with dead letter producer options" do
+    defp policy(producer), do: [dead_letter_policy: [max_redelivery: 3, producer: producer]]
+
+    test "accepts producer options" do
+      assert validate!(policy(compression: :lz4))[:dead_letter_policy][:producer] == [compression: :lz4]
+    end
+
+    test "rejects an option no producer has" do
+      assert_raise NimbleOptions.ValidationError, ~r/nonsense/, fn ->
+        validate!(policy(nonsense: true))
+      end
+    end
+
+    test "rejects an option with the wrong value, naming what it accepts" do
+      assert_raise NimbleOptions.ValidationError, ~r/compression/, fn ->
+        validate!(policy(compression: :LZ4))
+      end
+    end
+
+    # These come from the consumer that owns the producer, so accepting them would silently
+    # either be overridden or detach the producer from its consumer.
+    for managed <- [:topic, :client, :name] do
+      test "rejects #{managed}, which the consumer decides" do
+        assert_raise NimbleOptions.ValidationError, ~r/belongs to the consumer/, fn ->
+          validate!(policy([{unquote(managed), "nope"}]))
+        end
+      end
+    end
+  end
 end

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -3,6 +3,7 @@ defmodule Pulsar.MessageTest do
 
   alias Pulsar.Message
   alias Pulsar.Protocol.Binary.Pulsar.Proto.KeyValue
+  alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
   alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageMetadata
   alias Pulsar.Protocol.Binary.Pulsar.Proto.SingleMessageMetadata
 
@@ -100,6 +101,40 @@ defmodule Pulsar.MessageTest do
       assert Message.key(message) == nil
       assert Message.event_time(message) == nil
       assert Message.properties(message) == %{}
+    end
+  end
+
+  describe "message_id_string/1" do
+    defp message_id(overrides \\ []) do
+      struct(%MessageIdData{ledgerId: 7, entryId: 42, partition: -1, batch_index: -1}, overrides)
+    end
+
+    defp id_string(message_id), do: Message.message_id_string(%Message{message_id: message_id})
+
+    test "prints an unbatched id on a non-partitioned topic" do
+      assert id_string(message_id()) == "7:42:-1"
+    end
+
+    test "carries the partition of a partitioned topic" do
+      assert id_string(message_id(partition: 3)) == "7:42:3"
+    end
+
+    # Every entry of a batch shares one ledger and entry id, so without the index the string
+    # would name the batch rather than the message.
+    test "tells two entries of the same batch apart" do
+      ids = Enum.map(0..1, &id_string(message_id(batch_index: &1)))
+
+      assert ids == ["7:42:-1:0", "7:42:-1:1"]
+    end
+
+    # A chunked message carries one id per chunk; the first is where it began.
+    test "answers for the chunk a chunked message began at" do
+      assert id_string([message_id(), message_id(entryId: 43)]) == "7:42:-1"
+    end
+
+    test "answers nil when there is no id" do
+      assert id_string(nil) == nil
+      assert id_string([]) == nil
     end
   end
 end

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -498,6 +498,49 @@ defmodule Pulsar.TopologyTest do
     end
   end
 
+  describe "companions" do
+    test "runs what a resource attaches and tells its workers what it answered" do
+      test_pid = self()
+
+      attach = fn opts, root ->
+        send(test_pid, {:attached, root})
+
+        {Keyword.put(opts, :companion_root, root),
+         [%{id: :companion, start: {Agent, :start_link, [fn -> :companion end]}}]}
+      end
+
+      {root, _registry} =
+        start_async_topology(fn _topic, _opts -> {:ok, 0} end, [companions: attach], worker: OptsWorker)
+
+      :ok = Topology.await_ready(root, 1_000)
+
+      assert_receive {:attached, ^root}
+
+      assert {:companion, companion, :worker, _modules} =
+               root |> Supervisor.which_children() |> List.keyfind(:companion, 0)
+
+      assert is_pid(companion)
+
+      assert [{0, opts}] = worker_opts(root)
+      assert Keyword.fetch!(opts, :companion_root) == root
+    end
+
+    # It configures the root, so a worker is started without it either way.
+    test "keeps the declaration out of the options its workers are started with" do
+      attach = fn opts, _root -> {opts, []} end
+
+      for declared <- [[companions: attach], []] do
+        {root, _registry} =
+          start_async_topology(fn _topic, _opts -> {:ok, 0} end, declared, worker: OptsWorker)
+
+        :ok = Topology.await_ready(root, 1_000)
+
+        assert [{0, opts}] = worker_opts(root)
+        refute Keyword.has_key?(opts, :companions)
+      end
+    end
+  end
+
   defp worker_opts(root) do
     for {index, group} <- Topology.groups(root) do
       [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)


### PR DESCRIPTION
## Summary

A consumer's dead letter producer is now a child of that consumer's `Pulsar.Topology` root, and an ordinary producer below that point: its own discovery, its own partitions, its own restarts. It was previously started with `Pulsar.Producer.Worker.start_link/1` from inside a consumer worker, which left it unsupervised and linked to a process that does not trap exits.

Diverting is also now exclusive with delivering. Closes #173.

The dead letter path gains what it needs to be run in anger: producer options, telemetry, and a guide.

This is not a breaking change. No signature, option or return value moves, and the one behaviour that changes for existing callers restores a documented default that the old code contradicted.

## Motivation

`start_dead_letter_producer/1` (`consumer/worker.ex:849`) called `ProducerWorker.start_link/1` directly from the worker's `handle_continue({:init_dead_letter_producer, …})` (`:303`). That bypassed `Pulsar.Producer`, `Pulsar.Topology`, the client's producer supervisor and its registry, leaving a bare linked GenServer owned by a consumer worker.

**A dead letter broker disconnect took the consumer with it.** A producer worker stops on `:broker_exited`, `:broker_crashed` and `:broker_close_requested`, all routine. The consumer worker does not trap exits, so that linked exit propagated: subscription dropped, flow permits reset, chunk state lost. Its group restarted it, so a dead letter topic nothing had ever published to could restart-loop live consumers.

**Nothing restarted the producer.** No supervisor owned it. Had the link not killed the consumer first, `dead_letter_producer_pid` would have been a dead pid, which the `is_nil` guard at `:492` does not catch.

**A slow dead letter topic crashed the consumer.** `ProducerWorker.send_message/3` is a `GenServer.call` with a 5s default, made once per message inside the consumer's `handle_info` (`:864`). A call timeout is an exit rather than `{:error, reason}`, so the error branch that leaves messages nacked could never see one.

**Partitioned dead letter topics did not work.** The producer was handed a raw topic string with no discovery behind it, so against a partitioned dead letter topic it registered on the base name.

**Every worker had its own.** With `:consumer_count` above one, or a partitioned source topic, each worker opened a separate producer to the same dead letter topic.

**Consumer startup waited on it.** `{:stop, reason, state}` at `:312` meant a dead letter topic that could not be created failed the consumer's boot and spent its restart budget, even when no message ever failed.

**A diverted message was delivered to the callback as well (#173).** `process_messages_normally/2` and `maybe_send_batch_to_dead_letter/2` both ran over the whole batch, unconditionally and in sequence, so reaching `:max_redelivery` started diverting without stopping delivery. Three things followed, and the suite encoded the first of them: `dead_letter_policy_test.exs` asserted the callback saw each message `max_redelivery + 1` times.

- The callback kept seeing a message for as long as the divert failed, unbounded rather than bounded by `:max_redelivery`, since the option is a threshold and not a cap.
- A callback failing three times and then returning `{:ok, state}` on the fourth had its message acknowledged *and* copied to the dead letter topic. One message, two outcomes.
- An id could be both nacked by the callback and acked by a successful divert, leaving `:trigger_redelivery` asking the broker to redeliver something already acknowledged.

**The default topic contradicted its own documentation.** `:dead_letter_policy`'s `:topic` documents the default as `"<topic>-<subscription>-DLQ"`, but the name was built at `:852` from `state.topic`, which for a partitioned consumer is the partition that worker holds. A three-partition consumer produced three dead letter topics named after partitions.

## Where it lives

```
Pulsar.Topology                                consumer root
├── {:dead_letter, "orders-billing-DLQ"}       Pulsar.Topology, a producer
│   ├── Discovery
│   └── {:topic, :non_partitioned}
│       └── Pulsar.Producer.Worker
├── Discovery
├── {:partition, 0}
│   └── Pulsar.Consumer.Worker
└── {:partition, 1}
    └── Pulsar.Consumer.Worker
```

`Pulsar.Consumer.DeadLetter` is the new module. It resolves the topic and the producer's name, builds the child spec, and owns the divert path.

It attaches through a general seam rather than one `Pulsar.Topology` knows by name. A resource declares `:companions`, a function of its root's options and the root itself, answering the options its workers inherit together with the children to run alongside them. `Pulsar.Consumer.start_link/1` passes `&DeadLetter.attach/2`; producers pass nothing; `Pulsar.Topology` names neither. The declaration is popped from the options rather than read, since it configures the root and is not part of what a worker is started with.

Four things follow from where the resolution happens:

- **One dead letter topic per subscription.** The topic is derived from the root's options, before `Pulsar.Topology.Group` rewrites `:name` and `:topic` per partition and per worker. The root only ever holds the base topic, so there is nowhere for a partition name to enter.
- **A producer restart is invisible to the workers.** They inherit `:dead_letter_root`, the root pid, rather than a producer pid or a name, and find the producer among its children at divert time. They inherit the resolved `:dead_letter_topic` too, so telemetry can name it even on the path where the producer cannot be resolved.
- **Startup no longer waits on a broker.** A producer's topology root comes up before its discovery resolves, so the consumer's boot is not sequenced behind the dead letter topic being reachable. The unit tests exercise this with a resolver that never returns.
- **A dead letter topic that is unreachable or slow leaves messages nacked.** `Pulsar.Producer.send/3` already answers `{:error, :not_ready}` during discovery and converts a worker dying mid-send into an error, which is the branch that was unreachable before.

`Pulsar.Topology.workers/1` no longer descends into a nested topology root, so the dead letter producer's workers do not read as consumer workers to `Pulsar.Consumer.send_flow/3`, `Pulsar.Reader` or `await_ready/2`.

## Diverting or delivering, not both

The two passes become exclusive:

```elixir
new_state =
  case divert(new_state, messages) do
    {:divert, redelivery_count} -> send_batch_to_dead_letter(new_state, messages, redelivery_count)
    :deliver -> process_messages_normally(new_state, messages)
  end

{:noreply, check_and_refill_permits(new_state)}
```

`divert/2` answers before counting, so a consumer with no dead letter policy never walks a delivery, and
the one that does diverts carries its count across rather than recomputing it.

All-or-nothing per delivery is the right granularity rather than a simplification: a batch arrives as one broker command and a chunked message answers the maximum across its chunks, so every message built from one delivery carries the same redelivery count. The previous "maximum across the batch" was already equivalent to "the redelivery count of this delivery".

The permit refill moves out of `process_messages_normally/2` so both paths get it, or a consumer diverting everything would quietly stop being sent messages. `:max_redelivery` now means what its documentation implies, deliveries to attempt before diverting, rather than deliveries before diverting starts happening as well.

## What a diverted message carries

Previously only the payload survived, so a dead letter consumer had no way to trace a message back to where it failed.

| Property | Value |
| --- | --- |
| `payload` | Unchanged |
| Key and ordering key | The origin's, so a `Key_Shared` dead letter consumer partitions the same way as the origin |
| Properties | The origin's, plus the two below rather than in place of them |
| Event time | The origin's |
| `REAL_TOPIC` | The topic the message was consumed from; the partition for a partitioned consumer |
| `ORIGIN_MESSAGE_ID` | `ledgerId:entryId:partition`, with a batch entry's index appended |

The two property names are the Java client's, so both ends of a dead letter topic agree on them without a convention of ours in between.

The id is formatted by a new accessor, **`Pulsar.Message.message_id_string/1`**, rather than here. `message_id` is documented as opaque, and printing one means resolving the delivery shape twice over: a chunked message carries one id per chunk, and a batch entry has to append its index or every message in a batch reports the ledger and entry id of the batch alone, naming the batch rather than the message. That is the resolution `Pulsar.Message`'s accessors exist to hold, and it is worth having on its own for logging and correlation. Adding an accessor is not breaking.

## Configuring the producer

The producer took `Pulsar.Producer`'s defaults and nothing else. `:compression` in particular matters for a
topic holding payloads that have already failed to process, and there was no way to set it:

```elixir
dead_letter_policy: [
  max_redelivery: 3,
  producer: [compression: :lz4, batch_enabled: false]
]
```

Validated against `Pulsar.Producer.Options` while the caller still holds the consumer's options, so a bad
value raises a `NimbleOptions.ValidationError` naming the option at `Pulsar.Consumer.start/1` rather than
failing a supervisor's start later. `:topic`, `:client` and `:name` come from the consumer and are rejected
rather than silently overridden.

The key has no schema default, so a policy that does not mention it stays exactly as written.

## Telemetry

The consumer emitted nothing for any of this. Chunk events and `flow_control` were the only consumer events,
so the sole machine-readable trace of a message being parked was the dead letter producer's
`[:pulsar, :producer, :message, :published]`, matched on a `producer_name` suffix — indirect, coupled to a
name, and firing only when the publish succeeded. The failure case, which is the one worth paging on, had a
`Logger.error` and nothing else.

| Event | When |
| --- | --- |
| `[:pulsar, :consumer, :message, :nacked]` | A callback returned `{:error, …}`, or `Pulsar.Consumer.nack/2` was called |
| `[:pulsar, :consumer, :redelivery, :requested]` | The redelivery interval asked the broker for the nacked messages back |
| `[:pulsar, :consumer, :dead_letter, :diverted]` | Messages reached the threshold and were published |
| `[:pulsar, :consumer, :dead_letter, :failed]` | Publishing failed, so the messages stay nacked |

All four carry `%{count: n}`, one event per delivery rather than per message, alongside `:topic`,
`:subscription_name` and `:consumer_id`. The dead letter pair adds `:dead_letter_topic` and
`:redelivery_count`, and `:failed` carries `:reason`.

`:nacked` and `:redelivery, :requested` are not dead letter specific. They are on the path a message takes to
get there, and a dead letter rate is not interpretable without the retry pressure behind it.

## Why it is not registered

`Pulsar.Producer.start_link/1` registers what it starts in the client's producer registry, and using it here would have made a consumer's startup depend on the producer branch. That registry is the first child of its branch (`client.ex:196`), and the consumer branch starts first (`:180`), so a client with declared consumers would have failed to boot.

Reordering the branches fixes the boot and keeps the coupling. Hoisting both registries to the client level was the other option, and it costs isolation. The registry precedes its resources under `:rest_for_one` precisely so that if it dies, the `DynamicSupervisor` and `Bootstrap` are rebuilt with it and every resource re-registers, with a blast radius of one branch. Hoisted, that guarantee needs `:rest_for_one` at the client level too, so a producer-registry crash would then rebuild every consumer as well; under `:one_for_one` it would be worse, leaving live resources unregistered for good.

So the dependency is removed rather than ordered around. `Pulsar.Topology.start_link/4,5` accepts `nil` for the registry and starts unnamed, and `Pulsar.Producer.start_link_unregistered/1` takes that path. Workers already resolved the producer by traversing the consumer root, so the registration was decorative.

It goes through `Pulsar.Producer` rather than assembling the topology at the call site so that one module still knows how to build a producer. Constructing it here would have made the "ordinary producer" claim rest on nothing, and any later change to `start_link/1` would have skipped the dead letter producer silently.

It is genuinely private as a result: `Pulsar.Producer.stop("…-dead-letter-producer")` can no longer terminate it out from under a consumer, and it does not appear among a client's producers. The producer still carries a name, which keys its epochs and its telemetry.

## Why a child rather than a producer linked to its consumer

The alternative was to start it as a regular producer on the client and link the two stable topology roots, which reads like it would tie their lifetimes together. It does not. Both roots are OTP supervisors, a supervisor always traps exits, and an `EXIT` from a process that is neither its parent nor one of its children reaches `handle_info` and is discarded. Two linked supervisors are inert in both directions.

Measured rather than assumed: a supervisor linked to a peer survives that peer's abnormal death, and a peer that does not trap exits dies with the supervisor. The only direction in which a link bites is the one that caused the original bug.

Coupling them would therefore need a monitor and explicit teardown on both sides, which is the ownership that being a child already provides.

## What changes for callers

| | Before | After |
| --- | --- | --- |
| Dead letter topic of a partitioned consumer | One per partition, named after it | One per subscription, as documented |
| A dead letter topic that is unreachable or slow | Consumer exits and restarts | Messages stay nacked |
| A dead letter policy on a topic that cannot be created | Consumer fails to start | Consumer starts; the producer retries |
| A diverted message | Payload only, and delivered to the callback too | Payload, key, ordering key, properties, event time and origin; not delivered |
| Callback invocations for a poison message | `max_redelivery + 1`, unbounded while diverting fails | `max_redelivery` |
| An invalid message reaching the threshold | Diverted and passed to `handle_invalid_message/2` | Diverted only |
| Observability of nacks, retries and parking | Log lines | Four telemetry events |
| The dead letter producer's options | `Pulsar.Producer`'s defaults, fixed | Settable through `:producer` |

Nothing here is configured differently. The first row is the only one that can go unnoticed: a partitioned consumer relying on the default topic writes somewhere else after this, so anything subscribed to the per-partition names needs repointing.

## Documentation

`docs/dead_letter_policies.md` follows the existing guides' shape, and `examples/odds_even_dlq.exs` is a
runnable end-to-end flow where odd numbers are rejected until they are parked and even ones are processed.

Writing them turned up two things worth knowing that nothing recorded:

- **A dead letter policy does nothing without `:redelivery_interval`.** It is absent by default, and without
  it the library never asks the broker to redeliver a nacked message, so the redelivery count never grows and
  the threshold is never reached. Every integration test sets it; no documentation mentioned it.
- **A producer cannot ask the broker to create a topic.** `CommandSubscribe` carries `force_topic_creation`,
  which is what `:force_create_topic` sets, and `CommandProducer` has no equivalent. So a dead letter topic
  depends on `allowTopicAutoCreation` or on being created beforehand — starting the consumer that reads it is
  enough, which is the ordering the example uses.

## Follow-ups

- A retry letter topic, `retryLetterTopic` in the Java client, is the natural companion to this and is not implemented. It fits the same shape: another producer under the consumer, plus a reconsume-later path on the callback.

