### PR TITLE
Improve handling of sequence ids by producers

### DIFF
--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -87,6 +87,10 @@ defmodule Pulsar.Consumer.DeadLetter do
     # send/3 already answers {:error, :not_ready} during discovery and turns a worker dying
     # mid-send into an error, so an unavailable dead letter topic never reaches the consumer.
     case Producer.send(producer, message.payload, opts) do
+      # {:ok, :deduplicated} is acknowledged along with the rest. An error would nack the message
+      # into a divert that is still over the redelivery threshold, so it would divert again, and
+      # this producer's name is shared by every node running the consumer -- a collision between
+      # them need not clear. The producer already logs and reports what the broker discarded.
       {:ok, _message_id} -> :ok
       {:error, _reason} = error -> error
     end

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -29,6 +29,22 @@ defmodule Pulsar.Producer do
   alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
   alias Pulsar.Topology
 
+  @typedoc """
+  What a chunked send is answered with, since its message spans several broker messages.
+  """
+  @type chunked_message_id :: %{
+          first_chunk_message_id: MessageIdData.t(),
+          last_chunk_message_id: MessageIdData.t(),
+          uuid: String.t(),
+          num_chunks: pos_integer()
+        }
+
+  @typedoc """
+  What `send/3` is answered with. `:deduplicated` carries no message id because the broker
+  assigned none; see `send/3`.
+  """
+  @type send_result :: MessageIdData.t() | chunked_message_id() | :deduplicated
+
   @doc false
   def child_spec(opts), do: Topology.child_spec(__MODULE__, id(opts), opts)
 
@@ -118,6 +134,15 @@ defmodule Pulsar.Producer do
   - `{:error, :metadata_too_large}` with `:chunking_enabled`, when `:properties` and the rest
     of the metadata leave no room for a payload to be split into
 
+  A successful send answers with the broker's message id, or with a `t:chunked_message_id/0`
+  when `:chunking_enabled` split the payload.
+
+  On a topic with deduplication enabled it can instead answer `{:ok, :deduplicated}`: the broker
+  recognised the sequence id as one it had already stored, kept the message it had, and assigned
+  this call no message id. Deduplication matches on the sequence id alone and never on the
+  payload, so the message it kept is not necessarily the one passed here. Before 3.0 this was
+  reported as `{:ok, message_id}`, with a message id referring to nothing.
+
   ## Options
 
   - `:partition_key` - decides the partition of a partitioned topic, hashed under the
@@ -134,7 +159,7 @@ defmodule Pulsar.Producer do
       {:ok, message_id} = Pulsar.Producer.send(:audit, "payload", partition_key: "tenant-1")
   """
   @spec send(pid() | String.t() | atom(), binary(), keyword()) ::
-          {:ok, MessageIdData.t()} | {:error, term()}
+          {:ok, send_result()} | {:error, term()}
   def send(producer, message, opts \\ [])
 
   def send(producer, message, opts) when is_pid(producer) and is_binary(message), do: publish(producer, message, opts)

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -442,11 +442,16 @@ defmodule Pulsar.Producer.Worker do
     callers = Enum.map(batch, fn {_message, from} -> from end)
     messages_count = length(messages)
 
+    # A batch spends one sequence id per message it carries, so the next one starts past the
+    # whole range. Advertising only the first repeats the ids consumers see and leaves the
+    # broker's high-water mark short of what was handed out.
     sequence_id = state.sequence_id + 1
+    highest_sequence_id = sequence_id + messages_count - 1
 
     command_send = %Binary.CommandSend{
       producer_id: state.producer_id,
       sequence_id: sequence_id,
+      highest_sequence_id: highest_sequence_id,
       num_messages: messages_count
     }
 
@@ -463,6 +468,7 @@ defmodule Pulsar.Producer.Worker do
     message_metadata = %Binary.MessageMetadata{
       producer_name: state.producer_name,
       sequence_id: sequence_id,
+      highest_sequence_id: highest_sequence_id,
       publish_time: System.system_time(:millisecond),
       compression: Protocol.to_compression(state.compression),
       uncompressed_size: uncompressed_size,
@@ -482,9 +488,10 @@ defmodule Pulsar.Producer.Worker do
           Map.put(producer_metadata(state), :sequence_id, sequence_id)
         )
 
+        # Keyed on the first id, which is the one the receipt comes back on.
         new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}})
 
-        %{state | sequence_id: sequence_id, pending_sends: new_pending, batch: [], batched: 0}
+        %{state | sequence_id: highest_sequence_id, pending_sends: new_pending, batch: [], batched: 0}
 
       {:error, reason} ->
         Logger.error("Failed to send batch: #{inspect(reason)}")

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -33,6 +33,9 @@ defmodule Pulsar.Producer.Worker do
   # never generates a uuid. Only its encoded length matters here.
   @uuid_placeholder "00000000-0000-0000-0000-000000000000"
 
+  # The broker's -1, as it arrives over an unsigned 64-bit field.
+  @unpersisted 18_446_744_073_709_551_615
+
   defstruct [
     :client,
     :topic,
@@ -120,7 +123,7 @@ defmodule Pulsar.Producer.Worker do
   (default 5000), and `:ordering_key`, which orders within a `:key_shared` subscription
   without affecting which partition the message lands on.
   """
-  @spec send_message(pid(), binary(), keyword()) :: {:ok, map()} | {:error, term()}
+  @spec send_message(pid(), binary(), keyword()) :: {:ok, map() | :deduplicated} | {:error, term()}
   def send_message(producer_pid, message, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 5000)
     GenServer.call(producer_pid, {:send_message, message, opts}, timeout)
@@ -327,6 +330,17 @@ defmodule Pulsar.Producer.Worker do
     {:noreply, %{state | batch_flush_timer: timer_ref}}
   end
 
+  # A topic with deduplication enabled acknowledges a send it discarded, using this in place of
+  # the message id it never assigned. The send did reach the broker, so the caller is told so.
+  @impl true
+  def handle_info(
+        {:send_receipt,
+         %Binary.CommandSendReceipt{message_id: %{ledgerId: @unpersisted, entryId: @unpersisted}} = receipt},
+        state
+      ) do
+    {:noreply, report_deduplicated(receipt, state)}
+  end
+
   @impl true
   def handle_info({:send_receipt, %Binary.CommandSendReceipt{} = receipt}, state) do
     new_state =
@@ -348,8 +362,10 @@ defmodule Pulsar.Producer.Worker do
           GenServer.reply(from, {:ok, receipt.message_id})
           %{state | pending_sends: new_pending}
 
+        # A chunk of a message that was given up on, which a partial send and a discarded chunk
+        # both leave behind: the entry is gone, but what reached the broker is still answered.
         {nil, _} ->
-          Logger.warning("Received receipt for unknown sequence_id #{receipt.sequence_id}")
+          Logger.debug("Received receipt for untracked sequence_id #{receipt.sequence_id}")
           state
       end
 
@@ -499,6 +515,48 @@ defmodule Pulsar.Producer.Worker do
         %{state | batch: [], batched: 0}
     end
   end
+
+  defp report_deduplicated(receipt, state) do
+    case Map.pop(state.pending_sends, receipt.sequence_id) do
+      {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
+        report_discarded(receipt, length(callers), state)
+        Enum.each(callers, fn from -> GenServer.reply(from, {:ok, :deduplicated}) end)
+        %{state | pending_sends: new_pending}
+
+      # One discarded chunk leaves a message that can never be reassembled, so the rest of it
+      # goes too rather than waiting for receipts that no longer complete anything.
+      {{from, %{uuid: uuid}}, new_pending} ->
+        report_discarded(receipt, 1, state)
+        GenServer.reply(from, {:ok, :deduplicated})
+        %{state | pending_sends: Map.reject(new_pending, &chunk_of?(&1, uuid))}
+
+      {{from, _metadata}, new_pending} ->
+        report_discarded(receipt, 1, state)
+        GenServer.reply(from, {:ok, :deduplicated})
+        %{state | pending_sends: new_pending}
+
+      # Answered and reported already, by the discarded chunk that dropped this one.
+      {nil, _} ->
+        Logger.debug("Received deduplicated receipt for untracked sequence_id #{receipt.sequence_id}")
+        state
+    end
+  end
+
+  defp report_discarded(receipt, count, state) do
+    Logger.warning(
+      "Broker discarded sequence_id #{receipt.sequence_id} on #{state.topic} as already stored " <>
+        "under producer name #{state.producer_name}"
+    )
+
+    :telemetry.execute(
+      [:pulsar, :producer, :message, :deduplicated],
+      %{count: count},
+      Map.put(producer_metadata(state), :sequence_id, receipt.sequence_id)
+    )
+  end
+
+  defp chunk_of?({_sequence_id, {_from, %{uuid: uuid}}}, uuid), do: true
+  defp chunk_of?(_pending_send, _uuid), do: false
 
   defp handle_chunk_receipt(receipt, from, chunk_metadata, new_pending, state) do
     uuid = chunk_metadata.uuid

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -582,6 +582,7 @@ defmodule Pulsar.Producer.Worker do
               |> Map.put(:topic_epoch, response.topic_epoch)
               |> Map.put(:schema_version, response.schema_version)
               |> Map.put(:broker_max_message_size, broker_max_message_size(broker_pid))
+              |> Map.put(:sequence_id, max(state.sequence_id, response.last_sequence_id))
 
             {:ok, state}
           else

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -72,8 +72,9 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert received_msg.chunk_metadata.num_chunks == 2
 
     # Workers pick these up from their options by name, so a rename empties every event.
-    assert_receive {:telemetry_event, %{event: [:pulsar, :producer, :chunk, :start], metadata: metadata}}
-    assert metadata.topic == topic
+    assert_receive {:telemetry_event,
+                    %{event: [:pulsar, :producer, :chunk, :start], metadata: %{topic: ^topic} = metadata}}
+
     assert metadata.base_topic == topic
     assert metadata.partition == nil
   end
@@ -171,8 +172,9 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert large_message in payloads
 
     # An unchunked send groups by the same keys a chunked one does.
-    assert_receive {:telemetry_event, %{event: [:pulsar, :producer, :message, :published], metadata: metadata}}
-    assert metadata.topic == topic
+    assert_receive {:telemetry_event,
+                    %{event: [:pulsar, :producer, :message, :published], metadata: %{topic: ^topic} = metadata}}
+
     assert metadata.base_topic == topic
     assert metadata.partition == nil
   end
@@ -502,11 +504,10 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
                     %{
                       event: [:pulsar, :consumer, :chunk, :expired],
                       measurements: measurements,
-                      metadata: metadata
+                      metadata: %{uuid: "test-uuid-expired"}
                     }}
 
     assert measurements.received_chunks == 2
-    assert metadata.uuid == "test-uuid-expired"
 
     updated_state = :sys.get_state(consumer)
     refute Map.has_key?(updated_state.chunked_message_contexts, "test-uuid-expired")
@@ -623,7 +624,7 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
                     %{
                       event: [:pulsar, :consumer, :chunk, :discarded],
                       measurements: measurements,
-                      metadata: metadata
+                      metadata: %{uuid: "fake-uuid-oldest"} = metadata
                     }},
                    2000
 

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -83,6 +83,32 @@ defmodule Pulsar.Integration.Producer.BatchTest do
       end
     end
 
+    # A batch spends one sequence id per message it carries, so the next batch has to start
+    # past the whole range. Starting at the previous batch's first id repeats the ids consumers
+    # see and understates the high-water mark the broker reports back on reconnect.
+    @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
+    test "consecutive batches claim sequence id ranges that do not overlap" do
+      {consumer_pid, producer_pid} =
+        setup_producer_consumer("sequence-ids", batch_size: 3, flush_interval: 30_000)
+
+      [producer] = Utils.wait_for(fn -> Topology.workers(producer_pid) end, until: &match?([_], &1))
+
+      messages = Enum.map(1..9, &"seq-#{&1}")
+      send_messages(producer_pid, messages)
+
+      assert_messages_received(consumer_pid, messages)
+
+      assert :sys.get_state(producer).sequence_id == 9
+
+      sequence_ids =
+        consumer_pid
+        |> DummyConsumer.get_messages()
+        |> Enum.map(& &1.raw.single_metadata.sequence_id)
+        |> Enum.sort()
+
+      assert sequence_ids == Enum.to_list(1..9)
+    end
+
     @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
     test "flushes single message batch on timer" do
       {consumer_pid, producer_pid} =

--- a/test/integration/producer/deduplication_test.exs
+++ b/test/integration/producer/deduplication_test.exs
@@ -1,6 +1,9 @@
 defmodule Pulsar.Integration.Producer.DeduplicationTest do
   use ExUnit.Case, async: true
 
+  import TelemetryTest
+
+  alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
   alias Pulsar.Test.Support.DummyConsumer
   alias Pulsar.Test.Support.System
   alias Pulsar.Test.Support.Utils
@@ -19,6 +22,8 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
     on_exit(fn -> Pulsar.Client.stop(@client) end)
   end
 
+  setup [:telemetry_listen]
+
   describe "a topic with deduplication enabled" do
     test "a producer restarting under the same name resumes past the sequence id it reached" do
       {consumer_pid, topic} = setup_topic("resume")
@@ -36,13 +41,73 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
       second = Enum.map(1..5, &"second-#{&1}")
 
       for payload <- second do
-        assert {:ok, message_id} = Pulsar.Producer.send(producer, payload)
-
-        # A deduplicated send is still answered, with this in place of a message id.
+        assert {:ok, %MessageIdData{} = message_id} = Pulsar.Producer.send(producer, payload)
         refute message_id.ledgerId == @deduplicated
       end
 
       assert_messages_received(consumer_pid, first ++ second)
+    end
+
+    # Resuming the counter stops a producer colliding with itself, but two sharing a name, or a
+    # topic whose mark rolled back, still reissue an id the broker has seen. Rewinding the
+    # counter is how that is reached from a single producer.
+    test "a send the broker discards as a duplicate answers with no message id" do
+      {consumer_pid, topic} = setup_topic("reissued")
+
+      producer = start_producer(topic, "reissued-producer")
+      assert {:ok, _} = Pulsar.Producer.send(producer, "stored")
+
+      [worker] = Topology.workers(producer)
+      :sys.replace_state(worker, &%{&1 | sequence_id: 0})
+
+      # Discarded on its sequence id, despite this payload never having been published.
+      assert {:ok, :deduplicated} = Pulsar.Producer.send(producer, "discarded")
+
+      # Published after the discarded one and on the same topic, so its arrival is the point at
+      # which "discarded" would have arrived too had the broker stored it.
+      assert {:ok, _} = Pulsar.Producer.send(producer, "barrier")
+      assert_messages_received(consumer_pid, ["stored", "barrier"])
+
+      assert ["stored", "barrier"] == consumer_pid |> DummyConsumer.get_messages() |> Enum.map(& &1.payload)
+    end
+
+    test "a chunked message is not deduplicated, though an unchunked one at the same id is" do
+      {_consumer_pid, topic} = setup_topic("chunked")
+
+      producer = start_producer(topic, "chunked-producer", chunking_enabled: true, max_message_size: 32)
+
+      # Three unchunked sends take ids 1..3, so that is the mark the broker holds.
+      for payload <- ["one", "two", "three"], do: assert({:ok, _} = Pulsar.Producer.send(producer, payload))
+
+      [worker] = Topology.workers(producer)
+      :sys.replace_state(worker, &%{&1 | sequence_id: 1})
+
+      # Four chunks over ids 2..5, the first two of them at or below the mark.
+      assert {:ok, %{num_chunks: 4}} = Pulsar.Producer.send(producer, String.duplicate("x", 128))
+      assert worker_state(producer).pending_sends == %{}
+
+      # The same id, unchunked, is discarded -- so it is is_chunk that exempts them.
+      :sys.replace_state(worker, &%{&1 | sequence_id: 1})
+      assert {:ok, :deduplicated} = Pulsar.Producer.send(producer, "unchunked")
+    end
+
+    @tag telemetry_listen: [[:pulsar, :producer, :message, :deduplicated]]
+    test "a discarded batch answers every caller and reports the messages it carried" do
+      {_consumer_pid, topic} = setup_topic("batch")
+
+      producer = start_producer(topic, "batch-producer", batch_enabled: true, batch_size: 3, flush_interval: 30_000)
+      producer_name = worker_state(producer).producer_name
+
+      assert [ok: _, ok: _, ok: _] = send_concurrently(producer, ["a", "b", "c"])
+
+      [worker] = Topology.workers(producer)
+      :sys.replace_state(worker, &%{&1 | sequence_id: 0})
+
+      assert [ok: :deduplicated, ok: :deduplicated, ok: :deduplicated] =
+               send_concurrently(producer, ["d", "e", "f"])
+
+      assert [%{count: 3}] =
+               Utils.collect_events([:pulsar, :producer, :message, :deduplicated], producer_names: [producer_name])
     end
   end
 
@@ -65,8 +130,8 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
     {consumer_pid, topic}
   end
 
-  defp start_producer(topic, name) do
-    {:ok, producer} = Pulsar.Producer.start(topic, client: @client, name: name)
+  defp start_producer(topic, name, opts \\ []) do
+    {:ok, producer} = Pulsar.Producer.start(topic, [client: @client, name: name] ++ opts)
 
     Utils.wait_for(fn -> Topology.workers(producer) end,
       until: fn
@@ -81,6 +146,12 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
   defp worker_state(producer) do
     [worker] = Topology.workers(producer)
     :sys.get_state(worker)
+  end
+
+  defp send_concurrently(producer, payloads) do
+    payloads
+    |> Enum.map(fn payload -> Task.async(fn -> Pulsar.Producer.send(producer, payload) end) end)
+    |> Task.await_many(10_000)
   end
 
   defp assert_messages_received(consumer_pid, expected_payloads) do

--- a/test/integration/producer/deduplication_test.exs
+++ b/test/integration/producer/deduplication_test.exs
@@ -1,0 +1,91 @@
+defmodule Pulsar.Integration.Producer.DeduplicationTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Test.Support.DummyConsumer
+  alias Pulsar.Test.Support.System
+  alias Pulsar.Test.Support.Utils
+  alias Pulsar.Topology
+
+  @moduletag :integration
+  @client :producer_dedup_test_client
+  @topic "persistent://public/default/producer-dedup-test"
+
+  # The broker's "not persisted" message id, which reaches us as an unsigned 64-bit -1.
+  @deduplicated 18_446_744_073_709_551_615
+
+  setup_all do
+    broker = System.broker()
+    {:ok, _} = Pulsar.Client.start_link(name: @client, host: broker.service_url)
+    on_exit(fn -> Pulsar.Client.stop(@client) end)
+  end
+
+  describe "a topic with deduplication enabled" do
+    test "a producer restarting under the same name resumes past the sequence id it reached" do
+      {consumer_pid, topic} = setup_topic("resume")
+
+      producer = start_producer(topic, "resume-producer")
+      first = Enum.map(1..5, &"first-#{&1}")
+      Enum.each(first, fn payload -> assert {:ok, _} = Pulsar.Producer.send(producer, payload) end)
+
+      assert worker_state(producer).sequence_id == 5
+      assert :ok = Pulsar.Producer.stop(producer, client: @client)
+
+      producer = start_producer(topic, "resume-producer")
+      assert worker_state(producer).sequence_id == 5
+
+      second = Enum.map(1..5, &"second-#{&1}")
+
+      for payload <- second do
+        assert {:ok, message_id} = Pulsar.Producer.send(producer, payload)
+
+        # A deduplicated send is still answered, with this in place of a message id.
+        refute message_id.ledgerId == @deduplicated
+      end
+
+      assert_messages_received(consumer_pid, first ++ second)
+    end
+  end
+
+  # Helpers
+
+  defp setup_topic(suffix) do
+    topic = @topic <> "-" <> suffix
+    :ok = System.create_topic(topic)
+    :ok = System.enable_deduplication(topic)
+
+    {:ok, _consumer_group} =
+      Pulsar.Consumer.start(topic, "dedup-#{suffix}-sub", DummyConsumer,
+        client: @client,
+        initial_position: :earliest,
+        init_args: [notify_pid: self()]
+      )
+
+    [consumer_pid] = Utils.wait_for_consumer_ready(1)
+
+    {consumer_pid, topic}
+  end
+
+  defp start_producer(topic, name) do
+    {:ok, producer} = Pulsar.Producer.start(topic, client: @client, name: name)
+
+    Utils.wait_for(fn -> Topology.workers(producer) end,
+      until: fn
+        [worker] -> :sys.get_state(worker).ready
+        _workers -> false
+      end
+    )
+
+    producer
+  end
+
+  defp worker_state(producer) do
+    [worker] = Topology.workers(producer)
+    :sys.get_state(worker)
+  end
+
+  defp assert_messages_received(consumer_pid, expected_payloads) do
+    Utils.wait_for(fn -> DummyConsumer.count_messages(consumer_pid) >= length(expected_payloads) end)
+    payloads = consumer_pid |> DummyConsumer.get_messages() |> Enum.map(& &1.payload)
+    Enum.each(expected_payloads, fn expected -> assert expected in payloads end)
+  end
+end

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -114,6 +114,23 @@ defmodule Pulsar.Test.Support.System do
     :ok
   end
 
+  def enable_deduplication(topic) do
+    broker = broker()
+
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "topicPolicies",
+      "set-deduplication",
+      "--enable",
+      topic
+    ]
+
+    {_, 0} = docker_exec(command)
+    :ok
+  end
+
   def unload_topic(topic) do
     broker = broker()
     command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", "unload", topic]

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -127,8 +127,10 @@ defmodule Pulsar.Test.Support.System do
       topic
     ]
 
-    {_, 0} = docker_exec(command)
-    :ok
+    case docker_exec(command) do
+      {_output, 0} -> :ok
+      {output, code} -> raise "enabling deduplication on #{topic} failed (exit #{code}): #{output}"
+    end
   end
 
   def unload_topic(topic) do


### PR DESCRIPTION
## Summary

A producer's sequence ids now describe what it actually published. A batch advertises the whole range it spends rather than only its first id, a restarting producer resumes from the high-water mark the broker reports instead of starting again at 0, and a send the broker discards as a duplicate is reported as such instead of being handed back a message id that refers to nothing.

The three are one chain. The first decides what the broker's mark means, the second reads that mark back, and the third covers the case where the mark is hit anyway.

## Motivation

Sequence ids are invisible from inside the suite. Nothing in the public API exposes them, nothing fails when they are wrong, and on a topic without deduplication they have no effect at all. Every defect here needed a topic with `deduplication` enabled to have any consequence, and no test in the suite enabled it.

| What the protocol expects | What this client did (before this change) |
| --- | --- |
| A batch advertises `sequence_id` and `highest_sequence_id` spanning the messages it carries | `highest_sequence_id` never set; the counter advanced by one per flush regardless of batch size (`producer/worker.ex:445`, `:487`) |
| A producer resumes from `CommandProducerSuccess.last_sequence_id` | The field was decoded and discarded at both registration sites (`producer/worker.ex:380`, `:569`) |
| A receipt of `-1:-1` means the message was discarded as a duplicate | Passed straight back as `{:ok, message_id}` (`producer/worker.ex:348`) |

## 1. A batch spends one sequence id per message, not one per batch

`do_flush_batch/1` numbered the entries inside a batch `base..base + n - 1` and then stored `base` back as the counter, so consecutive batches overlapped. Four batches of three left the producer at sequence id 4 rather than 12, and every batch reused the two ids before it.

**The review that prompted this claimed the broker drops every batch after the first on a dedup-enabled topic. That is not what happens, and the PR title should not be read as claiming it.** Measured against `apachepulsar/pulsar:4.2.4` with `topicPolicies set-deduplication --enable`, all four batches were accepted:

```
receipt sequence_id: 1, highest_sequence_id: 0
receipt sequence_id: 2, highest_sequence_id: -1
receipt sequence_id: 3, highest_sequence_id: -1
receipt sequence_id: 4, highest_sequence_id: -1
```

The broker's check is `sequence_id <= last_pushed`. Because the base still advanced by exactly one per flush, each batch was strictly greater than the last and passed. Nothing was dropped.

What was actually wrong is narrower and still worth fixing:

- **Entry sequence ids repeat across batches.** Batch one hands out 1, 2, 3 and batch two hands out 2, 3, 4. Anything doing consumer-side deduplication or ordering on the sequence id in `SingleMessageMetadata` sees duplicates.
- **The broker's mark understates what was published.** It tracked the bases — 1, 2, 3, 4 — for twelve messages. That mark is exactly what section 2 resumes from, so the two are only correct together.

After the change the same run gives bases 1, 4, 7, 10 with the broker echoing 3, 6, 9, 12. Both `CommandSend` and `MessageMetadata` carry the range, matching what the Java client's batch container sets.

## 2. A restarting producer resumed at 0

This is the one with teeth, and it is silent data loss.

`CommandProducerSuccess` carries the highest sequence id the broker has seen for a producer name. It was decoded and dropped, so a producer restarting under a stable name — the default, `"<topic>-producer"` — began again at 0. On a dedup-enabled topic every send at or below the old mark is discarded.

Measured: five messages, stop the producer, restart it under the same name, five more.

```
sequence_id after first round: 5
sequence_id on restart:        0
sends answered with the -1 message id: 5/5
consumer received (5): ["first-1", "first-2", "first-3", "first-4", "first-5"]
broker msgInCounter: 10
```

Every send in the second round returned `{:ok, message_id}` and none of them reached a consumer. Note the last line: the broker counts all ten as received and then discards five, so that metric does not reveal the loss either. Nothing on either side surfaces the gap, and it persists until the producer publishes past its old mark.

The mark is applied at registration as a maximum, so it can only move the counter forward. The broker reports `-1` when it has no mark, which the maximum discards.

This relies on a stable producer name. A producer that lets the broker generate one gets a fresh name per connection, so there is no mark to resume from and this is correctly a no-op — deduplication keys on the name.

**A `:wait_for_exclusive` producer is not covered, and cannot be.** An earlier revision of this branch also applied the mark to the second `CommandProducerSuccess` that arrives when such a producer is promoted. Measured, that message carries `-1` even when the identical producer name has already published to the topic:

```
A sequence_id after 5 sends: 5
B while waiting   -> producer_ready: false, last_sequence_id: -1
B after promotion -> producer_ready: true,  last_sequence_id: -1
```

The broker populates `last_sequence_id` on ordinary registration only, so that code was `max(counter, -1)` and was removed rather than kept as a line implying the case is handled. A producer promoted out of `:wait_for_exclusive` therefore still starts its counter at 0 and remains exposed to the defect above on a deduplication-enabled topic. Nothing in the protocol gives the client the mark at that point.

Reproducing this at all needs `start_link_unregistered/1`: two producers sharing a `:name` cannot both go through `Pulsar.Producer.start/2`, since the second is refused by the client registry with `{:error, {:already_started, _}}`.

## 3. A discarded send is no longer reported as a stored one

Deduplication still fires after section 2 removes the accidental trigger: two producers sharing a name, or a topic whose mark rolled back, reissue an id the broker has seen. The broker acknowledges those sends with a message id of `-1:-1` in place of the one it never assigned.

`send/3` now answers `{:ok, :deduplicated}`, with a warning and a `[:pulsar, :producer, :message, :deduplicated]` event.

**It stays an `:ok` rather than becoming an error.** The send did reach the broker and was answered; the argument for treating that as a failure would be that the payload is not on the topic, and the argument against is that deduplication exists to make retries idempotent. What settles it for this client is that a retry cannot reach this path: there is no internal resend. A broker crash stops the producer (`producer/worker.ex:316`), a publish failure returns to the caller, and `Backoff.run/1` wraps registration only. Every occurrence is therefore an id collision rather than a replay — which also means **the message the broker kept need not be the one passed here**, since deduplication matches on the sequence id alone and never on the payload.

The event is emitted from the branch that answers callers, not before the lookup, so one discarded message is reported once however many entries it spanned. A discarded batch reports `count: length(callers)`: one entry discarded is as many messages lost as it carried. Reporting happens before the callers are released, so a `send/3` that has returned is already accounted for by any attached handler.

### Chunked messages are exempt, and the branch that handles them is defensive

A discarded chunk would leave a message that can never be reassembled, so the code drops its siblings rather than leave them in `pending_sends` waiting for receipts that complete nothing. That branch cannot be reached against a live broker. Measured on the same producer, with the counter rewound below the mark:

```
mark should now be 3; producer counter: 3
rewound counter to: 1
RESULT: chunked message stored, num_chunks=4      <- ids 2..5, mark 3
unchunked below mark: {:ok, :deduplicated}         <- id 2, same mark
```

Pulsar exempts anything marked `is_chunk` from deduplication, because a chunk's sequence id identifies the chunk rather than the message. Note that this exemption only began applying to this client in #177, which is what started setting `is_chunk` at all.

The branch is kept rather than deleted: without the purge, a chunk answered with the sentinel would reply to its caller and strand every sibling in `pending_sends` permanently. It is defensive against a broker that behaves differently, and `a chunked message is not deduplicated, though an unchunked one at the same id is` pins the behaviour it is defending against, so a future Pulsar that changes its mind fails the suite rather than leaking quietly.

### Untracked receipts are expected, not anomalous

A receipt whose sequence id is no longer pending was logged at `warning`. That fires routinely: `publish_messages/4`'s error path restores `pending_sends` wholesale, so chunks that already reached the socket are answered with nothing left to track — behaviour that predates this PR. The purge above adds a second such path. Both now log at `debug`.

The dead letter path deliberately treats `{:ok, :deduplicated}` as diverted (`consumer/dead_letter.ex:89`). Returning an error there would nack the message back into a divert that is still over the redelivery threshold, and the dead letter producer's name is shared by every node running the consumer, so a collision between them need not clear — an unbounded redelivery loop. The producer's warning and event already identify it, since the name ends in `-dead-letter-producer`.

`@spec send/3` is corrected while here. It claimed `{:ok, MessageIdData.t()}` and was already wrong before this change: the chunked path replies with a plain map (`producer/worker.ex:585`). It is now `{:ok, send_result()}`, with `chunked_message_id/0` naming the chunked shape.

## Verification

`test.integration` is green against `apachepulsar/pulsar:4.2.4` across two consecutive full runs, 117 integration and 277 unit.

**Every new test was checked against the code it guards.** `consecutive batches claim sequence id ranges that do not overlap` fails with `left: 3, right: 9`; the restart test fails with `left: 0, right: 5`; the batch discard test fails with `left: [%{count: 3}]` when the event is forced back to `count: 1`. None passes by construction.

**The restart test asserts the consequence, not just the counter.** It checks that no send comes back with the sentinel id and that all ten messages reach a consumer, so it would still fail if the counter were right and the messages were lost for another reason.

**Deduplication is reached deliberately.** After section 2 a plain restart no longer collides, so `a send the broker discards as a duplicate answers with no message id` rewinds the worker's counter with `:sys.replace_state/2`. The payload it then sends was never published under that id, which is what makes the assertion sharp: the broker discards it on the sequence id alone.

**The absence assertion needed a barrier.** Asserting that the discarded payload never arrives is a race — the consumer had already received the earlier message, so the check could run before a wrongly-persisted one showed up. A third message is published after the discarded one and waited for; its arrival is the point at which the discarded one would have arrived too.

**A pre-existing test isolation bug was fixed on the way.** `chunking_test.exs` asserted on whichever `[:pulsar, :producer, :message, :published]` event arrived first, with no filter. The suite is `async: true`, so under load it picked up an event from `reader-common-test` and failed:

```
code:  assert metadata.topic == topic
left:  "persistent://public/default/reader-common-test"
right: "persistent://public/default/chunking-test-mixed"
```

It passed in isolation, which is why it survived. Four `assert_receive` patterns in that file now pin the discriminating field so the pattern selects the right event instead of asserting on the wrong one.

**The batch branch is covered too.** `a discarded batch answers every caller and reports the messages it carried` asserts that all three callers waiting on one discarded entry are answered, and that the event counts three rather than one. It earned its keep immediately: it caught the event being emitted after `GenServer.reply/2` rather than before, which let a caller return before its discard was reported.

**Known gaps.** The sibling purge cannot be exercised, for the reason above — the broker does not deduplicate chunks — so it is covered by reading the code, and by a test pinning the exemption it depends on. The two-producers-sharing-a-name case is argued rather than demonstrated; `:sys.replace_state/2` stands in for it.

## Breaking changes and migration

### 1. `send/3` can answer `{:ok, :deduplicated}`

Only on a topic with deduplication enabled. Code matching `{:ok, _}` is unaffected. Code that reads the message id — `.ledgerId`, `.entryId` — now fails on an atom where it previously received a struct whose fields pointed at nothing, so the failure moves from silent to loud rather than from working to broken.

### 2. Sequence ids on the wire change

No public API moves, and the counter is still strictly monotonic, so nothing an existing deployment does starts being rejected. Two things are observable:

- `[:pulsar, :producer, :batch, :published]`'s `sequence_id` metadata now advances by the batch size rather than by one. It is an opaque counter, but dashboards plotting it will show a step change.
- Two producers sharing a *name* across versions — one on 2.x, one on this — advance their counters at different rates. That configuration is already broken on a dedup-enabled topic for the reasons in section 3, so this is a note rather than a new failure.

### 3. A restarting producer no longer republishes from 0

Strictly a fix, but a producer that was relying on its sends being silently discarded after a restart — which is to say, one that has been losing messages — will start publishing them.
