### PR TITLE
fix(chunking)!: chunked messages are not wire-compatible

### DIFF
--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -45,6 +45,14 @@ than being compressed on its own. This is how the Java client frames chunks, so 
 chunked message can cross between the two. It also means a payload that compresses to under
 `max_message_size` is sent whole and never chunked.
 
+> #### `is_chunk` is not visible to consumers {: .info}
+>
+> The producer sets `is_chunk` on the `CommandSend` that carries each chunk, which tells the
+> broker the entry is part of a larger message. It is a field of `CommandSend` only: the broker
+> does not relay it, and the `CommandMessage` a consumer receives has no equivalent. A consumer
+> recognises a chunk from the message metadata instead — a `uuid` together with a `chunk_id` —
+> which is what `Pulsar.Message.chunked?/1` reports.
+
 ### Consumer Side
 
 The consumer automatically handles chunk assembly:
@@ -149,7 +157,10 @@ Chunks may not complete for several reasons:
 1. **Expiration**: Not all chunks arrived within the timeout period
 2. **Queue overflow**: Too many concurrent chunked messages
 
-Incomplete chunks are delivered to your callback with `complete: false`:
+Incomplete chunks are delivered to your callback with `complete: false`. Their `payload` is
+whatever chunks did arrive, concatenated, and under `:compression` those are still compressed:
+a message only decompresses once all of its chunks are back together, so a partial one cannot
+be decompressed at all. Treat the payload of an incomplete message as opaque.
 
 ```elixir
 def handle_message(%Pulsar.Message{chunk_metadata: %{complete: false, error: reason, received_chunks: n}}, state) do
@@ -242,9 +253,23 @@ end
 
 The consumer emits telemetry events for chunk lifecycle:
 
-- `[:pulsar, :consumer, :chunk, :received]` - When a chunk is received
-- `[:pulsar, :consumer, :chunk, :complete]` - When all chunks are assembled
-- `[:pulsar, :consumer, :chunk, :discarded]` - When a chunked message is discarded
-- `[:pulsar, :consumer, :chunk, :expired]` - When a chunked message expires
+| Event | Measurements | When |
+| --- | --- | --- |
+| `[:pulsar, :consumer, :chunk, :received]` | `chunk_id`, `num_chunks` | A chunk arrives |
+| `[:pulsar, :consumer, :chunk, :complete]` | `num_chunks`, `total_size`, `age_ms` | All chunks are assembled |
+| `[:pulsar, :consumer, :chunk, :discarded]` | `received_chunks`, `num_chunks` | A chunked message is evicted |
+| `[:pulsar, :consumer, :chunk, :expired]` | `age_ms`, `received_chunks`, `num_chunks` | A chunked message times out |
+
+Every consumer event carries `uuid`, `consumer_id`, `topic` and `subscription` as metadata, and
+the two that give up on a message also carry `reason`. `received_chunks` against `num_chunks`
+says how much of the message had arrived before it was dropped, and `age_ms` on `:complete` is
+how long assembly took, which is what `:expire_incomplete_chunked_message_after` should be set
+against.
+
+The producer emits `[:pulsar, :producer, :chunk, :start]`, `:sent` and `:complete`, all carrying
+`uuid`, `producer_id` and `topic`. Their `total_size` and `chunk_size` count the bytes actually
+sent, so with `:compression` set they describe the compressed message rather than the payload
+handed to `Pulsar.Producer.send/3`. On the consumer side `:complete`'s `total_size` is the
+reassembled message after decompression, so the two do not line up when compression is on.
 
 See the Telemetry documentation for more details on monitoring chunked messages.

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -33,17 +33,17 @@ When a producer is configured with chunking enabled:
 ```
 
 Large messages are automatically:
-1. Compressed as a whole, if `:compression` is set, and then split — so a chunk is a slice of
-   the compressed message rather than a separately compressed slice, which is what every other
-   Pulsar client expects on the wire
-2. Split into chunks of `max_message_size` bytes, capped so that a chunk plus the message
-   metadata that travels with it stays inside the limit the broker advertised at connect time
+1. Compressed as a whole, when `:compression` is set
+2. Split into chunks of `max_message_size` bytes, capped so that a chunk plus the metadata
+   travelling with it stays inside the limit the broker advertised at connect time
 3. Each chunk is assigned a unique UUID and sequence number
 4. Chunks are sent to the broker individually
 5. Each chunk consumes one flow control permit
 
-Because the split happens after compression, a payload that compresses to under
-`max_message_size` is sent as a single message and is never chunked at all.
+Compression runs before the split, so a chunk carries a slice of the compressed message rather
+than being compressed on its own. This is how the Java client frames chunks, so a compressed
+chunked message can cross between the two. It also means a payload that compresses to under
+`max_message_size` is sent whole and never chunked.
 
 ### Consumer Side
 

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -33,10 +33,17 @@ When a producer is configured with chunking enabled:
 ```
 
 Large messages are automatically:
-1. Split into chunks of `max_message_size` bytes
-2. Each chunk is assigned a unique UUID and sequence number
-3. Chunks are sent to the broker individually
-4. Each chunk consumes one flow control permit
+1. Compressed as a whole, if `:compression` is set, and then split — so a chunk is a slice of
+   the compressed message rather than a separately compressed slice, which is what every other
+   Pulsar client expects on the wire
+2. Split into chunks of `max_message_size` bytes, capped so that a chunk plus the message
+   metadata that travels with it stays inside the limit the broker advertised at connect time
+3. Each chunk is assigned a unique UUID and sequence number
+4. Chunks are sent to the broker individually
+5. Each chunk consumes one flow control permit
+
+Because the split happens after compression, a payload that compresses to under
+`max_message_size` is sent as a single message and is never chunked at all.
 
 ### Consumer Side
 
@@ -90,7 +97,10 @@ holding a list of protocol structs per chunk rather than a single one.
 
 > #### Warning {: .warning}
 >
-> Batching and chunking cannot be enabled simultaneously on a producer. When `chunking_enabled: true` is set, batching is automatically disabled. These features are mutually exclusive because they represent different strategies for message transmission.
+> Batching and chunking cannot be enabled simultaneously on a producer: a batch is one entry
+> holding many messages, and a chunked message is one message spread over many entries. Starting
+> a producer with both `batch_enabled: true` and `chunking_enabled: true` raises a validation
+> error rather than silently picking one.
 
 ### Producer Configuration
 

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -260,14 +260,16 @@ The consumer emits telemetry events for chunk lifecycle:
 | `[:pulsar, :consumer, :chunk, :discarded]` | `received_chunks`, `num_chunks` | A chunked message is evicted |
 | `[:pulsar, :consumer, :chunk, :expired]` | `age_ms`, `received_chunks`, `num_chunks` | A chunked message times out |
 
-Every consumer event carries `uuid`, `consumer_id`, `topic`, `base_topic`, `partition` and
-`subscription_name` as metadata, and the two that give up on a message also carry `reason`.
+Each of these carries `uuid` alongside the `topic`, `base_topic`, `partition`,
+`subscription_name` and `consumer_id` that every consumer event carries, and the two that give
+up on a message also carry `reason`.
 `received_chunks` against `num_chunks` says how much of the message had arrived before it was
 dropped, and `age_ms` on `:complete` is how long assembly took, which is what
 `:expire_incomplete_chunked_message_after` should be set against.
 
 The producer emits `[:pulsar, :producer, :chunk, :start]`, `:sent` and `:complete`, all carrying
-`uuid`, `producer_id`, `topic`, `base_topic` and `partition`. Their `total_size` and
+`uuid` alongside the `topic`, `base_topic`, `partition`, `producer_id` and `producer_name` that
+every producer event carries. Their `total_size` and
 `chunk_size` count the bytes actually sent, so with `:compression` set they describe the
 compressed message rather than the payload handed to `Pulsar.Producer.send/3`. On the consumer
 side `:complete`'s `total_size` is the reassembled message after decompression, so the two do

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -260,16 +260,21 @@ The consumer emits telemetry events for chunk lifecycle:
 | `[:pulsar, :consumer, :chunk, :discarded]` | `received_chunks`, `num_chunks` | A chunked message is evicted |
 | `[:pulsar, :consumer, :chunk, :expired]` | `age_ms`, `received_chunks`, `num_chunks` | A chunked message times out |
 
-Every consumer event carries `uuid`, `consumer_id`, `topic` and `subscription` as metadata, and
-the two that give up on a message also carry `reason`. `received_chunks` against `num_chunks`
-says how much of the message had arrived before it was dropped, and `age_ms` on `:complete` is
-how long assembly took, which is what `:expire_incomplete_chunked_message_after` should be set
-against.
+Every consumer event carries `uuid`, `consumer_id`, `topic`, `base_topic`, `partition` and
+`subscription_name` as metadata, and the two that give up on a message also carry `reason`.
+`received_chunks` against `num_chunks` says how much of the message had arrived before it was
+dropped, and `age_ms` on `:complete` is how long assembly took, which is what
+`:expire_incomplete_chunked_message_after` should be set against.
 
 The producer emits `[:pulsar, :producer, :chunk, :start]`, `:sent` and `:complete`, all carrying
-`uuid`, `producer_id` and `topic`. Their `total_size` and `chunk_size` count the bytes actually
-sent, so with `:compression` set they describe the compressed message rather than the payload
-handed to `Pulsar.Producer.send/3`. On the consumer side `:complete`'s `total_size` is the
-reassembled message after decompression, so the two do not line up when compression is on.
+`uuid`, `producer_id`, `topic`, `base_topic` and `partition`. Their `total_size` and
+`chunk_size` count the bytes actually sent, so with `:compression` set they describe the
+compressed message rather than the payload handed to `Pulsar.Producer.send/3`. On the consumer
+side `:complete`'s `total_size` is the reassembled message after decompression, so the two do
+not line up when compression is on.
+
+`:topic` names a single partition and `:base_topic` the topic it belongs to, so one set of
+events both aggregates over a partitioned topic and breaks down by partition. They are equal,
+and `:partition` is `nil`, when the topic is not partitioned.
 
 See the Telemetry documentation for more details on monitoring chunked messages.

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -180,7 +180,7 @@ defmodule Pulsar.Broker do
   Gets the largest message this broker accepts, as advertised in `CommandConnected`.
 
   `nil` until the handshake completes, and again after a reconnection until the new
-  connection has been handshaken.
+  connection has handshaken.
   """
   @spec get_max_message_size(GenServer.server()) :: pos_integer() | nil
   def get_max_message_size(broker), do: :gen_statem.call(broker, :get_max_message_size)

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -25,6 +25,7 @@ defmodule Pulsar.Broker do
     :conn_timeout,
     :auth,
     :max_frame_size,
+    :max_message_size,
     :ping_interval,
     :cleanup_interval,
     :request_timeout,
@@ -47,6 +48,7 @@ defmodule Pulsar.Broker do
           conn_timeout: timeout(),
           auth: list(),
           max_frame_size: pos_integer(),
+          max_message_size: pos_integer() | nil,
           ping_interval: timeout(),
           cleanup_interval: timeout(),
           request_timeout: timeout(),
@@ -64,7 +66,8 @@ defmodule Pulsar.Broker do
     buffer: <<>>,
     requests: %{},
     consumers: %{},
-    producers: %{}
+    producers: %{},
+    max_message_size: nil
   }
 
   @client_version "Pulsar Elixir Client"
@@ -172,6 +175,15 @@ defmodule Pulsar.Broker do
   """
   @spec get_producers(GenServer.server()) :: %{integer() => pid()}
   def get_producers(broker), do: :gen_statem.call(broker, :get_producers)
+
+  @doc """
+  Gets the largest message this broker accepts, as advertised in `CommandConnected`.
+
+  `nil` until the handshake completes, and again after a reconnection until the new
+  connection has been handshaken.
+  """
+  @spec get_max_message_size(GenServer.server()) :: pos_integer() | nil
+  def get_max_message_size(broker), do: :gen_statem.call(broker, :get_max_message_size)
 
   @doc """
   Gracefully stops the broker by closing all consumers/producers first.
@@ -647,6 +659,11 @@ defmodule Pulsar.Broker do
     {:keep_state, broker, actions}
   end
 
+  def connected({:call, from}, :get_max_message_size, broker) do
+    actions = [{:reply, from, broker.max_message_size}]
+    {:keep_state, broker, actions}
+  end
+
   def connected({:call, from}, request, broker) do
     Logger.debug("Handling request #{inspect(request)}")
     actions = [{:reply, from, {:ok, :handled}}]
@@ -668,12 +685,12 @@ defmodule Pulsar.Broker do
     :keep_state_and_data
   end
 
-  defp handle_command(%Binary.CommandConnected{} = cmd, _broker) do
+  defp handle_command(%Binary.CommandConnected{} = cmd, broker) do
     Logger.info(
       "Successfully connected to broker: protocol_version=#{cmd.protocol_version}, server_version=#{cmd.server_version}"
     )
 
-    :keep_state_and_data
+    {:keep_state, %{broker | max_message_size: cmd.max_message_size}}
   end
 
   defp handle_command(%Binary.CommandLookupTopicResponse{request_id: request_id} = command, broker) do

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -557,6 +557,13 @@ defmodule Pulsar.Broker do
     end
   end
 
+  # An oversized frame is answered by closing the connection, which would take down every
+  # consumer and producer registered here.
+  def connected({:call, from}, {:publish_message, encoded_message}, %__MODULE__{max_message_size: limit} = broker)
+      when is_integer(limit) and byte_size(encoded_message) > limit do
+    {:keep_state, broker, [{:reply, from, {:error, :message_too_large}}]}
+  end
+
   def connected({:call, from}, {:publish_message, encoded_message}, broker) do
     %__MODULE__{socket_module: mod, socket: socket} = broker
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -307,6 +307,18 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
+  # The keys `context/1` gives a callback, so chunk events group like every other signal.
+  defp chunk_context(state, uuid) do
+    %{
+      uuid: uuid,
+      consumer_id: state.consumer_id,
+      topic: state.topic,
+      base_topic: state.base_topic,
+      partition: state.partition,
+      subscription_name: state.subscription_name
+    }
+  end
+
   defp context(state) do
     %{
       topic: state.topic,
@@ -1006,7 +1018,7 @@ defmodule Pulsar.Consumer.Worker do
     :telemetry.execute(
       [:pulsar, :consumer, :chunk, :received],
       %{chunk_id: chunk_id, num_chunks: num_chunks},
-      %{uuid: uuid, consumer_id: state.consumer_id, topic: state.topic, subscription: state.subscription_name}
+      chunk_context(state, uuid)
     )
 
     chunk_data = %{
@@ -1087,7 +1099,7 @@ defmodule Pulsar.Consumer.Worker do
         total_size: byte_size(complete_payload),
         age_ms: ChunkedMessageContext.age_ms(ctx)
       },
-      %{uuid: uuid, consumer_id: state.consumer_id, topic: state.topic, subscription: state.subscription_name}
+      chunk_context(state, uuid)
     )
 
     final_state = %{state | chunked_message_contexts: Map.delete(state.chunked_message_contexts, uuid)}
@@ -1117,13 +1129,7 @@ defmodule Pulsar.Consumer.Worker do
         :telemetry.execute(
           [:pulsar, :consumer, :chunk, :discarded],
           %{received_chunks: oldest_ctx.received_chunks, num_chunks: oldest_ctx.num_chunks_from_msg},
-          %{
-            uuid: oldest_uuid,
-            consumer_id: state.consumer_id,
-            topic: state.topic,
-            subscription: state.subscription_name,
-            reason: :queue_full
-          }
+          Map.put(chunk_context(state, oldest_uuid), :reason, :queue_full)
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(oldest_ctx)
@@ -1171,13 +1177,7 @@ defmodule Pulsar.Consumer.Worker do
             received_chunks: ctx.received_chunks,
             num_chunks: ctx.num_chunks_from_msg
           },
-          %{
-            uuid: uuid,
-            consumer_id: state.consumer_id,
-            topic: state.topic,
-            subscription: state.subscription_name,
-            reason: :expired
-          }
+          Map.put(chunk_context(state, uuid), :reason, :expired)
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(ctx)

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -555,9 +555,12 @@ defmodule Pulsar.Consumer.Worker do
     |> Map.merge(%{dead_letter_topic: state.dead_letter_topic, redelivery_count: redelivery_count})
   end
 
+  # Shared by every event this consumer emits, so they all group the same way.
   defp consumer_metadata(state) do
     %{
       topic: state.topic,
+      base_topic: state.base_topic,
+      partition: state.partition,
       subscription_name: state.subscription_name,
       consumer_id: state.consumer_id
     }
@@ -996,18 +999,6 @@ defmodule Pulsar.Consumer.Worker do
     :ok
   end
 
-  # The keys `context/1` gives a callback, so chunk events group like every other signal.
-  defp chunk_context(state, uuid) do
-    %{
-      uuid: uuid,
-      consumer_id: state.consumer_id,
-      topic: state.topic,
-      base_topic: state.base_topic,
-      partition: state.partition,
-      subscription_name: state.subscription_name
-    }
-  end
-
   defp maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata) do
     base_message_id = command.message_id
     uuid = metadata.uuid
@@ -1018,7 +1009,7 @@ defmodule Pulsar.Consumer.Worker do
     :telemetry.execute(
       [:pulsar, :consumer, :chunk, :received],
       %{chunk_id: chunk_id, num_chunks: num_chunks},
-      chunk_context(state, uuid)
+      Map.put(consumer_metadata(state), :uuid, uuid)
     )
 
     chunk_data = %{
@@ -1099,7 +1090,7 @@ defmodule Pulsar.Consumer.Worker do
         total_size: byte_size(complete_payload),
         age_ms: ChunkedMessageContext.age_ms(ctx)
       },
-      chunk_context(state, uuid)
+      Map.put(consumer_metadata(state), :uuid, uuid)
     )
 
     final_state = %{state | chunked_message_contexts: Map.delete(state.chunked_message_contexts, uuid)}
@@ -1129,7 +1120,7 @@ defmodule Pulsar.Consumer.Worker do
         :telemetry.execute(
           [:pulsar, :consumer, :chunk, :discarded],
           %{received_chunks: oldest_ctx.received_chunks, num_chunks: oldest_ctx.num_chunks_from_msg},
-          Map.put(chunk_context(state, oldest_uuid), :reason, :queue_full)
+          Map.merge(consumer_metadata(state), %{uuid: oldest_uuid, reason: :queue_full})
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(oldest_ctx)
@@ -1177,7 +1168,7 @@ defmodule Pulsar.Consumer.Worker do
             received_chunks: ctx.received_chunks,
             num_chunks: ctx.num_chunks_from_msg
           },
-          Map.put(chunk_context(state, uuid), :reason, :expired)
+          Map.merge(consumer_metadata(state), %{uuid: uuid, reason: :expired})
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(ctx)

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -307,18 +307,6 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  # The keys `context/1` gives a callback, so chunk events group like every other signal.
-  defp chunk_context(state, uuid) do
-    %{
-      uuid: uuid,
-      consumer_id: state.consumer_id,
-      topic: state.topic,
-      base_topic: state.base_topic,
-      partition: state.partition,
-      subscription_name: state.subscription_name
-    }
-  end
-
   defp context(state) do
     %{
       topic: state.topic,
@@ -1006,6 +994,18 @@ defmodule Pulsar.Consumer.Worker do
   defp schedule_chunk_cleanup(interval) when is_integer(interval) and interval > 0 do
     Process.send_after(self(), :cleanup_expired_chunks, interval)
     :ok
+  end
+
+  # The keys `context/1` gives a callback, so chunk events group like every other signal.
+  defp chunk_context(state, uuid) do
+    %{
+      uuid: uuid,
+      consumer_id: state.consumer_id,
+      topic: state.topic,
+      base_topic: state.base_topic,
+      partition: state.partition,
+      subscription_name: state.subscription_name
+    }
   end
 
   defp maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -365,8 +365,8 @@ defmodule Pulsar.Consumer.Worker do
         {command, metadata, payload, broker_metadata} ->
           {state_after, msgs} =
             if chunked_message?(metadata) do
-              # A chunk is a slice of the compressed message, so it only decompresses once
-              # its siblings have been put back around it.
+              # A chunk is a slice of the compressed message, so it cannot be decompressed
+              # before the rest of the slices are back around it.
               maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
             else
               payload = maybe_uncompress(metadata, payload)
@@ -1075,8 +1075,8 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp complete_chunked_message(state, uuid, ctx, num_chunks) do
-    # Every chunk repeats the metadata of the message it came from, so any of them describes
-    # how the reassembled payload was compressed.
+    # Every chunk repeats the metadata of the message it came from, so any of them says how
+    # the reassembled payload was compressed.
     assembled_payload = ChunkedMessageContext.assemble_payload(ctx)
     complete_payload = maybe_uncompress(hd(ctx.metadatas), assembled_payload)
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -1006,7 +1006,7 @@ defmodule Pulsar.Consumer.Worker do
     :telemetry.execute(
       [:pulsar, :consumer, :chunk, :received],
       %{chunk_id: chunk_id, num_chunks: num_chunks},
-      %{uuid: uuid, consumer_id: state.consumer_id}
+      %{uuid: uuid, consumer_id: state.consumer_id, topic: state.topic, subscription: state.subscription_name}
     )
 
     chunk_data = %{
@@ -1082,8 +1082,12 @@ defmodule Pulsar.Consumer.Worker do
 
     :telemetry.execute(
       [:pulsar, :consumer, :chunk, :complete],
-      %{num_chunks: ctx.num_chunks_from_msg, total_size: byte_size(complete_payload)},
-      %{uuid: uuid, consumer_id: state.consumer_id}
+      %{
+        num_chunks: ctx.num_chunks_from_msg,
+        total_size: byte_size(complete_payload),
+        age_ms: ChunkedMessageContext.age_ms(ctx)
+      },
+      %{uuid: uuid, consumer_id: state.consumer_id, topic: state.topic, subscription: state.subscription_name}
     )
 
     final_state = %{state | chunked_message_contexts: Map.delete(state.chunked_message_contexts, uuid)}
@@ -1112,8 +1116,14 @@ defmodule Pulsar.Consumer.Worker do
 
         :telemetry.execute(
           [:pulsar, :consumer, :chunk, :discarded],
-          %{reason: :queue_full},
-          %{uuid: oldest_uuid, consumer_id: state.consumer_id}
+          %{received_chunks: oldest_ctx.received_chunks, num_chunks: oldest_ctx.num_chunks_from_msg},
+          %{
+            uuid: oldest_uuid,
+            consumer_id: state.consumer_id,
+            topic: state.topic,
+            subscription: state.subscription_name,
+            reason: :queue_full
+          }
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(oldest_ctx)
@@ -1156,8 +1166,18 @@ defmodule Pulsar.Consumer.Worker do
       Enum.each(expired, fn {uuid, ctx} ->
         :telemetry.execute(
           [:pulsar, :consumer, :chunk, :expired],
-          %{age_ms: ChunkedMessageContext.age_ms(ctx), received_chunks: ctx.received_chunks},
-          %{uuid: uuid, consumer_id: state.consumer_id}
+          %{
+            age_ms: ChunkedMessageContext.age_ms(ctx),
+            received_chunks: ctx.received_chunks,
+            num_chunks: ctx.num_chunks_from_msg
+          },
+          %{
+            uuid: uuid,
+            consumer_id: state.consumer_id,
+            topic: state.topic,
+            subscription: state.subscription_name,
+            reason: :expired
+          }
         )
 
         partial_payload = ChunkedMessageContext.assemble_payload(ctx)

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -363,12 +363,13 @@ defmodule Pulsar.Consumer.Worker do
           {[build_invalid_message(command, bytes, validation_error)], state}
 
         {command, metadata, payload, broker_metadata} ->
-          payload = maybe_uncompress(metadata, payload)
-
           {state_after, msgs} =
             if chunked_message?(metadata) do
+              # A chunk is a slice of the compressed message, so it only decompresses once
+              # its siblings have been put back around it.
               maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
             else
+              payload = maybe_uncompress(metadata, payload)
               unwrapped = unwrap_messages(metadata, payload)
               pulsar_messages = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
               {state, pulsar_messages}
@@ -1045,38 +1046,7 @@ defmodule Pulsar.Consumer.Worker do
     } = chunk_data
 
     {:ok, ctx} = ChunkedMessageContext.new(command, metadata, payload, broker_metadata)
-    new_contexts = Map.put(state.chunked_message_contexts, uuid, ctx)
-    new_state = %{state | chunked_message_contexts: new_contexts}
-
-    if ChunkedMessageContext.complete?(ctx) do
-      complete_payload = ChunkedMessageContext.assemble_payload(ctx)
-
-      :telemetry.execute(
-        [:pulsar, :consumer, :chunk, :complete],
-        %{num_chunks: ctx.num_chunks_from_msg, total_size: byte_size(complete_payload)},
-        %{uuid: uuid, consumer_id: state.consumer_id}
-      )
-
-      final_state = %{new_state | chunked_message_contexts: Map.delete(new_state.chunked_message_contexts, uuid)}
-
-      all_message_ids = ChunkedMessageContext.all_message_ids(ctx)
-
-      chunk_metadata = %{
-        chunked: true,
-        complete: true,
-        uuid: uuid,
-        num_chunks: num_chunks,
-        message_ids: all_message_ids,
-        commands: ctx.commands,
-        metadatas: ctx.metadatas,
-        broker_metadatas: ctx.broker_metadatas
-      }
-
-      message = build_message_from_chunk(chunk_metadata, complete_payload)
-      {final_state, [message]}
-    else
-      {new_state, []}
-    end
+    put_chunk_context(state, uuid, ctx, num_chunks)
   end
 
   defp add_chunk_to_context(state, ctx, chunk_data) do
@@ -1090,38 +1060,47 @@ defmodule Pulsar.Consumer.Worker do
     } = chunk_data
 
     {:ok, updated_ctx} = ChunkedMessageContext.add_chunk(ctx, command, metadata, payload, broker_metadata)
-    new_contexts = Map.put(state.chunked_message_contexts, uuid, updated_ctx)
+    put_chunk_context(state, uuid, updated_ctx, num_chunks)
+  end
+
+  defp put_chunk_context(state, uuid, ctx, num_chunks) do
+    new_contexts = Map.put(state.chunked_message_contexts, uuid, ctx)
     new_state = %{state | chunked_message_contexts: new_contexts}
 
-    if ChunkedMessageContext.complete?(updated_ctx) do
-      complete_payload = ChunkedMessageContext.assemble_payload(updated_ctx)
-
-      :telemetry.execute(
-        [:pulsar, :consumer, :chunk, :complete],
-        %{num_chunks: updated_ctx.num_chunks_from_msg, total_size: byte_size(complete_payload)},
-        %{uuid: uuid, consumer_id: state.consumer_id}
-      )
-
-      final_state = %{new_state | chunked_message_contexts: Map.delete(new_state.chunked_message_contexts, uuid)}
-
-      all_message_ids = ChunkedMessageContext.all_message_ids(updated_ctx)
-
-      chunk_metadata = %{
-        chunked: true,
-        complete: true,
-        uuid: uuid,
-        num_chunks: num_chunks,
-        message_ids: all_message_ids,
-        commands: updated_ctx.commands,
-        metadatas: updated_ctx.metadatas,
-        broker_metadatas: updated_ctx.broker_metadatas
-      }
-
-      message = build_message_from_chunk(chunk_metadata, complete_payload)
-      {final_state, [message]}
+    if ChunkedMessageContext.complete?(ctx) do
+      complete_chunked_message(new_state, uuid, ctx, num_chunks)
     else
       {new_state, []}
     end
+  end
+
+  defp complete_chunked_message(state, uuid, ctx, num_chunks) do
+    # Every chunk repeats the metadata of the message it came from, so any of them describes
+    # how the reassembled payload was compressed.
+    assembled_payload = ChunkedMessageContext.assemble_payload(ctx)
+    complete_payload = maybe_uncompress(hd(ctx.metadatas), assembled_payload)
+
+    :telemetry.execute(
+      [:pulsar, :consumer, :chunk, :complete],
+      %{num_chunks: ctx.num_chunks_from_msg, total_size: byte_size(complete_payload)},
+      %{uuid: uuid, consumer_id: state.consumer_id}
+    )
+
+    final_state = %{state | chunked_message_contexts: Map.delete(state.chunked_message_contexts, uuid)}
+
+    chunk_metadata = %{
+      chunked: true,
+      complete: true,
+      uuid: uuid,
+      num_chunks: num_chunks,
+      message_ids: ChunkedMessageContext.all_message_ids(ctx),
+      commands: ctx.commands,
+      metadatas: ctx.metadatas,
+      broker_metadatas: ctx.broker_metadatas
+    }
+
+    message = build_message_from_chunk(chunk_metadata, complete_payload)
+    {final_state, [message]}
   end
 
   defp handle_chunk_queue_full(state, chunk_data) do

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -109,12 +109,13 @@ defmodule Pulsar.Producer do
 
   Returns `{:error, :not_ready}` while its topic topology is being discovered.
 
-  A message the broker would reject for its size is refused here instead, because the broker
-  answers an oversized frame by closing a connection every producer and consumer on that
-  broker shares. Without `:chunking_enabled` that is `{:error, :message_too_large}`, and a
-  batch too big to flush answers the same to each of its callers. With `:chunking_enabled` the
-  payload is split to fit, but `{:error, :metadata_too_large}` still comes back when
-  `:properties` and the rest of the metadata leave no room for a payload at all.
+  A message too large for the broker is refused here rather than sent, since the broker would
+  answer it by closing a connection shared with every other producer and consumer:
+
+  - `{:error, :message_too_large}` without `:chunking_enabled`, and for each caller of a batch
+    that grew too big to flush
+  - `{:error, :metadata_too_large}` with `:chunking_enabled`, when `:properties` and the rest
+    of the metadata leave no room for a payload to be split into
 
   ## Options
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -109,6 +109,13 @@ defmodule Pulsar.Producer do
 
   Returns `{:error, :not_ready}` while its topic topology is being discovered.
 
+  A message the broker would reject for its size is refused here instead, because the broker
+  answers an oversized frame by closing a connection every producer and consumer on that
+  broker shares. Without `:chunking_enabled` that is `{:error, :message_too_large}`, and a
+  batch too big to flush answers the same to each of its callers. With `:chunking_enabled` the
+  payload is split to fit, but `{:error, :metadata_too_large}` still comes back when
+  `:properties` and the rest of the metadata leave no room for a payload at all.
+
   ## Options
 
   - `:partition_key` - decides the partition of a partitioned topic, hashed under the

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -112,8 +112,9 @@ defmodule Pulsar.Producer do
   A message too large for the broker is refused here rather than sent, since the broker would
   answer it by closing a connection shared with every other producer and consumer:
 
-  - `{:error, :message_too_large}` without `:chunking_enabled`, and for each caller of a batch
-    that grew too big to flush
+  - `{:error, :message_too_large}` for a message, or a whole batch, that does not fit. With
+    `:chunking_enabled` the payload is split to fit, so this only surfaces if the broker's
+    limit is not yet known to the producer
   - `{:error, :metadata_too_large}` with `:chunking_enabled`, when `:properties` and the rest
     of the metadata leave no room for a payload to be split into
 

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -140,7 +140,7 @@ defmodule Pulsar.Producer.Options do
   end
 
   # A batch is one entry holding many messages and a chunked message is one message spread
-  # over many entries, so a producer cannot do both at once. Java refuses the pair as well.
+  # over many entries, so a producer cannot do both at once.
   defp validate_chunking(opts) do
     if opts[:batch_enabled] and opts[:chunking_enabled] do
       {:error,

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -72,12 +72,19 @@ defmodule Pulsar.Producer.Options do
     chunking_enabled: [
       type: :boolean,
       default: false,
-      doc: "Split payloads larger than `:max_message_size` across several messages."
+      doc: """
+      Split payloads larger than `:max_message_size` across several messages. Cannot be
+      combined with `:batch_enabled`. A payload is compressed before it is measured, so
+      one that compresses below the limit is sent whole.
+      """
     ],
     max_message_size: [
       type: :pos_integer,
       default: 5_242_880,
-      doc: "Largest chunk to send, in bytes. Only used when chunking."
+      doc: """
+      Largest chunk payload to send, in bytes. Only used when chunking. Capped by the limit
+      the broker advertises when the producer connects, minus the metadata each chunk carries.
+      """
     ],
     schema: [
       type: :keyword_list,
@@ -118,8 +125,32 @@ defmodule Pulsar.Producer.Options do
   Validates producer options.
   """
   @spec validate!(keyword()) :: keyword()
-  def validate!(opts), do: NimbleOptions.validate!(opts, @schema)
+  def validate!(opts) do
+    case opts |> NimbleOptions.validate!(@schema) |> validate_chunking() do
+      {:ok, opts} -> opts
+      {:error, error} -> raise error
+    end
+  end
 
   @spec validate(keyword()) :: {:ok, keyword()} | {:error, NimbleOptions.ValidationError.t()}
-  def validate(opts), do: NimbleOptions.validate(opts, @schema)
+  def validate(opts) do
+    with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
+      validate_chunking(opts)
+    end
+  end
+
+  # A batch is one entry holding many messages and a chunked message is one message spread
+  # over many entries, so a producer cannot do both at once. Java refuses the pair as well.
+  defp validate_chunking(opts) do
+    if opts[:batch_enabled] and opts[:chunking_enabled] do
+      {:error,
+       %NimbleOptions.ValidationError{
+         key: :chunking_enabled,
+         value: true,
+         message: "invalid value for :chunking_enabled option: cannot be enabled together with :batch_enabled"
+       }}
+    else
+      {:ok, opts}
+    end
+  end
 end

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -25,6 +25,10 @@ defmodule Pulsar.Producer.Worker do
     :UnsupportedVersionError
   ]
 
+  # Checksum and size prefixes around the metadata, the CommandSend framing, and room for the
+  # chunk counters to grow a byte or two once their real values are known.
+  @chunk_framing_overhead 64
+
   defstruct [
     :client,
     :topic,
@@ -41,6 +45,7 @@ defmodule Pulsar.Producer.Worker do
     :topic_epoch,
     :chunking_enabled,
     :max_message_size,
+    :broker_max_message_size,
     :batch_enabled,
     {:batch, []},
     {:batched, 0},
@@ -66,6 +71,7 @@ defmodule Pulsar.Producer.Worker do
           topic_epoch: integer() | nil,
           chunking_enabled: boolean(),
           max_message_size: non_neg_integer(),
+          broker_max_message_size: pos_integer() | nil,
           batch_enabled: boolean(),
           batch: list({map(), GenServer.from()}),
           batched: non_neg_integer(),
@@ -239,34 +245,33 @@ defmodule Pulsar.Producer.Worker do
   end
 
   def handle_call({:send_message, payload, opts}, from, state) do
-    messages = maybe_chunk(payload, opts, state)
+    # Pulsar compresses the whole message and splits the compressed bytes, so a chunk is a
+    # slice of a compressed stream rather than a compressed slice. Every chunk repeats the
+    # metadata of the message it belongs to, which the consumer needs to put it back together.
+    base_metadata = build_message_metadata(payload, opts, state)
+    compressed_payload = maybe_compress(base_metadata, payload)
+    messages = maybe_chunk(compressed_payload, base_metadata, state)
 
     result =
       Enum.reduce_while(messages, {:ok, state}, fn {chunk_payload, chunk_metadata}, {:ok, acc_state} ->
         sequence_id = acc_state.sequence_id + 1
-        command_send = %Binary.CommandSend{producer_id: acc_state.producer_id, sequence_id: sequence_id}
 
-        message_metadata = %Binary.MessageMetadata{
-          producer_name: acc_state.producer_name,
+        command_send = %Binary.CommandSend{
+          producer_id: acc_state.producer_id,
           sequence_id: sequence_id,
-          publish_time: System.system_time(:millisecond),
-          uncompressed_size: byte_size(chunk_payload),
-          compression: Protocol.to_compression(acc_state.compression),
-          partition_key: Keyword.get(opts, :partition_key),
-          ordering_key: Keyword.get(opts, :ordering_key),
-          properties: Protocol.to_key_value_list(Keyword.get(opts, :properties)),
-          event_time: to_timestamp(Keyword.get(opts, :event_time)),
-          deliver_at_time: resolve_deliver_at_time(opts),
-          uuid: Map.get(chunk_metadata, :uuid),
-          chunk_id: Map.get(chunk_metadata, :chunk_id),
-          num_chunks_from_msg: Map.get(chunk_metadata, :num_chunks),
-          total_chunk_msg_size: Map.get(chunk_metadata, :total_chunk_msg_size),
-          schema_version: acc_state.schema_version
+          is_chunk: map_size(chunk_metadata) > 0
         }
 
-        compressed_payload = maybe_compress(message_metadata, chunk_payload)
+        message_metadata = %{
+          base_metadata
+          | sequence_id: sequence_id,
+            uuid: Map.get(chunk_metadata, :uuid),
+            chunk_id: Map.get(chunk_metadata, :chunk_id),
+            num_chunks_from_msg: Map.get(chunk_metadata, :num_chunks),
+            total_chunk_msg_size: Map.get(chunk_metadata, :total_chunk_msg_size)
+        }
 
-        encoded_message = Protocol.encode(command_send, message_metadata, compressed_payload)
+        encoded_message = Protocol.encode(command_send, message_metadata, chunk_payload)
 
         case Pulsar.Broker.publish_message(acc_state.broker_pid, encoded_message) do
           :ok ->
@@ -566,6 +571,7 @@ defmodule Pulsar.Producer.Worker do
               |> Map.put(:ready, Map.get(response, :producer_ready, true))
               |> Map.put(:topic_epoch, response.topic_epoch)
               |> Map.put(:schema_version, response.schema_version)
+              |> Map.put(:broker_max_message_size, broker_max_message_size(broker_pid))
 
             {:ok, state}
           else
@@ -602,6 +608,13 @@ defmodule Pulsar.Producer.Worker do
         {result, stop_metadata}
       end
     )
+  end
+
+  defp broker_max_message_size(broker_pid) do
+    case Pulsar.Broker.get_max_message_size(broker_pid) do
+      size when is_integer(size) and size > 0 -> size
+      _ -> nil
+    end
   end
 
   defp create_producer(broker_pid, state) do
@@ -690,12 +703,28 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  defp maybe_chunk(payload, _opts, state) do
-    payload_size = byte_size(payload)
+  defp build_message_metadata(payload, opts, state) do
+    %Binary.MessageMetadata{
+      producer_name: state.producer_name,
+      sequence_id: 0,
+      publish_time: System.system_time(:millisecond),
+      uncompressed_size: byte_size(payload),
+      compression: Protocol.to_compression(state.compression),
+      partition_key: Keyword.get(opts, :partition_key),
+      ordering_key: Keyword.get(opts, :ordering_key),
+      properties: Protocol.to_key_value_list(Keyword.get(opts, :properties)),
+      event_time: to_timestamp(Keyword.get(opts, :event_time)),
+      deliver_at_time: resolve_deliver_at_time(opts),
+      schema_version: state.schema_version
+    }
+  end
 
-    if state.chunking_enabled and payload_size > state.max_message_size do
-      uuid = Uniq.UUID.uuid4()
-      chunk_size = state.max_message_size
+  defp maybe_chunk(payload, base_metadata, %{chunking_enabled: true} = state) do
+    payload_size = byte_size(payload)
+    uuid = Uniq.UUID.uuid4()
+    chunk_size = chunk_payload_budget(base_metadata, uuid, payload_size, state)
+
+    if payload_size > chunk_size do
       num_chunks = div(payload_size + chunk_size - 1, chunk_size)
 
       Logger.debug("Chunking message: #{payload_size} bytes into #{num_chunks} chunks (max: #{chunk_size} bytes each)")
@@ -723,6 +752,30 @@ defmodule Pulsar.Producer.Worker do
       end)
     else
       [{payload, %{}}]
+    end
+  end
+
+  defp maybe_chunk(payload, _base_metadata, _state), do: [{payload, %{}}]
+
+  # A chunk travels with a full copy of the message metadata, and the broker's limit covers
+  # both. :max_message_size stays a budget for payload bytes, so only the broker's own limit
+  # has the metadata and framing taken out of it.
+  defp chunk_payload_budget(base_metadata, uuid, total_size, state) do
+    case state.broker_max_message_size do
+      broker_limit when is_integer(broker_limit) and broker_limit > 0 ->
+        metadata = %{
+          base_metadata
+          | uuid: uuid,
+            chunk_id: 0,
+            num_chunks_from_msg: 0,
+            total_chunk_msg_size: total_size
+        }
+
+        overhead = byte_size(Binary.MessageMetadata.encode(metadata)) + @chunk_framing_overhead
+        min(state.max_message_size, max(broker_limit - overhead, 1))
+
+      _ ->
+        state.max_message_size
     end
   end
 

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -63,7 +63,7 @@ defmodule Pulsar.Producer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           sequence_id: integer(),
-          pending_sends: %{integer() => {GenServer.from(), map()}},
+          pending_sends: %{integer() => {GenServer.from(), map() | nil}},
           access_mode: atom(),
           compression: :none | :lz4 | :zlib | :snappy | :zstd,
           ready: boolean(),
@@ -264,21 +264,13 @@ defmodule Pulsar.Producer.Worker do
         command_send = %Binary.CommandSend{
           producer_id: acc_state.producer_id,
           sequence_id: sequence_id,
-          is_chunk: map_size(chunk_metadata) > 0
+          is_chunk: not is_nil(chunk_metadata)
         }
 
-        message_metadata = %{
-          base_metadata
-          | sequence_id: sequence_id,
-            uuid: Map.get(chunk_metadata, :uuid),
-            chunk_id: Map.get(chunk_metadata, :chunk_id),
-            num_chunks_from_msg: Map.get(chunk_metadata, :num_chunks),
-            total_chunk_msg_size: Map.get(chunk_metadata, :total_chunk_msg_size)
-        }
-
+        message_metadata = apply_chunk_metadata(base_metadata, sequence_id, chunk_metadata)
         encoded_message = Protocol.encode(command_send, message_metadata, chunk_payload)
 
-        case publish_frame(acc_state, encoded_message) do
+        case Pulsar.Broker.publish_message(acc_state.broker_pid, encoded_message) do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
@@ -337,7 +329,7 @@ defmodule Pulsar.Producer.Worker do
           %{state | pending_sends: new_pending}
 
         # Chunked message case
-        {{from, chunk_metadata}, new_pending} when is_map(chunk_metadata) and map_size(chunk_metadata) > 0 ->
+        {{from, chunk_metadata}, new_pending} when is_map(chunk_metadata) ->
           handle_chunk_receipt(receipt, from, chunk_metadata, new_pending, state)
 
         # Single message case
@@ -471,7 +463,7 @@ defmodule Pulsar.Producer.Worker do
 
     encoded_frame = Protocol.encode(command_send, message_metadata, compressed_payload)
 
-    case publish_frame(state, encoded_frame) do
+    case Pulsar.Broker.publish_message(state.broker_pid, encoded_frame) do
       :ok ->
         :telemetry.execute(
           [:pulsar, :producer, :batch, :published],
@@ -523,7 +515,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :complete],
       %{num_chunks: num_chunks},
-      %{uuid: uuid, producer_id: state.producer_id}
+      %{uuid: uuid, producer_id: state.producer_id, topic: state.topic}
     )
 
     chunked_msg_id = %{
@@ -615,18 +607,6 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  # An oversized frame is answered by closing the connection rather than by refusing the send,
-  # and that connection carries every other producer and consumer on this broker.
-  defp publish_frame(state, encoded_frame) do
-    case state.broker_max_message_size do
-      limit when is_integer(limit) and byte_size(encoded_frame) > limit ->
-        {:error, :message_too_large}
-
-      _ ->
-        Pulsar.Broker.publish_message(state.broker_pid, encoded_frame)
-    end
-  end
-
   defp broker_max_message_size(broker_pid) do
     case Pulsar.Broker.get_max_message_size(broker_pid) do
       size when is_integer(size) and size > 0 -> size
@@ -703,7 +683,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :sent],
       %{chunk_id: chunk_id, chunk_size: byte_size(chunk_payload)},
-      %{uuid: uuid, producer_id: state.producer_id, sequence_id: sequence_id}
+      %{uuid: uuid, producer_id: state.producer_id, sequence_id: sequence_id, topic: state.topic}
     )
   end
 
@@ -720,9 +700,28 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
+  defp apply_chunk_metadata(base_metadata, sequence_id, nil) do
+    %{base_metadata | sequence_id: sequence_id}
+  end
+
+  defp apply_chunk_metadata(base_metadata, sequence_id, chunk_metadata) do
+    %{uuid: uuid, chunk_id: chunk_id, num_chunks: num_chunks, total_chunk_msg_size: total} = chunk_metadata
+
+    %{
+      base_metadata
+      | sequence_id: sequence_id,
+        uuid: uuid,
+        chunk_id: chunk_id,
+        num_chunks_from_msg: num_chunks,
+        total_chunk_msg_size: total
+    }
+  end
+
   defp build_message_metadata(payload, opts, state) do
     %Binary.MessageMetadata{
       producer_name: state.producer_name,
+      # Replaced per chunk, but not left nil: the budget below encodes this to measure it,
+      # and proto2 rejects a nil on a required field.
       sequence_id: 0,
       publish_time: System.system_time(:millisecond),
       uncompressed_size: byte_size(payload),
@@ -750,11 +749,11 @@ defmodule Pulsar.Producer.Worker do
         {:ok, split_into_chunks(payload, payload_size, uuid, chunk_size, state)}
 
       _ ->
-        {:ok, [{payload, %{}}]}
+        {:ok, [{payload, nil}]}
     end
   end
 
-  defp maybe_chunk(payload, _base_metadata, _state), do: {:ok, [{payload, %{}}]}
+  defp maybe_chunk(payload, _base_metadata, _state), do: {:ok, [{payload, nil}]}
 
   defp split_into_chunks(payload, payload_size, uuid, chunk_size, state) do
     num_chunks = div(payload_size + chunk_size - 1, chunk_size)
@@ -769,9 +768,7 @@ defmodule Pulsar.Producer.Worker do
 
     Enum.map(0..(num_chunks - 1), fn chunk_id ->
       offset = chunk_id * chunk_size
-      remaining = payload_size - offset
-      current_chunk_size = min(remaining, chunk_size)
-      <<_skip::binary-size(^offset), chunk_data::binary-size(^current_chunk_size), _rest::binary>> = payload
+      chunk_data = binary_part(payload, offset, min(payload_size - offset, chunk_size))
 
       chunk_metadata = %{
         uuid: uuid,

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -249,8 +249,14 @@ defmodule Pulsar.Producer.Worker do
     # of compressed bytes rather than compressed on its own.
     base_metadata = build_message_metadata(payload, opts, state)
     compressed_payload = maybe_compress(base_metadata, payload)
-    messages = maybe_chunk(compressed_payload, base_metadata, state)
 
+    case maybe_chunk(compressed_payload, base_metadata, state) do
+      {:ok, messages} -> publish_messages(messages, base_metadata, from, state)
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp publish_messages(messages, base_metadata, from, state) do
     result =
       Enum.reduce_while(messages, {:ok, state}, fn {chunk_payload, chunk_metadata}, {:ok, acc_state} ->
         sequence_id = acc_state.sequence_id + 1
@@ -272,7 +278,7 @@ defmodule Pulsar.Producer.Worker do
 
         encoded_message = Protocol.encode(command_send, message_metadata, chunk_payload)
 
-        case Pulsar.Broker.publish_message(acc_state.broker_pid, encoded_message) do
+        case publish_frame(acc_state, encoded_message) do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
@@ -465,7 +471,7 @@ defmodule Pulsar.Producer.Worker do
 
     encoded_frame = Protocol.encode(command_send, message_metadata, compressed_payload)
 
-    case Pulsar.Broker.publish_message(state.broker_pid, encoded_frame) do
+    case publish_frame(state, encoded_frame) do
       :ok ->
         :telemetry.execute(
           [:pulsar, :producer, :batch, :published],
@@ -609,6 +615,18 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
+  # An oversized frame is answered by closing the connection rather than by refusing the send,
+  # and that connection carries every other producer and consumer on this broker.
+  defp publish_frame(state, encoded_frame) do
+    case state.broker_max_message_size do
+      limit when is_integer(limit) and byte_size(encoded_frame) > limit ->
+        {:error, :message_too_large}
+
+      _ ->
+        Pulsar.Broker.publish_message(state.broker_pid, encoded_frame)
+    end
+  end
+
   defp broker_max_message_size(broker_pid) do
     case Pulsar.Broker.get_max_message_size(broker_pid) do
       size when is_integer(size) and size > 0 -> size
@@ -721,40 +739,50 @@ defmodule Pulsar.Producer.Worker do
   defp maybe_chunk(payload, base_metadata, %{chunking_enabled: true} = state) do
     payload_size = byte_size(payload)
     uuid = Uniq.UUID.uuid4()
-    chunk_size = chunk_payload_budget(base_metadata, uuid, payload_size, state)
 
-    if payload_size > chunk_size do
-      num_chunks = div(payload_size + chunk_size - 1, chunk_size)
+    case chunk_payload_budget(base_metadata, uuid, payload_size, state) do
+      # The metadata on its own fills the broker's limit, and smaller chunks would only
+      # repeat it, so no split can rescue this message.
+      chunk_size when chunk_size < 1 ->
+        {:error, :metadata_too_large}
 
-      Logger.debug("Chunking message: #{payload_size} bytes into #{num_chunks} chunks (max: #{chunk_size} bytes each)")
+      chunk_size when payload_size > chunk_size ->
+        {:ok, split_into_chunks(payload, payload_size, uuid, chunk_size, state)}
 
-      :telemetry.execute(
-        [:pulsar, :producer, :chunk, :start],
-        %{total_size: payload_size, num_chunks: num_chunks, chunk_size: chunk_size},
-        %{uuid: uuid, producer_id: state.producer_id, topic: state.topic}
-      )
-
-      Enum.map(0..(num_chunks - 1), fn chunk_id ->
-        offset = chunk_id * chunk_size
-        remaining = payload_size - offset
-        current_chunk_size = min(remaining, chunk_size)
-        <<_skip::binary-size(^offset), chunk_data::binary-size(^current_chunk_size), _rest::binary>> = payload
-
-        chunk_metadata = %{
-          uuid: uuid,
-          chunk_id: chunk_id,
-          num_chunks: num_chunks,
-          total_chunk_msg_size: payload_size
-        }
-
-        {chunk_data, chunk_metadata}
-      end)
-    else
-      [{payload, %{}}]
+      _ ->
+        {:ok, [{payload, %{}}]}
     end
   end
 
-  defp maybe_chunk(payload, _base_metadata, _state), do: [{payload, %{}}]
+  defp maybe_chunk(payload, _base_metadata, _state), do: {:ok, [{payload, %{}}]}
+
+  defp split_into_chunks(payload, payload_size, uuid, chunk_size, state) do
+    num_chunks = div(payload_size + chunk_size - 1, chunk_size)
+
+    Logger.debug("Chunking message: #{payload_size} bytes into #{num_chunks} chunks (max: #{chunk_size} bytes each)")
+
+    :telemetry.execute(
+      [:pulsar, :producer, :chunk, :start],
+      %{total_size: payload_size, num_chunks: num_chunks, chunk_size: chunk_size},
+      %{uuid: uuid, producer_id: state.producer_id, topic: state.topic}
+    )
+
+    Enum.map(0..(num_chunks - 1), fn chunk_id ->
+      offset = chunk_id * chunk_size
+      remaining = payload_size - offset
+      current_chunk_size = min(remaining, chunk_size)
+      <<_skip::binary-size(^offset), chunk_data::binary-size(^current_chunk_size), _rest::binary>> = payload
+
+      chunk_metadata = %{
+        uuid: uuid,
+        chunk_id: chunk_id,
+        num_chunks: num_chunks,
+        total_chunk_msg_size: payload_size
+      }
+
+      {chunk_data, chunk_metadata}
+    end)
+  end
 
   # The broker's limit covers the metadata each chunk repeats as well as its payload.
   # :max_message_size counts payload bytes only, so the deduction applies to the broker's
@@ -771,7 +799,7 @@ defmodule Pulsar.Producer.Worker do
         }
 
         overhead = byte_size(Binary.MessageMetadata.encode(metadata)) + @chunk_framing_overhead
-        min(state.max_message_size, max(broker_limit - overhead, 1))
+        min(state.max_message_size, broker_limit - overhead)
 
       _ ->
         state.max_message_size

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -30,8 +30,8 @@ defmodule Pulsar.Producer.Worker do
   @chunk_framing_overhead 64
 
   # Stands in while the budget is measured, so a message that turns out not to need chunking
-  # never generates a uuid. Itself a uuid, so it encodes to the length the chunks will use.
-  @uuid_placeholder Uniq.UUID.uuid4()
+  # never generates a uuid. Only its encoded length matters here.
+  @uuid_placeholder "00000000-0000-0000-0000-000000000000"
 
   defstruct [
     :client,
@@ -479,12 +479,7 @@ defmodule Pulsar.Producer.Worker do
         :telemetry.execute(
           [:pulsar, :producer, :batch, :published],
           %{count: messages_count},
-          %{
-            topic: state.topic,
-            producer_name: state.producer_name,
-            producer_id: state.producer_id,
-            sequence_id: sequence_id
-          }
+          Map.put(producer_metadata(state), :sequence_id, sequence_id)
         )
 
         new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}})
@@ -526,7 +521,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :complete],
       %{num_chunks: num_chunks},
-      chunk_context(state, uuid)
+      Map.put(producer_metadata(state), :uuid, uuid)
     )
 
     chunked_msg_id = %{
@@ -618,13 +613,14 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  defp chunk_context(state, uuid) do
+  # Shared by every event this producer emits, so they all group the same way.
+  defp producer_metadata(state) do
     %{
-      uuid: uuid,
-      producer_id: state.producer_id,
       topic: state.topic,
       base_topic: state.base_topic,
-      partition: state.partition
+      partition: state.partition,
+      producer_id: state.producer_id,
+      producer_name: state.producer_name
     }
   end
 
@@ -704,7 +700,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :sent],
       %{chunk_id: chunk_id, chunk_size: byte_size(chunk_payload)},
-      Map.put(chunk_context(state, uuid), :sequence_id, sequence_id)
+      Map.merge(producer_metadata(state), %{uuid: uuid, sequence_id: sequence_id})
     )
   end
 
@@ -712,12 +708,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :message, :published],
       %{count: 1},
-      %{
-        topic: state.topic,
-        producer_name: state.producer_name,
-        producer_id: state.producer_id,
-        sequence_id: sequence_id
-      }
+      Map.put(producer_metadata(state), :sequence_id, sequence_id)
     )
   end
 
@@ -784,7 +775,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :start],
       %{total_size: payload_size, num_chunks: num_chunks, chunk_size: chunk_size},
-      chunk_context(state, uuid)
+      Map.put(producer_metadata(state), :uuid, uuid)
     )
 
     Enum.map(0..(num_chunks - 1), fn chunk_id ->

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -25,8 +25,8 @@ defmodule Pulsar.Producer.Worker do
     :UnsupportedVersionError
   ]
 
-  # Checksum and size prefixes around the metadata, the CommandSend framing, and room for the
-  # chunk counters to grow a byte or two once their real values are known.
+  # Checksum and size prefixes around the metadata, the CommandSend framing, and slack for the
+  # chunk counters once their real values are known.
   @chunk_framing_overhead 64
 
   defstruct [
@@ -245,9 +245,8 @@ defmodule Pulsar.Producer.Worker do
   end
 
   def handle_call({:send_message, payload, opts}, from, state) do
-    # Pulsar compresses the whole message and splits the compressed bytes, so a chunk is a
-    # slice of a compressed stream rather than a compressed slice. Every chunk repeats the
-    # metadata of the message it belongs to, which the consumer needs to put it back together.
+    # Compression covers the whole message and the split comes after it, so a chunk is a slice
+    # of compressed bytes rather than compressed on its own.
     base_metadata = build_message_metadata(payload, opts, state)
     compressed_payload = maybe_compress(base_metadata, payload)
     messages = maybe_chunk(compressed_payload, base_metadata, state)
@@ -757,9 +756,9 @@ defmodule Pulsar.Producer.Worker do
 
   defp maybe_chunk(payload, _base_metadata, _state), do: [{payload, %{}}]
 
-  # A chunk travels with a full copy of the message metadata, and the broker's limit covers
-  # both. :max_message_size stays a budget for payload bytes, so only the broker's own limit
-  # has the metadata and framing taken out of it.
+  # The broker's limit covers the metadata each chunk repeats as well as its payload.
+  # :max_message_size counts payload bytes only, so the deduction applies to the broker's
+  # limit alone.
   defp chunk_payload_budget(base_metadata, uuid, total_size, state) do
     case state.broker_max_message_size do
       broker_limit when is_integer(broker_limit) and broker_limit > 0 ->

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -30,8 +30,8 @@ defmodule Pulsar.Producer.Worker do
   @chunk_framing_overhead 64
 
   # Stands in while the budget is measured, so a message that turns out not to need chunking
-  # never generates a uuid. Every uuid4 encodes to this length.
-  @uuid_placeholder String.duplicate("0", 36)
+  # never generates a uuid. Itself a uuid, so it encodes to the length the chunks will use.
+  @uuid_placeholder Uniq.UUID.uuid4()
 
   defstruct [
     :client,

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -29,9 +29,15 @@ defmodule Pulsar.Producer.Worker do
   # chunk counters once their real values are known.
   @chunk_framing_overhead 64
 
+  # Stands in while the budget is measured, so a message that turns out not to need chunking
+  # never generates a uuid. Every uuid4 encodes to this length.
+  @uuid_placeholder String.duplicate("0", 36)
+
   defstruct [
     :client,
     :topic,
+    :base_topic,
+    :partition,
     :producer_id,
     :producer_name,
     :broker_pid,
@@ -58,6 +64,8 @@ defmodule Pulsar.Producer.Worker do
 
   @type t :: %__MODULE__{
           topic: String.t(),
+          base_topic: String.t(),
+          partition: non_neg_integer() | nil,
           producer_id: integer(),
           producer_name: String.t() | nil,
           broker_pid: pid(),
@@ -279,7 +287,7 @@ defmodule Pulsar.Producer.Worker do
             {:cont, {:ok, new_state}}
 
           {:error, reason} ->
-            {:halt, {:error, reason}}
+            {:halt, {:error, reason, acc_state}}
         end
       end)
 
@@ -287,8 +295,11 @@ defmodule Pulsar.Producer.Worker do
       {:ok, new_state} ->
         {:noreply, new_state}
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+      # Rolling the counter back would reissue sequence ids still in flight, which the
+      # broker's deduplication reads as repeats. The pending entries do go: a message missing
+      # chunks can never complete, and its caller already has an error.
+      {:error, reason, acc_state} ->
+        {:reply, {:error, reason}, %{acc_state | pending_sends: state.pending_sends}}
     end
   end
 
@@ -515,7 +526,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :complete],
       %{num_chunks: num_chunks},
-      %{uuid: uuid, producer_id: state.producer_id, topic: state.topic}
+      chunk_context(state, uuid)
     )
 
     chunked_msg_id = %{
@@ -607,6 +618,16 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
+  defp chunk_context(state, uuid) do
+    %{
+      uuid: uuid,
+      producer_id: state.producer_id,
+      topic: state.topic,
+      base_topic: state.base_topic,
+      partition: state.partition
+    }
+  end
+
   defp broker_max_message_size(broker_pid) do
     case Pulsar.Broker.get_max_message_size(broker_pid) do
       size when is_integer(size) and size > 0 -> size
@@ -683,7 +704,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :sent],
       %{chunk_id: chunk_id, chunk_size: byte_size(chunk_payload)},
-      %{uuid: uuid, producer_id: state.producer_id, sequence_id: sequence_id, topic: state.topic}
+      Map.put(chunk_context(state, uuid), :sequence_id, sequence_id)
     )
   end
 
@@ -737,16 +758,15 @@ defmodule Pulsar.Producer.Worker do
 
   defp maybe_chunk(payload, base_metadata, %{chunking_enabled: true} = state) do
     payload_size = byte_size(payload)
-    uuid = Uniq.UUID.uuid4()
 
-    case chunk_payload_budget(base_metadata, uuid, payload_size, state) do
+    case chunk_payload_budget(base_metadata, payload_size, state) do
       # The metadata on its own fills the broker's limit, and smaller chunks would only
       # repeat it, so no split can rescue this message.
       chunk_size when chunk_size < 1 ->
         {:error, :metadata_too_large}
 
       chunk_size when payload_size > chunk_size ->
-        {:ok, split_into_chunks(payload, payload_size, uuid, chunk_size, state)}
+        {:ok, split_into_chunks(payload, payload_size, chunk_size, state)}
 
       _ ->
         {:ok, [{payload, nil}]}
@@ -755,7 +775,8 @@ defmodule Pulsar.Producer.Worker do
 
   defp maybe_chunk(payload, _base_metadata, _state), do: {:ok, [{payload, nil}]}
 
-  defp split_into_chunks(payload, payload_size, uuid, chunk_size, state) do
+  defp split_into_chunks(payload, payload_size, chunk_size, state) do
+    uuid = Uniq.UUID.uuid4()
     num_chunks = div(payload_size + chunk_size - 1, chunk_size)
 
     Logger.debug("Chunking message: #{payload_size} bytes into #{num_chunks} chunks (max: #{chunk_size} bytes each)")
@@ -763,7 +784,7 @@ defmodule Pulsar.Producer.Worker do
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :start],
       %{total_size: payload_size, num_chunks: num_chunks, chunk_size: chunk_size},
-      %{uuid: uuid, producer_id: state.producer_id, topic: state.topic}
+      chunk_context(state, uuid)
     )
 
     Enum.map(0..(num_chunks - 1), fn chunk_id ->
@@ -784,12 +805,12 @@ defmodule Pulsar.Producer.Worker do
   # The broker's limit covers the metadata each chunk repeats as well as its payload.
   # :max_message_size counts payload bytes only, so the deduction applies to the broker's
   # limit alone.
-  defp chunk_payload_budget(base_metadata, uuid, total_size, state) do
+  defp chunk_payload_budget(base_metadata, total_size, state) do
     case state.broker_max_message_size do
       broker_limit when is_integer(broker_limit) and broker_limit > 0 ->
         metadata = %{
           base_metadata
-          | uuid: uuid,
+          | uuid: @uuid_placeholder,
             chunk_id: 0,
             num_chunks_from_msg: 0,
             total_chunk_msg_size: total_size

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -30,6 +30,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     :ok
   end
 
+  @tag telemetry_listen: [[:pulsar, :producer, :chunk, :start]]
   test "receives and reassembles a simple chunked message" do
     topic = isolated_topic("simple")
     large_message = "This is a test message that will be chunked."
@@ -69,6 +70,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert received_msg.chunk_metadata.chunked == true
     assert received_msg.chunk_metadata.complete == true
     assert received_msg.chunk_metadata.num_chunks == 2
+
+    # Workers pick these up from their options by name, so a rename empties every event.
+    assert_receive {:telemetry_event, %{event: [:pulsar, :producer, :chunk, :start], metadata: metadata}}
+    assert metadata.topic == topic
+    assert metadata.base_topic == topic
+    assert metadata.partition == nil
   end
 
   test "handles interleaved chunks from multiple chunked messages" do
@@ -379,7 +386,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     topic = isolated_topic("budget-boundary")
 
     # Just past the limit, so the first chunk fills the budget exactly and the second holds
-    # the remainder. Sending twice the limit would prove nothing more.
+    # the remainder.
     message = String.duplicate("x", 6_291_456)
 
     {:ok, producer} =
@@ -617,6 +624,11 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert measurements.received_chunks == 1
     assert measurements.num_chunks == 3
     assert metadata.uuid == "fake-uuid-oldest"
+
+    assert metadata.topic == topic
+    assert metadata.base_topic == topic
+    assert metadata.partition == nil
+    assert metadata.subscription_name == "chunking-evict"
 
     Utils.wait_for(fn ->
       @consumer_callback.count_messages(consumer) == 1

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -372,6 +372,37 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert Pulsar.Message.properties(received_msg) == bulky_properties
   end
 
+  test "sizes a chunk so a full one still clears the broker's own limit" do
+    # Chunks budgeted right up to :max_message_size, which defaults to the broker's limit.
+    # The producer's deduction and the broker's check on the whole frame are separate
+    # calculations, and this is where they have to agree.
+    topic = isolated_topic("budget-boundary")
+    message = String.duplicate("x", 5_242_880 * 2)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(
+        topic,
+        client: @client,
+        name: :chunking_budget_boundary_producer,
+        chunking_enabled: true
+      )
+
+    {:ok, _consumer_group} =
+      Pulsar.Consumer.start(topic, "chunking-budget-boundary", @consumer_callback,
+        client: @client,
+        init_args: [notify_pid: self()]
+      )
+
+    [consumer] = Utils.wait_for_consumer_ready(1)
+
+    assert {:ok, _msg_id} = Pulsar.Producer.send(producer, message)
+
+    Utils.wait_for(fn -> @consumer_callback.count_messages(consumer) == 1 end)
+
+    [received_msg] = @consumer_callback.get_messages(consumer)
+    assert received_msg.payload == message
+  end
+
   test "refuses a message whose metadata alone exceeds the broker's limit" do
     # Has to fail in the producer: reaching the broker with this costs the whole connection.
     oversized_properties = %{"padding" => String.duplicate("p", 6_291_456)}
@@ -598,7 +629,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   # These tests run async against one broker, and a subscription starting at :latest would
-  # otherwise pick up whatever the others happen to be publishing at the time. The broker
-  # creates the topic on first use, so this stays a name rather than an admin call.
+  # otherwise pick up whatever the others are publishing. Naming a topic is enough while the
+  # cluster has allowAutoTopicCreation on; without it this needs System.create_topic/1.
   defp isolated_topic(suffix), do: @topic <> "-" <> suffix
 end

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -173,7 +173,14 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     assert byte_size(very_large_message) == 6_291_456
 
-    assert {:error, _reason} = Pulsar.Producer.send(producer, very_large_message)
+    Utils.wait_for(
+      fn -> Pulsar.Producer.send(producer, very_large_message) end,
+      until: &(&1 == {:error, :message_too_large}),
+      description: "the producer to refuse the oversized message"
+    )
+
+    # Reaching the broker with this would have closed the connection.
+    assert {:ok, _msg_id} = Pulsar.Producer.send(producer, "still connected")
   end
 
   test "producer with chunking enabled can send and receive messages larger than 5MB" do
@@ -336,6 +343,25 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     [received_msg] = @consumer_callback.get_messages(consumer)
     assert received_msg.payload == very_large_message
     assert Pulsar.Message.properties(received_msg) == bulky_properties
+  end
+
+  test "refuses a message whose metadata alone exceeds the broker's limit" do
+    # Has to fail in the producer: reaching the broker with this costs the whole connection.
+    oversized_properties = %{"padding" => String.duplicate("p", 6_291_456)}
+
+    {:ok, producer} =
+      Pulsar.Producer.start(
+        @topic,
+        client: @client,
+        name: :chunking_oversized_metadata_producer,
+        chunking_enabled: true
+      )
+
+    Utils.wait_for(
+      fn -> Pulsar.Producer.send(producer, "small payload", properties: oversized_properties) end,
+      until: &(&1 == {:error, :metadata_too_large}),
+      description: "the producer to refuse the oversized metadata"
+    )
   end
 
   @tag telemetry_listen: [[:pulsar, :consumer, :chunk, :expired]]

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -129,6 +129,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert p2_large_message in payloads
   end
 
+  @tag telemetry_listen: [[:pulsar, :producer, :message, :published]]
   test "handles mix of chunked and non-chunked messages" do
     topic = isolated_topic("mixed")
     small_message = "Small message"
@@ -168,6 +169,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     payloads = Enum.map(messages, & &1.payload)
     assert Enum.count(payloads, &(&1 == small_message)) == 2
     assert large_message in payloads
+
+    # An unchunked send groups by the same keys a chunked one does.
+    assert_receive {:telemetry_event, %{event: [:pulsar, :producer, :message, :published], metadata: metadata}}
+    assert metadata.topic == topic
+    assert metadata.base_topic == topic
+    assert metadata.partition == nil
   end
 
   test "producer with chunking disabled cannot send 5MB messages" do

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -257,8 +257,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
       assert received_msg.chunk_metadata.complete == true
       assert received_msg.chunk_metadata.num_chunks > 1
 
-      # Every chunk describes the message it belongs to, not the slice it carries, which is
-      # what lets a consumer size the buffer before the last chunk arrives.
+      # Every chunk describes the message it belongs to, not the slice it carries.
       for metadata <- received_msg.raw.metadata do
         assert metadata.uncompressed_size == byte_size(large_message)
         assert metadata.total_chunk_msg_size == hd(received_msg.raw.metadata).total_chunk_msg_size
@@ -267,8 +266,8 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "compresses before deciding whether to chunk" do
-    # Compresses to far under :max_message_size, so splitting the compressed bytes leaves
-    # nothing to split. Splitting first would have sent 64 chunks.
+    # Compresses to well under :max_message_size, so there is nothing left to split.
+    # Splitting first would have sent 64 chunks.
     compressible_message = String.duplicate("a", 65_536)
 
     {:ok, producer} =

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -31,11 +31,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "receives and reassembles a simple chunked message" do
+    topic = isolated_topic("simple")
     large_message = "This is a test message that will be chunked."
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_simple_producer,
         chunking_enabled: true,
@@ -44,7 +45,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-simple",
         @consumer_callback,
         client: @client,
@@ -71,12 +72,13 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "handles interleaved chunks from multiple chunked messages" do
+    topic = isolated_topic("interleaved")
     p1_large_message = "This is a test message that will be chunked from producer 1."
     p2_large_message = "This is a test message that will be chunked from producer 2."
 
     {:ok, producer1} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_interleaved_producer1,
         chunking_enabled: true,
@@ -85,7 +87,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, producer2} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_interleaved_producer2,
         chunking_enabled: true,
@@ -94,7 +96,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-interleaved",
         @consumer_callback,
         client: @client,
@@ -121,12 +123,13 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "handles mix of chunked and non-chunked messages" do
+    topic = isolated_topic("mixed")
     small_message = "Small message"
     large_message = "This is a test message that will be chunked."
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_mixed_producer,
         chunking_enabled: true,
@@ -135,7 +138,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-mixed",
         @consumer_callback,
         client: @client,
@@ -161,11 +164,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "producer with chunking disabled cannot send 5MB messages" do
+    topic = isolated_topic("disabled")
     very_large_message = String.duplicate("x", 6_291_456)
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_disabled_producer,
         chunking_enabled: false
@@ -184,11 +188,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "producer with chunking enabled can send and receive messages larger than 5MB" do
+    topic = isolated_topic("5mb")
     very_large_message = String.duplicate("x", 6_291_456)
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_enabled_5mb_producer,
         chunking_enabled: true
@@ -196,7 +201,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-5mb",
         @consumer_callback,
         client: @client,
@@ -227,24 +232,30 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert received_msg.chunk_metadata.num_chunks == 2
   end
 
+  @chunk_size 1024
+
   for compression <- [:none, :lz4, :zlib, :snappy, :zstd] do
     test "reassembles a chunked message compressed with #{compression}" do
       compression = unquote(compression)
-      large_message = :crypto.strong_rand_bytes(8192)
+      topic = isolated_topic("#{compression}")
+
+      # Half incompressible so it still needs several chunks once compressed, half trivially
+      # compressible so every codec removes something.
+      large_message = :crypto.strong_rand_bytes(4096) <> String.duplicate("a", 4096)
 
       {:ok, producer} =
         Pulsar.Producer.start(
-          @topic,
+          topic,
           client: @client,
           name: :"chunking_#{compression}_producer",
           chunking_enabled: true,
           compression: compression,
-          max_message_size: 1024
+          max_message_size: @chunk_size
         )
 
       {:ok, _consumer_group} =
         Pulsar.Consumer.start(
-          @topic,
+          topic,
           "chunking-#{compression}",
           @consumer_callback,
           client: @client,
@@ -267,19 +278,33 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
       # Every chunk describes the message it belongs to, not the slice it carries.
       for metadata <- received_msg.raw.metadata do
         assert metadata.uncompressed_size == byte_size(large_message)
-        assert metadata.total_chunk_msg_size == hd(received_msg.raw.metadata).total_chunk_msg_size
+      end
+
+      [%{total_chunk_msg_size: total} | _] = received_msg.raw.metadata
+      assert Enum.all?(received_msg.raw.metadata, &(&1.total_chunk_msg_size == total))
+
+      # An uncompressed total would not account for the chunks sent, for any codec that
+      # removed a byte.
+      assert received_msg.chunk_metadata.num_chunks == ceil(total / @chunk_size)
+
+      if compression == :none do
+        assert total == byte_size(large_message)
+      else
+        assert total < byte_size(large_message)
       end
     end
   end
 
   test "compresses before deciding whether to chunk" do
+    topic = isolated_topic("compress-first")
+
     # Compresses to well under :max_message_size, so there is nothing left to split.
     # Splitting first would have sent 64 chunks.
     compressible_message = String.duplicate("a", 65_536)
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_compress_first_producer,
         chunking_enabled: true,
@@ -289,7 +314,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-compress-first",
         @consumer_callback,
         client: @client,
@@ -310,6 +335,8 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
   end
 
   test "leaves room for the message metadata inside the broker's size limit" do
+    topic = isolated_topic("metadata-overhead")
+
     # Properties ride along with every chunk, so a chunk sized to :max_message_size on its
     # own would put the frame over what the broker accepts.
     bulky_properties = %{"padding" => String.duplicate("p", 32_768)}
@@ -317,7 +344,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_metadata_overhead_producer,
         chunking_enabled: true
@@ -325,7 +352,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-metadata-overhead",
         @consumer_callback,
         client: @client,
@@ -351,7 +378,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        isolated_topic("oversized-metadata"),
         client: @client,
         name: :chunking_oversized_metadata_producer,
         chunking_enabled: true
@@ -371,7 +398,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        isolated_topic("expire"),
         "chunking-expire",
         @consumer_callback,
         client: @client,
@@ -442,9 +469,11 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     alias Proto, as: Binary
     alias Pulsar.Consumer.ChunkedMessageContext
 
+    topic = isolated_topic("evict")
+
     {:ok, producer} =
       Pulsar.Producer.start(
-        @topic,
+        topic,
         client: @client,
         name: :chunking_evict_producer,
         chunking_enabled: true,
@@ -453,7 +482,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
 
     {:ok, _consumer_group} =
       Pulsar.Consumer.start(
-        @topic,
+        topic,
         "chunking-evict",
         @consumer_callback,
         client: @client,
@@ -550,7 +579,9 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
                     }},
                    2000
 
-    assert measurements.reason == :queue_full
+    assert metadata.reason == :queue_full
+    assert measurements.received_chunks == 1
+    assert measurements.num_chunks == 3
     assert metadata.uuid == "fake-uuid-oldest"
 
     Utils.wait_for(fn ->
@@ -565,4 +596,9 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert received_msg.chunk_metadata.complete == true
     assert received_msg.chunk_metadata.num_chunks == 2
   end
+
+  # These tests run async against one broker, and a subscription starting at :latest would
+  # otherwise pick up whatever the others happen to be publishing at the time. The broker
+  # creates the topic on first use, so this stays a name rather than an admin call.
+  defp isolated_topic(suffix), do: @topic <> "-" <> suffix
 end

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -377,7 +377,10 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     # The producer's deduction and the broker's check on the whole frame are separate
     # calculations, and this is where they have to agree.
     topic = isolated_topic("budget-boundary")
-    message = String.duplicate("x", 5_242_880 * 2)
+
+    # Just past the limit, so the first chunk fills the budget exactly and the second holds
+    # the remainder. Sending twice the limit would prove nothing more.
+    message = String.duplicate("x", 6_291_456)
 
     {:ok, producer} =
       Pulsar.Producer.start(

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -220,6 +220,125 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert received_msg.chunk_metadata.num_chunks == 2
   end
 
+  for compression <- [:none, :lz4, :zlib, :snappy, :zstd] do
+    test "reassembles a chunked message compressed with #{compression}" do
+      compression = unquote(compression)
+      large_message = :crypto.strong_rand_bytes(8192)
+
+      {:ok, producer} =
+        Pulsar.Producer.start(
+          @topic,
+          client: @client,
+          name: :"chunking_#{compression}_producer",
+          chunking_enabled: true,
+          compression: compression,
+          max_message_size: 1024
+        )
+
+      {:ok, _consumer_group} =
+        Pulsar.Consumer.start(
+          @topic,
+          "chunking-#{compression}",
+          @consumer_callback,
+          client: @client,
+          init_args: [notify_pid: self()]
+        )
+
+      [consumer] = Utils.wait_for_consumer_ready(1)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, large_message)
+
+      Utils.wait_for(fn ->
+        @consumer_callback.count_messages(consumer) == 1
+      end)
+
+      [received_msg] = @consumer_callback.get_messages(consumer)
+      assert received_msg.payload == large_message
+      assert received_msg.chunk_metadata.complete == true
+      assert received_msg.chunk_metadata.num_chunks > 1
+
+      # Every chunk describes the message it belongs to, not the slice it carries, which is
+      # what lets a consumer size the buffer before the last chunk arrives.
+      for metadata <- received_msg.raw.metadata do
+        assert metadata.uncompressed_size == byte_size(large_message)
+        assert metadata.total_chunk_msg_size == hd(received_msg.raw.metadata).total_chunk_msg_size
+      end
+    end
+  end
+
+  test "compresses before deciding whether to chunk" do
+    # Compresses to far under :max_message_size, so splitting the compressed bytes leaves
+    # nothing to split. Splitting first would have sent 64 chunks.
+    compressible_message = String.duplicate("a", 65_536)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(
+        @topic,
+        client: @client,
+        name: :chunking_compress_first_producer,
+        chunking_enabled: true,
+        compression: :zlib,
+        max_message_size: 1024
+      )
+
+    {:ok, _consumer_group} =
+      Pulsar.Consumer.start(
+        @topic,
+        "chunking-compress-first",
+        @consumer_callback,
+        client: @client,
+        init_args: [notify_pid: self()]
+      )
+
+    [consumer] = Utils.wait_for_consumer_ready(1)
+
+    {:ok, _msg_id} = Pulsar.Producer.send(producer, compressible_message)
+
+    Utils.wait_for(fn ->
+      @consumer_callback.count_messages(consumer) == 1
+    end)
+
+    [received_msg] = @consumer_callback.get_messages(consumer)
+    assert received_msg.payload == compressible_message
+    assert received_msg.chunk_metadata == nil
+  end
+
+  test "leaves room for the message metadata inside the broker's size limit" do
+    # Properties ride along with every chunk, so a chunk sized to :max_message_size on its
+    # own would put the frame over what the broker accepts.
+    bulky_properties = %{"padding" => String.duplicate("p", 32_768)}
+    very_large_message = String.duplicate("x", 6_291_456)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(
+        @topic,
+        client: @client,
+        name: :chunking_metadata_overhead_producer,
+        chunking_enabled: true
+      )
+
+    {:ok, _consumer_group} =
+      Pulsar.Consumer.start(
+        @topic,
+        "chunking-metadata-overhead",
+        @consumer_callback,
+        client: @client,
+        init_args: [notify_pid: self()]
+      )
+
+    [consumer] = Utils.wait_for_consumer_ready(1)
+
+    {:ok, _msg_id} = Pulsar.Producer.send(producer, very_large_message, properties: bulky_properties)
+
+    Utils.wait_for(fn ->
+      @consumer_callback.count_messages(consumer) == 1
+    end)
+
+    [received_msg] = @consumer_callback.get_messages(consumer)
+    assert received_msg.payload == very_large_message
+    assert Pulsar.Message.properties(received_msg) == bulky_properties
+  end
+
   @tag telemetry_listen: [[:pulsar, :consumer, :chunk, :expired]]
   test "expired incomplete chunked messages are cleaned up and delivered" do
     alias Proto, as: Binary

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -112,6 +112,19 @@ defmodule Pulsar.Integration.Producer.BatchTest do
 
       assert [] = Utils.collect_events([:pulsar, :producer, :batch, :published], producer_names: [state.producer_name])
     end
+
+    test "refuses a batch the broker would reject, and keeps the connection" do
+      {_consumer_pid, producer_pid} =
+        setup_producer_consumer("oversized-batch", batch_size: 2, flush_interval: 30_000)
+
+      half_of_an_oversized_batch = String.duplicate("x", 3 * 1024 * 1024)
+
+      assert [{:error, :message_too_large}, {:error, :message_too_large}] =
+               send_concurrently(producer_pid, [half_of_an_oversized_batch, half_of_an_oversized_batch])
+
+      # Reaching the broker with this would have closed the connection.
+      assert [{:ok, _}, {:ok, _}] = send_concurrently(producer_pid, ["a", "b"])
+    end
   end
 
   # Helpers
@@ -146,9 +159,16 @@ defmodule Pulsar.Integration.Producer.BatchTest do
   end
 
   defp send_messages(producer_pid, messages) do
-    tasks = Enum.map(messages, fn msg -> Task.async(fn -> Pulsar.Producer.send(producer_pid, msg) end) end)
-    results = Task.await_many(tasks, 10_000)
+    results = send_concurrently(producer_pid, messages)
     assert Enum.all?(results, &match?({:ok, _}, &1))
+  end
+
+  # A batch only flushes once :batch_size messages are in, so its callers have to be waiting
+  # at the same time.
+  defp send_concurrently(producer_pid, messages) do
+    messages
+    |> Enum.map(fn msg -> Task.async(fn -> Pulsar.Producer.send(producer_pid, msg) end) end)
+    |> Task.await_many(10_000)
   end
 
   defp assert_messages_received(consumer_pid, expected_payloads) do

--- a/test/unit/producer_options_test.exs
+++ b/test/unit/producer_options_test.exs
@@ -61,6 +61,17 @@ defmodule Pulsar.Producer.OptionsTest do
       assert validate!(partition_discovery_interval_ms: 5_000)[:partition_discovery_interval_ms] == 5_000
     end
 
+    test "rejects chunking together with batching" do
+      assert_raise NimbleOptions.ValidationError, ~r/:chunking_enabled.*:batch_enabled/, fn ->
+        validate!(batch_enabled: true, chunking_enabled: true)
+      end
+    end
+
+    test "accepts chunking and batching on their own" do
+      assert validate!(chunking_enabled: true)[:chunking_enabled] == true
+      assert validate!(batch_enabled: true)[:batch_enabled] == true
+    end
+
     test "rejects unknown options" do
       assert_raise NimbleOptions.ValidationError, ~r/unknown options.*:batch_sze.*:nonsense/, fn ->
         validate!(batch_sze: 10, nonsense: true)

--- a/test/unit/protocol_test.exs
+++ b/test/unit/protocol_test.exs
@@ -119,6 +119,13 @@ defmodule Pulsar.ProtocolTest do
       assert payload == ctx.payload
     end
 
+    test "carries is_chunk, which no consumer-facing struct exposes", ctx do
+      frame = Protocol.encode(%{ctx.command | is_chunk: true}, ctx.metadata, ctx.payload)
+
+      assert {:ok, {command, _metadata, _payload, nil}} = Protocol.decode(frame)
+      assert command.is_chunk == true
+    end
+
     test "checksum covers the metadata size, metadata and payload", ctx do
       frame = Protocol.encode(ctx.command, ctx.metadata, ctx.payload)
 


### PR DESCRIPTION
## Summary

Chunked messages are framed the way the protocol specifies rather than the way this client happened to read back. Compression covers the whole message before it is split, `uncompressed_size` and `total_chunk_msg_size` describe the message rather than the slice, `CommandSend.is_chunk` is set, and the broker's advertised `max_message_size` caps chunk sizing instead of a hardcoded 5 MiB.

While the size limit was being threaded through, the producer also stopped handing the broker frames it refuses. An oversized send is now answered locally instead of by a dropped connection.

This changes the bytes on the wire for compressed chunked messages, so it belongs in 3.0 alongside the other breaks rather than costing users a second migration later.

## Motivation

Chunking round-tripped correctly between an Elixir producer and an Elixir consumer, and that is the entire reason four wire-level divergences survived. Both sides were wrong in the same direction, so every test passed.

| What the protocol says | What this client did (before this change) |
| --- | --- |
| Compress the message, then split the compressed bytes | Split the payload, then compress each chunk (`producer/worker.ex:267`) |
| Reassemble the chunks, then decompress once | Decompress each chunk on arrival, then reassemble (`consumer/worker.ex:366`) |
| `uncompressed_size` is the full message size, repeated on every chunk | The size of that chunk's slice (`producer/worker.ex:253`) |
| `total_chunk_msg_size` is the compressed total | The uncompressed total (`producer/worker.ex:719`) |
| `CommandSend.is_chunk` marks a chunk | Never set; the field existed only in the generated module (`protocol/binary.ex:1030`) |

The first two are one defect seen from each end, and they are the ones with teeth. A Java consumer reassembles the chunks and then decompresses the result, so it is handed a concatenation of independently compressed streams and fails to decode it. In the other direction this client tries to decompress a fragment of a single compressed stream. **Chunking plus compression does not interoperate at all**, and chunking without compression does, which is why the gap is invisible from inside the suite.

Three things kept this durable:

1. **A round-trip test cannot detect it.** Both ends share the defect, so the payload comes back byte-identical. Proving wire compatibility requires asserting on the metadata fields themselves, which nothing did.
2. **The combination had no coverage.** `compression` appeared nowhere in `chunking_test.exs`, so the one configuration that breaks was never exercised, in either direction.
3. **Nothing fails locally.** No error, no log line, no broker rejection. The message arrives; only a consumer written in another language cannot read it.

## Broker `max_message_size`

`CommandConnected` carries the broker's limit and it was logged and discarded (`broker.ex:671`, before this change), leaving `:max_message_size` to default to a hardcoded `5_242_880`.

**This was not broken at stock defaults, and the PR title should not be read as claiming it was.** Pulsar accepts `maxMessageSize` plus 10 KiB of frame padding — the same allowance already encoded in `protocol.ex:36` as `5 * 1024 * 1024 + 10 * 1024` — which comfortably absorbs an ordinary producer name, partition key and handful of properties. A chunk sized to the full limit fit, and the pre-existing 5 MiB test passed for that reason rather than by luck.

It leaves two real exposures:

- **Metadata larger than the padding.** Properties ride along with *every* chunk, so 32 KiB of them puts each frame past `limit + 10 KiB`.
- **A broker configured below the client default.** Common on managed and multi-tenant deployments, where the whole budget is smaller and the padding shrinks with it.

The broker's answer in both cases is the subject of the next section.

`Broker.get_max_message_size/1` (`broker.ex:186`) exposes what the handshake advertised, read once at producer registration. `:max_message_size` keeps its meaning as a budget for payload bytes, and only the broker's own limit has metadata and framing deducted from it (`producer/worker.ex:790`):

```elixir
min(state.max_message_size, broker_limit - overhead)
```

This asymmetry is deliberate. Deducting from the configured value too would silently shrink `max_message_size: 32` to nothing.

## An oversized frame costs the connection, not the send

The broker does not reply with `CommandSendError`. It closes the TCP connection. Measured against `apachepulsar/pulsar:4.2.4` with a 6 MiB unchunked message:

```
1. small send before: {:ok, ...}
   [error] Socket closed by remote (0 pending requests, 0 consumers, 1 producers)
   [error] Connection closed. Reconnecting in 11ms.
2. oversized send: {:error, ...}   took (ms): 13
3. small send after: {:ok, ...}
```

Nothing hangs and the client recovers on its own, so the cost is not latency — it is that a broker connection is shared by every producer and consumer bound to that broker. The parenthetical counts what went down with it; the same line during a chunked reproduction read `0 pending requests, 7 consumers, 8 producers`. One oversized message from one producer restarts all of them.

The check lives in `Pulsar.Broker` (`broker.ex:562`), as a guard on the `:publish_message` clause that already receives the encoded frame. The broker process owns both the connection and the limit the handshake advertised, so nothing has to be cached or kept fresh elsewhere, and the cost is a `byte_size/1` on a binary rather than a second protobuf encode. Every publisher is covered by construction:

| Path | Before | After |
| --- | --- | --- |
| Unchunked send | Connection dropped, `{:error, :closed}` | `{:error, :message_too_large}` |
| Batch too large to flush | Connection dropped | `{:error, :message_too_large}` to each caller |
| Metadata alone over the limit, chunking on | Connection dropped | `{:error, :metadata_too_large}` |
| Chunked send | — | Cannot trip it; chunks are sized to fit |

The producer still reads the limit at registration, but only to size chunks (`producer/worker.ex:790`); enforcement is not its job. This matches what the Java client does, which validates size client-side and skips the check when chunking is enabled.

`:metadata_too_large` is a distinct error rather than a case of `:message_too_large` because the remedies are opposite: it fires when the *metadata* fills the limit, with a 13-byte payload in the test that covers it, and enabling chunking cannot help — every chunk repeats the metadata that is already too big.

## Batching and chunking are now rejected together

A batch is one entry holding many messages; a chunked message is one message spread over many entries. `producer/options.ex:144` refuses the pair instead of silently taking the batch path and never chunking. The docs claimed batching was "automatically disabled" when chunking was set, which was never true.

## Verification

`test.integration` is green against `apachepulsar/pulsar:4.2.4`, 389 tests total.

**Wire assertions, not round trips.** Since a round trip cannot see the defect, the new matrix asserts on the metadata the consumer received — `uncompressed_size` equal to the full message on every chunk, and `total_chunk_msg_size` consistent across them — for each of `:none`, `:lz4`, `:zlib`, `:snappy` and `:zstd`.

**The two size calculations are pinned against each other.** The producer deducts metadata and framing from the broker's limit; the broker checks the whole encoded frame. Those are separate calculations in separate modules with about 20 bytes of margin between them, so `sizes a chunk so a full one still clears the broker's own limit` sends a message just past the default limit, where the first chunk fills the budget exactly.

**A partial send no longer reuses sequence ids.** If a chunk fails after its predecessors reached the socket, the producer keeps the sequence ids they consumed rather than rolling the counter back — reissuing ids that are still in flight is exactly what broker-side deduplication reads as a repeat, which would silently drop later messages on a topic with dedup enabled. Their pending entries are dropped, since a message missing chunks can never complete. This was a latent bug from before the PR, in the function it restructures.

**The chunk count pins the total.** Each matrix case asserts `num_chunks == ceil(total_chunk_msg_size / max_message_size)`, so the field has to describe the bytes that were actually split. The payload is half incompressible and half trivially compressible, which keeps the message above one chunk after every codec while still guaranteeing `total < byte_size(payload)` — an uncompressed total fails the equation for any codec that removed a byte.

**A discriminating case for the ordering.** `compresses before deciding whether to chunk` sends 64 KiB of repeated bytes at `max_message_size: 1024`. Compressing first leaves ~30 bytes and no chunking at all; splitting first would have sent 64 chunks. The assertion is `chunk_metadata == nil`, which only holds under the correct order.

**The size budget was checked by reverting it.** Restoring the un-deducted budget and rerunning left 13/14 passing, failing only `leaves room for the message metadata inside the broker's size limit`, and failing by dropping the connection rather than by a bad assertion. The deduction is load-bearing and the test has teeth.

**`is_chunk` is pinned at the protocol layer only.** A consumer receives a `CommandMessage`, never the `CommandSend` that carried the flag, so it cannot be asserted end to end. `protocol_test.exs` pins that the field survives encoding and decoding; that the producer sets it on chunks is covered by reading the code, not by a test.

**Known gap in provenance.** Every claim here about Java's framing is drawn from the Java client's implementation rather than from running one against this branch. There is no cross-client test in the suite, so interoperability is argued rather than demonstrated — the opposite of how #176 pinned its hashing vectors to upstream's own suites. A Java or Go producer and consumer in the integration environment would settle it, and is worth doing separately.

## Breaking changes and migration

### 1. Compressed chunked messages are framed differently

Only messages with both `:chunking_enabled` and `:compression` set are affected. Uncompressed chunked messages are byte-identical to before, since splitting and reassembling is the same operation either way.

A consumer older than this release cannot read chunks produced by it, and vice versa. Drain in-flight chunked topics before upgrading producers, or upgrade consumers first.

### 2. `batch_enabled: true` with `chunking_enabled: true` now raises

Previously accepted and quietly resolved in favour of batching, so large messages were never chunked. Any producer configured this way was not getting the chunking it asked for; pick one.

### 3. Oversized sends return an error instead of dropping the connection

Strictly an improvement, but code that relied on the reconnect, or that matched on whichever disconnect error a too-large send happened to surface, now sees `{:error, :message_too_large}`.

### 4. An incomplete chunked message carries compressed bytes

A `complete: false` message's `payload` is the chunks that did arrive, concatenated. Decompression now happens after reassembly, so under `:compression` those bytes are still compressed — and a partial compressed stream cannot be decompressed at all. Previously each chunk was decompressed on arrival, so the fragment was plaintext. Both are unusable as a message; anything doing best-effort salvage on partial payloads is affected. Documented in `docs/chunking.md`.

### 5. Chunk telemetry changed units, and `:discarded` moved a key

Two changes for anyone with a handler attached:

- `[:pulsar, :producer, :chunk, :start]`'s `total_size` and `[:pulsar, :producer, :chunk, :sent]`'s `chunk_size` now count the bytes actually sent, which under `:compression` is the compressed message rather than the payload passed to `send/3`. Dashboards will show a step change on upgrade.
- `[:pulsar, :consumer, :chunk, :discarded]` carried `reason` in its **measurements**, where the convention is numeric values to aggregate. It moves to metadata, alongside a `reason` on `:expired` that was previously implicit in the event name.

The events also gained fields, which is additive and needs no action:

| Event | Added |
| --- | --- |
| `:consumer, :chunk, :complete` | `age_ms` — how long assembly took, which is what `:expire_incomplete_chunked_message_after` should be tuned against |
| `:consumer, :chunk, :discarded` | `received_chunks`, `num_chunks` — it previously carried no numbers at all, so there was no way to tell how much of a message was lost |
| `:consumer, :chunk, :expired` | `num_chunks`, to pair with the `received_chunks` it already had |
| every consumer chunk event | `topic`, `base_topic`, `partition`, `subscription_name`; `consumer_id` alone is an internal integer |
| every producer chunk event | `topic`, `base_topic`, `partition`, where only `:start` carried a topic at all |

Both sides emit the physical and the logical topic, so one set of events aggregates over a partitioned topic and still breaks down by partition. The keys are the ones `Pulsar.Consumer.Worker`'s callback context already uses, and `consumer/callback.ex:161` already documented the intent — "use `:topic` as a per-partition key for metrics or flow accounting, and `:base_topic` where business logic cares about the logical topic". The producer was being handed `base_topic` and `partition` by the topology (`topology.ex:594`) and dropping them on the floor, since neither was in its struct.

Note that consumer `:complete`'s `total_size` measures the reassembled message *after* decompression while the producer's counts compressed bytes, so the two do not line up when compression is on. Documented in `docs/chunking.md`.
