### PR TITLE
fix(producer)!: route partition keys with a Pulsar hashing scheme

### DIFF
--- a/lib/pulsar/hash.ex
+++ b/lib/pulsar/hash.ex
@@ -52,25 +52,18 @@ defmodule Pulsar.Hash do
   on it: the Pulsar ones take Pulsar's signSafeMod over a sign-masked hash, while `phash2`
   takes its range directly and does not give the same answer as a `rem/2` over `phash2/1`.
 
-  Raises unless the key is a valid UTF-8 binary. The key is validated once here rather than
-  per scheme so that changing `:hashing_scheme` never changes which keys are routable.
+  Raises unless the key is a binary, which every scheme needs and which `:erlang.phash2/2`
+  accepted anything in place of. Encoding is not checked: `:murmur3_32` hashes bytes, and a
+  key that is not valid UTF-8 fails the send at `partition_key`'s string field regardless of
+  whether routing looked at it.
   """
-  @spec partition(scheme() | nil, binary(), pos_integer()) :: non_neg_integer()
-  def partition(scheme, key, partitions) do
-    validate_key!(key)
+  @spec partition(scheme() | nil, term(), pos_integer()) :: non_neg_integer()
+  def partition(scheme, key, partitions) when is_binary(key) do
     reduce(scheme, key, partitions)
   end
 
-  # partition_key is a string on the wire, so a key that is not valid UTF-8 fails the send
-  # under every scheme anyway. Rejecting it here reports it against the option the caller set.
-  defp validate_key!(key) when is_binary(key) do
-    if not String.valid?(key) do
-      raise ArgumentError, ":partition_key must be valid UTF-8"
-    end
-  end
-
-  defp validate_key!(_key) do
-    raise ArgumentError, ":partition_key must be a UTF-8 binary"
+  def partition(_scheme, _key, _partitions) do
+    raise ArgumentError, ":partition_key must be a binary"
   end
 
   defp reduce(nil, key, partitions), do: reduce(@default_scheme, key, partitions)

--- a/lib/pulsar/hash.ex
+++ b/lib/pulsar/hash.ex
@@ -1,0 +1,136 @@
+defmodule Pulsar.Hash do
+  @moduledoc false
+
+  # Partition-key hashing, matching the schemes the other Pulsar clients implement so the same
+  # key reaches the same partition regardless of which client published it.
+  #
+  # Both Pulsar schemes mask the result with Integer.MAX_VALUE, as the Java client does, so
+  # reducing them to a partition is Pulsar's signSafeMod with no further sign handling.
+  #
+  # :phash2_legacy is not a Pulsar scheme and no other client can reproduce it. It exists only
+  # so a 2.x deployment can upgrade without its keys jumping partitions on the way, and should
+  # be migrated off deliberately. See partition/3 for why it cannot share their reduction.
+  #
+  # Reference implementations, which test/unit/hash_test.exs pins this module against. Both are
+  # tagged rather than tracking a branch, so a claim here always has a source that still says it;
+  # the Java tag is the broker version the integration suite runs against.
+  #
+  # Under https://github.com/apache/pulsar/blob/v4.2.4/
+  #
+  #   scheme selection   pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageRouterBase.java
+  #   murmur3 wrapper    pulsar-client/src/main/java/org/apache/pulsar/client/impl/Murmur3Hash32.java
+  #   murmur3 core       pulsar-common/src/main/java/org/apache/pulsar/common/util/Murmur3_32Hash.java
+  #   java string hash   pulsar-client/src/main/java/org/apache/pulsar/client/impl/JavaStringHash.java
+  #   default scheme     pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+  #
+  # Under https://github.com/apache/pulsar-client-go/blob/v0.21.0/
+  #
+  #   both schemes       pulsar/internal/hash.go
+  #   default scheme     pulsar/producer.go
+
+  import Bitwise
+
+  @schemes [:murmur3_32, :java_string_hash, :phash2_legacy]
+  @default_scheme :murmur3_32
+
+  @seed 0
+  @c1 0xCC9E2D51
+  @c2 0x1B873593
+  @mask32 0xFFFFFFFF
+  @max_int32 0x7FFFFFFF
+
+  @type scheme :: :murmur3_32 | :java_string_hash | :phash2_legacy
+
+  @spec schemes() :: [scheme()]
+  def schemes, do: @schemes
+
+  @spec default_scheme() :: scheme()
+  def default_scheme, do: @default_scheme
+
+  @doc """
+  Picks the partition of a `partitions`-wide topic for a key, under the given scheme.
+
+  Reducing the hash belongs here rather than in the caller because the schemes do not agree
+  on it: the Pulsar ones take Pulsar's signSafeMod over a sign-masked hash, while `phash2`
+  takes its range directly and does not give the same answer as a `rem/2` over `phash2/1`.
+  """
+  @spec partition(scheme() | nil, binary(), pos_integer()) :: non_neg_integer()
+  def partition(nil, key, partitions), do: partition(@default_scheme, key, partitions)
+  def partition(:murmur3_32, key, partitions), do: rem(murmur3_32(key), partitions)
+  def partition(:java_string_hash, key, partitions), do: rem(java_string_hash(key), partitions)
+  def partition(:phash2_legacy, key, partitions), do: :erlang.phash2(key, partitions)
+
+  @doc """
+  MurmurHash3 x86 32-bit, as Pulsar's `Murmur3_32Hash` applies it.
+
+  Every client implements this identically, which is why Pulsar recommends it whenever a topic
+  is published to from more than one language.
+
+  Seeded with zero and masked with `Integer.MAX_VALUE`, per `Murmur3_32Hash.makeHash/1`. A key
+  is hashed as its UTF-8 bytes, per `Murmur3Hash32.makeHash/1`.
+  """
+  @spec murmur3_32(binary()) :: non_neg_integer()
+  def murmur3_32(key) when is_binary(key) do
+    key
+    |> body(@seed)
+    |> finalize(byte_size(key))
+    |> band(@max_int32)
+  end
+
+  defp body(<<block::little-unsigned-32, rest::binary>>, h1) do
+    k1 = block |> mul(@c1) |> rotl(15) |> mul(@c2)
+    h1 = h1 |> bxor(k1) |> rotl(13) |> mul(5)
+
+    body(rest, band(h1 + 0xE6546B64, @mask32))
+  end
+
+  defp body(tail, h1), do: {tail, h1}
+
+  defp finalize({tail, h1}, length) do
+    h1
+    |> bxor(scramble(tail))
+    |> bxor(length)
+    |> fmix()
+  end
+
+  defp scramble(<<b0, b1, b2>>), do: scramble_k1(b2 <<< 16 ||| b1 <<< 8 ||| b0)
+  defp scramble(<<b0, b1>>), do: scramble_k1(b1 <<< 8 ||| b0)
+  defp scramble(<<b0>>), do: scramble_k1(b0)
+  defp scramble(<<>>), do: 0
+
+  defp scramble_k1(k1), do: k1 |> mul(@c1) |> rotl(15) |> mul(@c2)
+
+  defp fmix(h) do
+    h = h |> bxor(h >>> 16) |> mul(0x85EBCA6B)
+    h = h |> bxor(h >>> 13) |> mul(0xC2B2AE35)
+
+    bxor(h, h >>> 16)
+  end
+
+  defp mul(a, b), do: band(a * b, @mask32)
+
+  defp rotl(value, count), do: band(value <<< count ||| value >>> (32 - count), @mask32)
+
+  @doc """
+  Java's `String.hashCode`, as Pulsar's `JavaStringHash` applies it.
+
+  This is what the Java and Go clients route on by default, so it is the scheme to pick when
+  co-locating keys with producers that left their own default alone. It iterates UTF-16 code
+  units, so a key outside the basic multilingual plane hashes over its surrogate pair, and it
+  is masked with `Integer.MAX_VALUE` after overflowing as a signed 32-bit int.
+  """
+  @spec java_string_hash(binary()) :: non_neg_integer()
+  def java_string_hash(key) when is_binary(key) do
+    key
+    |> utf16_code_units()
+    |> Enum.reduce(0, fn unit, hash -> band(31 * hash + unit, @mask32) end)
+    |> band(@max_int32)
+  end
+
+  defp utf16_code_units(key) do
+    case :unicode.characters_to_binary(key, :utf8, {:utf16, :big}) do
+      utf16 when is_binary(utf16) -> for <<unit::big-unsigned-16 <- utf16>>, do: unit
+      _invalid -> raise ArgumentError, "partition key is not valid UTF-8: #{inspect(key)}"
+    end
+  end
+end

--- a/lib/pulsar/hash.ex
+++ b/lib/pulsar/hash.ex
@@ -52,10 +52,9 @@ defmodule Pulsar.Hash do
   on it: the Pulsar ones take Pulsar's signSafeMod over a sign-masked hash, while `phash2`
   takes its range directly and does not give the same answer as a `rem/2` over `phash2/1`.
 
-  Raises unless the key is a binary, which every scheme needs and which `:erlang.phash2/2`
-  accepted anything in place of. Encoding is not checked: `:murmur3_32` hashes bytes, and a
-  key that is not valid UTF-8 fails the send at `partition_key`'s string field regardless of
-  whether routing looked at it.
+  Raises unless the key is a binary, which `:erlang.phash2/2` accepted anything in place of.
+  Encoding is not checked: `:murmur3_32` hashes bytes, and a key that is not valid UTF-8 fails
+  the send at `partition_key`'s string field either way.
   """
   @spec partition(scheme() | nil, term(), pos_integer()) :: non_neg_integer()
   def partition(scheme, key, partitions) when is_binary(key) do

--- a/lib/pulsar/hash.ex
+++ b/lib/pulsar/hash.ex
@@ -7,13 +7,11 @@ defmodule Pulsar.Hash do
   # Both Pulsar schemes mask the result with Integer.MAX_VALUE, as the Java client does, so
   # reducing them to a partition is Pulsar's signSafeMod with no further sign handling.
   #
-  # :phash2_legacy is not a Pulsar scheme and no other client can reproduce it. It exists only
-  # so a 2.x deployment can upgrade without its keys jumping partitions on the way, and should
-  # be migrated off deliberately. See partition/3 for why it cannot share their reduction.
+  # :phash2_legacy is not a Pulsar scheme and no other client can reproduce it. It is a
+  # migration path off the pre-3.0 routing, not a peer of the other two.
   #
-  # Reference implementations, which test/unit/hash_test.exs pins this module against. Both are
-  # tagged rather than tracking a branch, so a claim here always has a source that still says it;
-  # the Java tag is the broker version the integration suite runs against.
+  # Reference implementations, which test/unit/hash_test.exs pins this module against. The
+  # Java tag is the broker version the integration suite runs against.
   #
   # Under https://github.com/apache/pulsar/blob/v4.2.4/
   #

--- a/lib/pulsar/hash.ex
+++ b/lib/pulsar/hash.ex
@@ -51,12 +51,32 @@ defmodule Pulsar.Hash do
   Reducing the hash belongs here rather than in the caller because the schemes do not agree
   on it: the Pulsar ones take Pulsar's signSafeMod over a sign-masked hash, while `phash2`
   takes its range directly and does not give the same answer as a `rem/2` over `phash2/1`.
+
+  Raises unless the key is a valid UTF-8 binary. The key is validated once here rather than
+  per scheme so that changing `:hashing_scheme` never changes which keys are routable.
   """
   @spec partition(scheme() | nil, binary(), pos_integer()) :: non_neg_integer()
-  def partition(nil, key, partitions), do: partition(@default_scheme, key, partitions)
-  def partition(:murmur3_32, key, partitions), do: rem(murmur3_32(key), partitions)
-  def partition(:java_string_hash, key, partitions), do: rem(java_string_hash(key), partitions)
-  def partition(:phash2_legacy, key, partitions), do: :erlang.phash2(key, partitions)
+  def partition(scheme, key, partitions) do
+    validate_key!(key)
+    reduce(scheme, key, partitions)
+  end
+
+  # partition_key is a string on the wire, so a key that is not valid UTF-8 fails the send
+  # under every scheme anyway. Rejecting it here reports it against the option the caller set.
+  defp validate_key!(key) when is_binary(key) do
+    if not String.valid?(key) do
+      raise ArgumentError, ":partition_key must be valid UTF-8"
+    end
+  end
+
+  defp validate_key!(_key) do
+    raise ArgumentError, ":partition_key must be a UTF-8 binary"
+  end
+
+  defp reduce(nil, key, partitions), do: reduce(@default_scheme, key, partitions)
+  defp reduce(:murmur3_32, key, partitions), do: rem(murmur3_32(key), partitions)
+  defp reduce(:java_string_hash, key, partitions), do: rem(java_string_hash(key), partitions)
+  defp reduce(:phash2_legacy, key, partitions), do: :erlang.phash2(key, partitions)
 
   @doc """
   MurmurHash3 x86 32-bit, as Pulsar's `Murmur3_32Hash` applies it.
@@ -119,16 +139,15 @@ defmodule Pulsar.Hash do
   """
   @spec java_string_hash(binary()) :: non_neg_integer()
   def java_string_hash(key) when is_binary(key) do
-    key
-    |> utf16_code_units()
-    |> Enum.reduce(0, fn unit, hash -> band(31 * hash + unit, @mask32) end)
-    |> band(@max_int32)
-  end
-
-  defp utf16_code_units(key) do
     case :unicode.characters_to_binary(key, :utf8, {:utf16, :big}) do
-      utf16 when is_binary(utf16) -> for <<unit::big-unsigned-16 <- utf16>>, do: unit
-      _invalid -> raise ArgumentError, "partition key is not valid UTF-8: #{inspect(key)}"
+      utf16 when is_binary(utf16) -> utf16 |> fold_code_units(0) |> band(@max_int32)
+      _invalid -> raise ArgumentError, ":partition_key must be valid UTF-8"
     end
   end
+
+  defp fold_code_units(<<unit::big-unsigned-16, rest::binary>>, hash) do
+    fold_code_units(rest, band(31 * hash + unit, @mask32))
+  end
+
+  defp fold_code_units(<<>>, hash), do: hash
 end

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -113,7 +113,7 @@ defmodule Pulsar.Producer do
 
   - `:partition_key` - decides the partition of a partitioned topic, hashed under the
     producer's `:hashing_scheme`, and is carried with the message so a `:key_shared`
-    subscription can use it
+    subscription can use it. Must be a binary; before 3.0 any term was accepted here
   - `:properties` - a map of user properties carried with the message
   - `:event_time` - the message's event time, in milliseconds
   - `:deliver_at_time` / `:deliver_after` - delayed delivery

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -23,6 +23,7 @@ defmodule Pulsar.Producer do
   """
 
   alias Pulsar.Client
+  alias Pulsar.Hash
   alias Pulsar.Producer.Options
   alias Pulsar.Producer.Worker
   alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
@@ -110,8 +111,9 @@ defmodule Pulsar.Producer do
 
   ## Options
 
-  - `:partition_key` - decides the partition of a partitioned topic, and is carried
-    with the message so a `:key_shared` subscription can use it
+  - `:partition_key` - decides the partition of a partitioned topic, hashed under the
+    producer's `:hashing_scheme`, and is carried with the message so a `:key_shared`
+    subscription can use it
   - `:properties` - a map of user properties carried with the message
   - `:event_time` - the message's event time, in milliseconds
   - `:deliver_at_time` / `:deliver_after` - delayed delivery
@@ -174,16 +176,17 @@ defmodule Pulsar.Producer do
         {:error, :not_found}
 
       :topology ->
-        route(Topology.groups(producer), message, opts)
+        {groups, hashing_scheme} = Topology.routing(producer)
+        route(groups, hashing_scheme, message, opts)
     end
   catch
     # A stale root and a worker that dies mid-send have the same public result.
     :exit, reason -> {:error, {:producer_died, reason}}
   end
 
-  defp route([], _message, _opts), do: {:error, :not_ready}
+  defp route([], _hashing_scheme, _message, _opts), do: {:error, :not_ready}
 
-  defp route(groups, message, opts) do
+  defp route(groups, hashing_scheme, message, opts) do
     # Missing partitions are added highest-first, so the contiguous width stays at the old
     # modulus until every new slot exists. Restarting groups remain present and retain their
     # slot, avoiding a temporary key remap during either growth or recovery.
@@ -192,7 +195,7 @@ defmodule Pulsar.Producer do
         {:error, :not_ready}
 
       partitions ->
-        index = select_partition(opts, partitions)
+        index = select_partition(opts, hashing_scheme, partitions)
 
         case List.keyfind(groups, index, 0) do
           {_index, group} when is_pid(group) -> send_to_worker(Topology.workers(group), message, opts)
@@ -211,10 +214,10 @@ defmodule Pulsar.Producer do
     end)
   end
 
-  defp select_partition(opts, partitions) do
+  defp select_partition(opts, hashing_scheme, partitions) do
     case Keyword.get(opts, :partition_key) do
       nil -> Enum.random(0..(partitions - 1))
-      partition_key -> :erlang.phash2(partition_key, partitions)
+      partition_key -> Hash.partition(hashing_scheme, partition_key, partitions)
     end
   end
 

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -1,6 +1,8 @@
 defmodule Pulsar.Producer.Options do
   @moduledoc false
 
+  alias Pulsar.Hash
+
   @schema [
     topic: [
       type: :string,
@@ -34,6 +36,23 @@ defmodule Pulsar.Producer.Options do
       type: {:in, [:none, :lz4, :zlib, :snappy, :zstd]},
       default: :none,
       doc: "Compression applied to the payload."
+    ],
+    hashing_scheme: [
+      type: {:in, Hash.schemes()},
+      default: Hash.default_scheme(),
+      doc: """
+      How a message's `:partition_key` is hashed to pick a partition of a partitioned topic.
+
+      `:murmur3_32` is implemented identically by every Pulsar client, so keys co-locate with
+      producers in other languages. `:java_string_hash` matches what the Java and Go clients
+      use when left at their own default.
+
+      `:phash2_legacy` is the non-standard `:erlang.phash2/2` routing used before 3.0. No
+      other client can reproduce it, so it is only for upgrading a partitioned topic without
+      remapping keys mid-flight: keeping a key's existing partition preserves its ordering,
+      which switching schemes breaks until the old partition drains. Prefer draining and
+      moving to `:murmur3_32`.
+      """
     ],
     batch_enabled: [
       type: :boolean,

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -279,14 +279,13 @@ defmodule Pulsar.Topology do
     end
   end
 
-  @doc """
-  Returns a topology root's groups together with the hashing scheme its resource was configured
-  with, from a single traversal of its children.
-
-  For a producer, which needs both to route a keyed message and would otherwise pay a second
-  call per send. Takes a root; `groups/1` covers the other levels. The scheme is `nil` for a
-  resource that does not route on a key.
-  """
+  # Groups and the configured hashing scheme from one traversal, for a producer that needs both
+  # to route a keyed message and would otherwise pay a second call per send.
+  #
+  # Unlike groups/1 this does not dispatch on kind/1: it assumes a topology root, and answers a
+  # group or a worker as though it had no groups. Pulsar.Producer resolves the kind before
+  # calling, and anything else should use groups/1.
+  @doc false
   @spec routing(pid()) :: {[{non_neg_integer(), pid() | :restarting | :undefined}], Hash.scheme() | nil}
   def routing(root) do
     children = supervisor_children(root)
@@ -434,9 +433,14 @@ defmodule Pulsar.Topology do
   defp resource_kind_for_config(_config), do: :unknown
 
   # Carried on the child id so routing reads it from the same which_children the groups come
-  # from, keeping a send to one call.
+  # from, keeping a send to one call. The registry value would be the usual place for this, but
+  # it cannot serve every caller: Producer.send/3 takes a pid without consulting the registry,
+  # and a producer started with start_link_unregistered/1 has none.
+  #
+  # nil where a resource does not route on a key, and for a producer whose options have not been
+  # through Producer.Options; Hash.partition/3 resolves it to the default.
   defp hashing_scheme_for_config(%{count_key: :producer_count, opts: opts}) do
-    Keyword.get(opts, :hashing_scheme, Hash.default_scheme())
+    Keyword.get(opts, :hashing_scheme)
   end
 
   defp hashing_scheme_for_config(_config), do: nil

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -434,7 +434,7 @@ defmodule Pulsar.Topology do
   defp resource_kind_for_config(_config), do: :unknown
 
   # Carried on the child id so routing reads it from the same which_children the groups come
-  # from, keeping a send to one call. Only a producer routes on a key; anything else has none.
+  # from, keeping a send to one call.
   defp hashing_scheme_for_config(%{count_key: :producer_count, opts: opts}) do
     Keyword.get(opts, :hashing_scheme, Hash.default_scheme())
   end

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -7,6 +7,7 @@ defmodule Pulsar.Topology do
 
   alias Pulsar.Backoff
   alias Pulsar.Consumer.Worker, as: ConsumerWorker
+  alias Pulsar.Hash
   alias Pulsar.Producer.Worker, as: ProducerWorker
   alias Pulsar.Topic
   alias Pulsar.Topology.Discovery
@@ -200,7 +201,7 @@ defmodule Pulsar.Topology do
     root
     |> supervisor_children()
     |> Enum.find_value({:error, :not_found}, fn
-      {{Discovery, _kind, _topic}, pid, :worker, [Discovery]} when is_pid(pid) -> {:ok, pid}
+      {{Discovery, _kind, _topic, _scheme}, pid, :worker, [Discovery]} when is_pid(pid) -> {:ok, pid}
       _child -> false
     end)
   end
@@ -211,7 +212,7 @@ defmodule Pulsar.Topology do
     root
     |> supervisor_children()
     |> Enum.find_value({:error, :not_found}, fn
-      {{Discovery, _kind, topic}, _pid, :worker, [Discovery]} -> topic
+      {{Discovery, _kind, topic, _scheme}, _pid, :worker, [Discovery]} -> topic
       _child -> false
     end)
   end
@@ -226,7 +227,7 @@ defmodule Pulsar.Topology do
     root
     |> supervisor_children()
     |> Enum.find_value(:unknown, fn
-      {{Discovery, kind, _topic}, _pid, :worker, [Discovery]} -> kind
+      {{Discovery, kind, _topic, _scheme}, _pid, :worker, [Discovery]} -> kind
       _child -> false
     end)
   end
@@ -278,13 +279,35 @@ defmodule Pulsar.Topology do
     end
   end
 
-  defp topology_groups(root) do
-    root
-    |> supervisor_children()
-    |> Enum.flat_map(fn
+  @doc """
+  Returns a topology root's groups together with the hashing scheme its resource was configured
+  with, from a single traversal of its children.
+
+  For a producer, which needs both to route a keyed message and would otherwise pay a second
+  call per send. Takes a root; `groups/1` covers the other levels. The scheme is `nil` for a
+  resource that does not route on a key.
+  """
+  @spec routing(pid()) :: {[{non_neg_integer(), pid() | :restarting | :undefined}], Hash.scheme() | nil}
+  def routing(root) do
+    children = supervisor_children(root)
+
+    {groups_from(children), hashing_scheme_from(children)}
+  end
+
+  defp topology_groups(root), do: root |> supervisor_children() |> groups_from()
+
+  defp groups_from(children) do
+    Enum.flat_map(children, fn
       {{:topic, :non_partitioned}, pid, :supervisor, _modules} -> [{0, pid}]
       {{:partition, index}, pid, :supervisor, _modules} -> [{index, pid}]
       _child -> []
+    end)
+  end
+
+  defp hashing_scheme_from(children) do
+    Enum.find_value(children, fn
+      {{Discovery, _kind, _topic, scheme}, _pid, :worker, [Discovery]} -> scheme
+      _child -> false
     end)
   end
 
@@ -384,7 +407,7 @@ defmodule Pulsar.Topology do
     discovery =
       {self(), config, controller_opts}
       |> Discovery.child_spec()
-      |> Map.put(:id, {Discovery, resource_kind_for_config(config), topic})
+      |> Map.put(:id, {Discovery, resource_kind_for_config(config), topic, hashing_scheme_for_config(config)})
 
     # Companions start before discovery so a worker never observes the tree without them. They
     # resolve their own brokers asynchronously, so none of them delays this root coming up.
@@ -409,6 +432,14 @@ defmodule Pulsar.Topology do
   defp resource_kind_for_config(%{count_key: :consumer_count}), do: :consumers
   defp resource_kind_for_config(%{count_key: :producer_count}), do: :producers
   defp resource_kind_for_config(_config), do: :unknown
+
+  # Carried on the child id so routing reads it from the same which_children the groups come
+  # from, keeping a send to one call. Only a producer routes on a key; anything else has none.
+  defp hashing_scheme_for_config(%{count_key: :producer_count, opts: opts}) do
+    Keyword.get(opts, :hashing_scheme, Hash.default_scheme())
+  end
+
+  defp hashing_scheme_for_config(_config), do: nil
 
   @doc false
   @spec reconcile(pid(), non_neg_integer(), map()) ::

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -283,8 +283,7 @@ defmodule Pulsar.Topology do
   # to route a keyed message and would otherwise pay a second call per send.
   #
   # Unlike groups/1 this does not dispatch on kind/1: it assumes a topology root, and answers a
-  # group or a worker as though it had no groups. Pulsar.Producer resolves the kind before
-  # calling, and anything else should use groups/1.
+  # group or a worker as though it had no groups. Use groups/1 for anything else.
   @doc false
   @spec routing(pid()) :: {[{non_neg_integer(), pid() | :restarting | :undefined}], Hash.scheme() | nil}
   def routing(root) do

--- a/test/unit/hash_test.exs
+++ b/test/unit/hash_test.exs
@@ -1,19 +1,18 @@
 defmodule Pulsar.HashTest do
   use ExUnit.Case, async: true
 
+  import Bitwise
+
   alias Pulsar.Hash
 
-  # The point of these schemes is that a key routes to the same partition whichever client
-  # published it, so the vectors below are lifted verbatim from the other clients' own suites
-  # rather than generated here. Both sources are pinned to a tag, so re-checking them years
-  # from now compares against the same text this was written from.
+  # A key must route to the same partition whichever client published it, so these vectors are
+  # lifted verbatim from the other clients' suites rather than generated here.
   #
   #   Java  https://github.com/apache/pulsar/blob/v4.2.4/
   #         pulsar-client/src/test/java/org/apache/pulsar/client/impl/HashTest.java
   #   Go    https://github.com/apache/pulsar-client-go/blob/v0.21.0/pulsar/internal/hash_test.go
   #
-  # The Java vectors are themselves annotated "Same value as C++ client", so they pin three
-  # implementations at once.
+  # Upstream annotates the Java vectors "Same value as C++ client".
 
   @java_murmur3_vectors [
     {"k1", 2_110_152_746},
@@ -24,8 +23,7 @@ defmodule Pulsar.HashTest do
     {"key02", 751_761_803}
   ]
 
-  # key1 overflows hashCode() as an unsigned int32; key2 is negative as a signed int32. Both
-  # are deliberate upstream edge cases for the masking.
+  # key1 overflows hashCode() as an unsigned int32, key2 is negative as a signed int32.
   @java_string_vectors [
     {"keykeykeykeykey1", 434_058_482},
     {"keykeykey2", 42_978_643}
@@ -33,6 +31,16 @@ defmodule Pulsar.HashTest do
 
   @go_murmur3_vectors [{"", 0x0}, {"hello", 0x248BFA47}, {"test", 0x3A6BD213}]
   @go_string_vectors [{"", 0x0}, {"hello", 0x5E918D2}, {"test", 0x364492}]
+
+  # Every key above is 0, 1 or 2 bytes past a 4-byte block, leaving the 3-byte tail branch
+  # unexercised. These are the canonical MurmurHash3 x86_32 seed-0 vectors, masked as Pulsar
+  # masks them, and "abc" is the one that reaches it.
+  @canonical_murmur3_vectors [
+    {"a", 0x3C2569B2},
+    {"ab", 0x9BBFD75F},
+    {"abc", 0xB3DD93FA},
+    {"abcd", 0x43ED676A}
+  ]
 
   describe "murmur3_32/1" do
     test "matches the Java client's Murmur3Hash32 vectors" do
@@ -52,9 +60,9 @@ defmodule Pulsar.HashTest do
       assert Hash.murmur3_32("€") == Hash.murmur3_32(<<0xE2, 0x82, 0xAC>>)
     end
 
-    test "covers every tail length" do
-      for length <- 0..8 do
-        assert Hash.murmur3_32(String.duplicate("k", length)) in 0..0x7FFFFFFF
+    test "matches the canonical vectors, which reach the 3-byte tail the others miss" do
+      for {key, raw} <- @canonical_murmur3_vectors do
+        assert Hash.murmur3_32(key) == band(raw, 0x7FFFFFFF)
       end
     end
   end
@@ -108,25 +116,17 @@ defmodule Pulsar.HashTest do
       end
     end
 
-    # phash2/2 takes its range directly and is not a rem/2 over phash2/1, so it cannot share
-    # the reduction the Pulsar schemes use. This is the whole reason partition/3 owns it.
-    test "differs from a rem/2 over the unranged hash, which is why it is not reduced like the others" do
+    test "cannot be reduced like the Pulsar schemes, since phash2/2 is not a rem/2 over phash2/1" do
       assert Enum.any?(0..200, fn candidate ->
                key = "key-#{candidate}"
                :erlang.phash2(key, 7) != rem(:erlang.phash2(key), 7)
              end)
     end
-
-    test "is not interoperable, and so is not the default" do
-      assert Hash.default_scheme() != :phash2_legacy
-      assert :phash2_legacy in Hash.schemes()
-    end
   end
 
   describe "default_scheme/0" do
-    test "is murmur3_32, which every Pulsar client implements identically" do
+    test "is the interoperable scheme, not the legacy one" do
       assert Hash.default_scheme() == :murmur3_32
-      assert Hash.default_scheme() in Hash.schemes()
     end
   end
 end

--- a/test/unit/hash_test.exs
+++ b/test/unit/hash_test.exs
@@ -108,20 +108,20 @@ defmodule Pulsar.HashTest do
       end
     end
 
-    # A key that routes under one scheme must route under all of them, or changing the option
-    # would change which keys are publishable, and :phash2_legacy would accept keys that stop
-    # working on the switch to :murmur3_32 it exists to migrate towards.
+    # :erlang.phash2/2 accepts any term, so without this :phash2_legacy would keep routing atom
+    # keys that stop working on the switch to :murmur3_32 it exists to migrate towards.
     test "rejects a non-binary key under every scheme" do
       for scheme <- Hash.schemes(), key <- [:tenant_a, 123, {:a, 1}, nil] do
         assert_raise ArgumentError, ~r/:partition_key/, fn -> Hash.partition(scheme, key, 8) end
       end
     end
 
-    test "rejects a key that is not valid UTF-8 under every scheme" do
-      for scheme <- Hash.schemes() do
-        assert_raise ArgumentError, ~r/:partition_key/, fn ->
-          Hash.partition(scheme, <<0xFF, 0xFE>>, 8)
-        end
+    # Encoding is deliberately not checked here. murmur3 and phash2 hash bytes, so validating
+    # UTF-8 would cost a scan of the key on every send to reject something the send rejects
+    # anyway at partition_key's string field.
+    test "routes a key that is not valid UTF-8 under the byte-oriented schemes" do
+      for scheme <- [:murmur3_32, :phash2_legacy] do
+        assert Hash.partition(scheme, <<0xFF, 0xFE>>, 8) in 0..7
       end
     end
   end

--- a/test/unit/hash_test.exs
+++ b/test/unit/hash_test.exs
@@ -107,6 +107,23 @@ defmodule Pulsar.HashTest do
         assert Hash.partition(scheme, key, partitions) in 0..(partitions - 1)
       end
     end
+
+    # A key that routes under one scheme must route under all of them, or changing the option
+    # would change which keys are publishable, and :phash2_legacy would accept keys that stop
+    # working on the switch to :murmur3_32 it exists to migrate towards.
+    test "rejects a non-binary key under every scheme" do
+      for scheme <- Hash.schemes(), key <- [:tenant_a, 123, {:a, 1}, nil] do
+        assert_raise ArgumentError, ~r/:partition_key/, fn -> Hash.partition(scheme, key, 8) end
+      end
+    end
+
+    test "rejects a key that is not valid UTF-8 under every scheme" do
+      for scheme <- Hash.schemes() do
+        assert_raise ArgumentError, ~r/:partition_key/, fn ->
+          Hash.partition(scheme, <<0xFF, 0xFE>>, 8)
+        end
+      end
+    end
   end
 
   describe "partition/3 with :phash2_legacy" do

--- a/test/unit/hash_test.exs
+++ b/test/unit/hash_test.exs
@@ -1,0 +1,132 @@
+defmodule Pulsar.HashTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Hash
+
+  # The point of these schemes is that a key routes to the same partition whichever client
+  # published it, so the vectors below are lifted verbatim from the other clients' own suites
+  # rather than generated here. Both sources are pinned to a tag, so re-checking them years
+  # from now compares against the same text this was written from.
+  #
+  #   Java  https://github.com/apache/pulsar/blob/v4.2.4/
+  #         pulsar-client/src/test/java/org/apache/pulsar/client/impl/HashTest.java
+  #   Go    https://github.com/apache/pulsar-client-go/blob/v0.21.0/pulsar/internal/hash_test.go
+  #
+  # The Java vectors are themselves annotated "Same value as C++ client", so they pin three
+  # implementations at once.
+
+  @java_murmur3_vectors [
+    {"k1", 2_110_152_746},
+    {"k2", 1_479_966_664},
+    {"key1", 462_881_061},
+    {"key2", 1_936_800_180},
+    {"key01", 39_696_932},
+    {"key02", 751_761_803}
+  ]
+
+  # key1 overflows hashCode() as an unsigned int32; key2 is negative as a signed int32. Both
+  # are deliberate upstream edge cases for the masking.
+  @java_string_vectors [
+    {"keykeykeykeykey1", 434_058_482},
+    {"keykeykey2", 42_978_643}
+  ]
+
+  @go_murmur3_vectors [{"", 0x0}, {"hello", 0x248BFA47}, {"test", 0x3A6BD213}]
+  @go_string_vectors [{"", 0x0}, {"hello", 0x5E918D2}, {"test", 0x364492}]
+
+  describe "murmur3_32/1" do
+    test "matches the Java client's Murmur3Hash32 vectors" do
+      for {key, expected} <- @java_murmur3_vectors do
+        assert Hash.murmur3_32(key) == expected
+      end
+    end
+
+    test "matches the Go client's Murmur3_32Hash vectors" do
+      for {key, expected} <- @go_murmur3_vectors do
+        assert Hash.murmur3_32(key) == expected
+      end
+    end
+
+    test "hashes the UTF-8 bytes of a key" do
+      assert Hash.murmur3_32("é") == Hash.murmur3_32(<<0xC3, 0xA9>>)
+      assert Hash.murmur3_32("€") == Hash.murmur3_32(<<0xE2, 0x82, 0xAC>>)
+    end
+
+    test "covers every tail length" do
+      for length <- 0..8 do
+        assert Hash.murmur3_32(String.duplicate("k", length)) in 0..0x7FFFFFFF
+      end
+    end
+  end
+
+  describe "java_string_hash/1" do
+    test "matches the Java client's JavaStringHash vectors" do
+      for {key, expected} <- @java_string_vectors do
+        assert Hash.java_string_hash(key) == expected
+      end
+    end
+
+    test "matches the Go client's JavaStringHash vectors" do
+      for {key, expected} <- @go_string_vectors do
+        assert Hash.java_string_hash(key) == expected
+      end
+    end
+
+    test "hashes a key outside the basic multilingual plane over its surrogate pair" do
+      # U+1D11E encodes to UTF-16 as 0xD834 0xDD1E, which Java folds as 31 * 0xD834 + 0xDD1E.
+      assert Hash.java_string_hash("𝄞") == 31 * 0xD834 + 0xDD1E
+    end
+
+    test "rejects a key that is not valid UTF-8" do
+      assert_raise ArgumentError, fn -> Hash.java_string_hash(<<0xFF, 0xFE>>) end
+    end
+  end
+
+  describe "partition/3" do
+    test "reduces a Pulsar scheme with signSafeMod" do
+      assert Hash.partition(:murmur3_32, "tenant-1", 8) == rem(Hash.murmur3_32("tenant-1"), 8)
+      assert Hash.partition(:java_string_hash, "tenant-1", 8) == rem(Hash.java_string_hash("tenant-1"), 8)
+    end
+
+    test "falls back to the default scheme when a resource carries none" do
+      assert Hash.partition(nil, "tenant-1", 8) == Hash.partition(Hash.default_scheme(), "tenant-1", 8)
+    end
+
+    test "answers a partition in range for every scheme" do
+      for scheme <- Hash.schemes(),
+          key <- ["", "tenant-1", "é", String.duplicate("k", 100)],
+          partitions <- [1, 2, 3, 8, 64] do
+        assert Hash.partition(scheme, key, partitions) in 0..(partitions - 1)
+      end
+    end
+  end
+
+  describe "partition/3 with :phash2_legacy" do
+    test "reproduces the pre-3.0 routing exactly" do
+      for key <- ["", "tenant-1", "key-7"], partitions <- [2, 3, 5, 8] do
+        assert Hash.partition(:phash2_legacy, key, partitions) == :erlang.phash2(key, partitions)
+      end
+    end
+
+    # phash2/2 takes its range directly and is not a rem/2 over phash2/1, so it cannot share
+    # the reduction the Pulsar schemes use. This is the whole reason partition/3 owns it.
+    test "differs from a rem/2 over the unranged hash, which is why it is not reduced like the others" do
+      assert Enum.any?(0..200, fn candidate ->
+               key = "key-#{candidate}"
+               :erlang.phash2(key, 7) != rem(:erlang.phash2(key), 7)
+             end)
+    end
+
+    test "is not interoperable, and so is not the default" do
+      assert Hash.default_scheme() != :phash2_legacy
+      assert :phash2_legacy in Hash.schemes()
+    end
+  end
+
+  describe "default_scheme/0" do
+    test "is murmur3_32, which every Pulsar client implements identically" do
+      assert Hash.default_scheme() == :murmur3_32
+      assert Hash.default_scheme() in Hash.schemes()
+    end
+  end
+end

--- a/test/unit/hash_test.exs
+++ b/test/unit/hash_test.exs
@@ -116,9 +116,8 @@ defmodule Pulsar.HashTest do
       end
     end
 
-    # Encoding is deliberately not checked here. murmur3 and phash2 hash bytes, so validating
-    # UTF-8 would cost a scan of the key on every send to reject something the send rejects
-    # anyway at partition_key's string field.
+    # murmur3 and phash2 hash bytes, so checking UTF-8 would cost a scan per send to reject
+    # what partition_key's string field rejects anyway.
     test "routes a key that is not valid UTF-8 under the byte-oriented schemes" do
       for scheme <- [:murmur3_32, :phash2_legacy] do
         assert Hash.partition(scheme, <<0xFF, 0xFE>>, 8) in 0..7

--- a/test/unit/producer_options_test.exs
+++ b/test/unit/producer_options_test.exs
@@ -16,6 +16,19 @@ defmodule Pulsar.Producer.OptionsTest do
       assert opts[:access_mode] == :shared
       assert opts[:compression] == :none
       assert opts[:batch_enabled] == false
+      assert opts[:hashing_scheme] == :murmur3_32
+    end
+
+    test "accepts every hashing scheme" do
+      for scheme <- Pulsar.Hash.schemes() do
+        assert validate!(hashing_scheme: scheme)[:hashing_scheme] == scheme
+      end
+    end
+
+    test "rejects an unknown hashing scheme rather than falling back to the default" do
+      assert_raise NimbleOptions.ValidationError, ~r/:hashing_scheme/, fn ->
+        validate!(hashing_scheme: :murmur2)
+      end
     end
 
     test "defaults the startup delays and partition discovery" do

--- a/test/unit/producer_test.exs
+++ b/test/unit/producer_test.exs
@@ -123,6 +123,15 @@ defmodule Pulsar.ProducerTest do
                  {:ok, :erlang.phash2(key, 8)}
       end
     end
+
+    test "raises on a non-binary key rather than reporting it as a dead producer" do
+      root = start_routing_topology()
+      start_partitions(root, 8)
+
+      assert_raise ArgumentError, ~r/:partition_key must be a binary/, fn ->
+        Producer.send(root, "payload", partition_key: :tenant_a)
+      end
+    end
   end
 
   defp send_message(module, producer, message), do: module.send(producer, message, [])

--- a/test/unit/producer_test.exs
+++ b/test/unit/producer_test.exs
@@ -123,22 +123,6 @@ defmodule Pulsar.ProducerTest do
                  {:ok, :erlang.phash2(key, 8)}
       end
     end
-
-    test "sends the same key to different partitions under the two schemes" do
-      murmur3 = start_routing_topology()
-      java = start_routing_topology(hashing_scheme: :java_string_hash)
-
-      start_partitions(murmur3, 8)
-      start_partitions(java, 8)
-
-      # Guards against both schemes silently resolving to one implementation.
-      assert Enum.any?(0..20, fn candidate ->
-               key = "key-#{candidate}"
-
-               Producer.send(murmur3, "payload", partition_key: key) !=
-                 Producer.send(java, "payload", partition_key: key)
-             end)
-    end
   end
 
   defp send_message(module, producer, message), do: module.send(producer, message, [])

--- a/test/unit/producer_test.exs
+++ b/test/unit/producer_test.exs
@@ -1,6 +1,7 @@
 defmodule Pulsar.ProducerTest do
   use ExUnit.Case, async: true
 
+  alias Pulsar.Hash
   alias Pulsar.Producer
   alias Pulsar.Topology
   alias Pulsar.Topology.Group
@@ -76,15 +77,67 @@ defmodule Pulsar.ProducerTest do
         assert {:ok, _group} = Supervisor.start_child(root, routing_group_spec(index))
       end
 
-      partition_key = key_for_partition(4, 5)
+      partition_key = key_for_partition(4, 5, :murmur3_32)
 
       assert Producer.send(root, "payload", partition_key: partition_key) ==
-               {:ok, :erlang.phash2(partition_key, 4)}
+               {:ok, partition_for(partition_key, 4, :murmur3_32)}
 
       assert {:ok, _group} = Supervisor.start_child(root, routing_group_spec(4))
 
       assert Producer.send(root, "payload", partition_key: partition_key) ==
-               {:ok, :erlang.phash2(partition_key, 6)}
+               {:ok, partition_for(partition_key, 6, :murmur3_32)}
+    end
+
+    test "routes a key under murmur3_32 by default" do
+      root = start_routing_topology()
+      start_partitions(root, 8)
+
+      for candidate <- 0..20 do
+        key = "key-#{candidate}"
+
+        assert Producer.send(root, "payload", partition_key: key) ==
+                 {:ok, partition_for(key, 8, :murmur3_32)}
+      end
+    end
+
+    test "routes a key under the configured hashing scheme" do
+      root = start_routing_topology(hashing_scheme: :java_string_hash)
+      start_partitions(root, 8)
+
+      for candidate <- 0..20 do
+        key = "key-#{candidate}"
+
+        assert Producer.send(root, "payload", partition_key: key) ==
+                 {:ok, partition_for(key, 8, :java_string_hash)}
+      end
+    end
+
+    test "routes a key exactly as 2.x did under :phash2_legacy" do
+      root = start_routing_topology(hashing_scheme: :phash2_legacy)
+      start_partitions(root, 8)
+
+      for candidate <- 0..20 do
+        key = "key-#{candidate}"
+
+        assert Producer.send(root, "payload", partition_key: key) ==
+                 {:ok, :erlang.phash2(key, 8)}
+      end
+    end
+
+    test "sends the same key to different partitions under the two schemes" do
+      murmur3 = start_routing_topology()
+      java = start_routing_topology(hashing_scheme: :java_string_hash)
+
+      start_partitions(murmur3, 8)
+      start_partitions(java, 8)
+
+      # Guards against both schemes silently resolving to one implementation.
+      assert Enum.any?(0..20, fn candidate ->
+               key = "key-#{candidate}"
+
+               Producer.send(murmur3, "payload", partition_key: key) !=
+                 Producer.send(java, "payload", partition_key: key)
+             end)
     end
   end
 
@@ -108,7 +161,7 @@ defmodule Pulsar.ProducerTest do
     pid
   end
 
-  defp start_routing_topology do
+  defp start_routing_topology(extra_opts \\ []) do
     test_pid = self()
     registry = :"producer-routing-registry-#{System.unique_integer([:positive])}"
     start_supervised!({Registry, keys: :unique, name: registry})
@@ -121,13 +174,17 @@ defmodule Pulsar.ProducerTest do
       end
     end
 
-    opts = [
-      topic: "persistent://public/default/routing",
-      name: "routing-producer",
-      client: :test,
-      producer_count: 1,
-      partition_discovery_interval_ms: false
-    ]
+    opts =
+      Keyword.merge(
+        [
+          topic: "persistent://public/default/routing",
+          name: "routing-producer",
+          client: :test,
+          producer_count: 1,
+          partition_discovery_interval_ms: false
+        ],
+        extra_opts
+      )
 
     root =
       start_supervised!(%{
@@ -156,12 +213,20 @@ defmodule Pulsar.ProducerTest do
     }
   end
 
-  defp key_for_partition(partition, partitions) do
+  defp start_partitions(root, count) do
+    for index <- 0..(count - 1) do
+      assert {:ok, _group} = Supervisor.start_child(root, routing_group_spec(index))
+    end
+  end
+
+  defp partition_for(key, partitions, scheme), do: Hash.partition(scheme, key, partitions)
+
+  defp key_for_partition(partition, partitions, scheme) do
     0
     |> Stream.iterate(&(&1 + 1))
     |> Enum.find_value(fn candidate ->
       key = "key-#{candidate}"
-      if :erlang.phash2(key, partitions) == partition, do: key
+      if partition_for(key, partitions, scheme) == partition, do: key
     end)
   end
 end


### PR DESCRIPTION
## Summary

Partition routing hashes a message's `:partition_key` with a scheme Pulsar actually defines, instead of `:erlang.phash2/2`. `:murmur3_32` is the default, `:hashing_scheme` selects `:java_string_hash` instead, and `:phash2_legacy` reproduces the old routing for the duration of an upgrade.

This changes which partition an existing key lands on, so it belongs in 3.0 alongside the other breaks rather than costing users a second migration later.

## Motivation

`select_partition/2` reduced the key with `:erlang.phash2(partition_key, partitions)` (`producer.ex:217`, before this change). No Pulsar client implements that function, and none can: it is an Erlang term hash, not one of the two schemes the protocol's clients agree on.

The consequence is that a key does not co-locate across languages. A Java, Go, C++ or Python producer sending `"tenant-1"` to a partitioned topic picks one partition; this client picks an unrelated one. Both are internally consistent, which is why it goes unnoticed, and both are publishing to the same topic, which is why it matters: **per-key ordering silently does not hold on any topic written to from more than one client.** A `:key_shared` subscriber sees a key's messages interleaved across partitions with no ordering guarantee between them, and per-key compaction operates on a split key.

Two things made this durable rather than obvious:

1. **The suite asserted the bug.** `producer_test.exs:82`, `:87` and `:164` computed their expected partition with `:erlang.phash2/2`, so routing was pinned to whatever the implementation did rather than to what Pulsar specifies. Any test written this way passes by construction.
2. **Nothing fails.** There is no error, no log line and no broker rejection. The messages arrive; only their placement is wrong, and only relative to a producer written in another language.

## The schemes

| Scheme | Hash | Interoperable | Notes |
| --- | --- | --- | --- |
| `:murmur3_32` | MurmurHash3 x86_32, seed 0, masked with `Integer.MAX_VALUE`, over UTF-8 bytes | Yes, with every client | Default |
| `:java_string_hash` | Java `String.hashCode()`, masked, over UTF-16 code units | Yes, with every client | What Java and Go use at *their* default |
| `:phash2_legacy` | `:erlang.phash2/2` | **No** | Pre-3.0 routing, for migration only |

`Pulsar.Hash.partition/3` (`hash.ex:56`) owns the reduction to a partition index rather than leaving it to the caller, because the schemes do not agree on it. The two Pulsar schemes mask the sign bit and take Pulsar's `signSafeMod`, so a plain `rem/2` is correct. `:erlang.phash2/2` takes its range as an argument and **is not equivalent to a `rem/2` over `:erlang.phash2/1`** — measured over 16,008 key/partition pairs, the two disagree in 4,642 of them, about 29%. Routing the legacy scheme through the other schemes' reduction would therefore not have reproduced 2.x behaviour, defeating the only reason the option exists.

## Where the scheme comes from at send time

`:hashing_scheme` is producer configuration, but `Pulsar.Producer.route/4` only ever held the group list. The send path already makes one `Supervisor.which_children/1` call through `Topology.groups/1`, so the scheme rides on the `Discovery` child id (`topology.ex:410`) and `Topology.routing/1` (`topology.ex:291`) returns both from that single traversal. A send costs the same one call it did before.

This follows what the id already does: `kind` and `topic` live there and are read back by `Topology.topic/1` and `resource_kind/1`. The scheme is `nil` for any resource that does not route on a key, which `partition/3` resolves to the default.

## Verification

The point of these schemes is cross-client agreement, so the vectors are lifted verbatim from the other clients' own suites rather than generated here, and both sources are pinned to a tag.

| Source | Vectors | Result |
| --- | --- | --- |
| [`HashTest.java`](https://github.com/apache/pulsar/blob/v4.2.4/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HashTest.java) @ `v4.2.4` | 6 murmur3, 2 java-string | all match |
| [`hash_test.go`](https://github.com/apache/pulsar-client-go/blob/v0.21.0/pulsar/internal/hash_test.go) @ `v0.21.0` | 3 murmur3, 3 java-string | all match |

Upstream annotates the Java vectors "Same value as C++ client", so they pin three implementations at once. The Java tag is the broker version the integration suite already runs against (#174).

Those 14 vectors leave one hole: every key in them is 0, 1 or 2 bytes past a 4-byte block, so the 3-byte tail branch (`hash.ex:94`) is unexercised. The canonical MurmurHash3 seed-0 vectors cover it, `"abc"` being the case that reaches it. Confirmed by mutation — swapping the byte order in that branch fails exactly one test and nothing else. These four are the widely published values rather than upstream's, so they carry weaker provenance than the 14 above and are labelled as such in the file.

## Why `:murmur3_32` is the default, when Java and Go default to `:java_string_hash`

Matching Java's default would make an Elixir producer co-locate with an unconfigured Java one, which is the narrower win it appears to be. Apache's own guidance is that `JavaStringHash` "is not useful when producers can be from different multiple language clients, under this use case, it is recommended to use `Murmur3_32Hash`" ([concepts-messaging](https://pulsar.apache.org/docs/next/concepts-messaging/)). An Elixir producer sharing a topic is *always* that case — the other producer is by definition not this client.

`:java_string_hash` remains a one-line option for anyone whose topic is shared specifically with unconfigured Java or Go producers.

## Breaking changes and migration

There are two, and only the first affects anyone whose keys already worked.

### 1. Keyed messages on a partitioned topic route to a different partition

Non-partitioned topics, keyless messages, and the `:partition_key` carried in the message for `:key_shared` are all unaffected.

The risk is confined to the transition. A key's ordering is only preserved once its old partition has drained, since messages published before the upgrade sit on the old partition while new ones go to the new one.

| Situation | Action |
| --- | --- |
| Non-partitioned topics only | None |
| Partitioned, no `:partition_key` in use | None |
| Partitioned, keys in use, ordering not depended on | None; keys redistribute once |
| Partitioned, keys in use, per-key ordering depended on | Set `hashing_scheme: :phash2_legacy`, upgrade, drain, then switch to `:murmur3_32` |

```elixir
# Preserve pre-3.0 routing through the upgrade, then remove this.
Pulsar.Producer.start(topic, hashing_scheme: :phash2_legacy)
```

`:phash2_legacy` is documented as migration-only and is not a peer of the other two. An unrecognised value fails at startup with a `NimbleOptions.ValidationError` listing what is accepted, so a typo does not fall back to a default silently.

### 2. `:partition_key` must be a binary

`:erlang.phash2/2` accepts any term, so `partition_key: :tenant_a` used to route. It never published: `partition_key` is a `string` on the wire, so a non-binary key fails protobuf encoding, with the producer worker crashing after routing had already succeeded. This legitimises nothing that worked — it moves the failure to an `ArgumentError` at the call site, naming the option.

Every scheme rejects the same keys, which matters for the migration above: were `:phash2_legacy` alone to keep accepting atom keys, it would hand back a cliff at the very step it exists to make safe.

Encoding is deliberately *not* checked. `:murmur3_32` and `:phash2_legacy` hash bytes, so validating UTF-8 would cost a scan of the key on every keyed send — measured at 73% of the routing call — to reject something the send rejects anyway at `partition_key`'s string field. `:java_string_hash` still raises on invalid UTF-8, since it has to decode the key to UTF-16 regardless and gets the check for free.

## Follow-ups

The producer audit that turned this up found several more issues, all independent of this change and all worth landing before 3.0 since two of them are breaking:

- **Batched sends reuse sequence ids.** A flush stores back the batch's first sequence id rather than its highest, so the next batch overlaps the previous one's range, and `CommandSend.highest_sequence_id` is never set. On a topic with deduplication enabled the broker drops every batch after the first as a duplicate, and callers time out with no receipt.
- **`CommandProducerSuccess.last_sequence_id` is ignored.** A restarted producer with a stable name resumes at 1, so a dedup-enabled topic rejects everything until it passes the old high-water mark. Small change, since `Pulsar.Producer.EpochStore` already establishes the pattern for restoring producer state across restarts.
- **`pending_sends` is unbounded and never reaped.** No send timeout, no `max_pending_messages`, and `terminate/2` replies to the batch but not to in-flight single sends, so a broker crash leaves every caller blocked to its own timeout. The consumer side already has the equivalent controls.
- **Chunking is not wire-compatible.** Chunks are compressed individually where Java compresses then splits, `total_chunk_msg_size` is the uncompressed total, `is_chunk` is never set, and the broker's `max_message_size` from `CommandConnected` is ignored in favour of a hardcoded 5 MiB. Elixir-to-Elixir round-trips, which is why it has held up so far.
- **Batching silently drops options.** `deliver_at_time`/`deliver_after` and `chunking_enabled` are ignored on the batch path, and a batch carries no entry-level `partition_key`, so batching plus `:key_shared` has no ordering guarantee. Java solves the last one with a key-based batch container.
- **Inconsistent error taxonomy.** `send/3` documents `{:error, :not_ready}` but the worker returns `{:error, :producer_waiting}`. Normalising it is breaking, so 3.0 is the window.

Keyless routing also uses `Enum.random/1` where Java uses a sticky round-robin per batching window, which fragments batches across partition workers. That one is additive and can land after 3.0.
