### PR TITLE
fix(consumer): a batch index ack acknowledged the whole batch

### DIFF
--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -252,6 +252,9 @@ per delivery rather than per message — and `%{topic:, subscription_name:, cons
 The two dead letter events add `:dead_letter_topic` and `:redelivery_count`; `:failed` also carries
 `:reason`.
 
+`:requested` counts entries, where the other three count messages. Against a batching producer three
+nacked messages of one batch are one entry to ask for again, so the two counts do not line up.
+
 `:nacked` reports that a callback rejected a message, whether or not anything will redeliver it. With no
 `:redelivery_interval` configured you will see it with no `:redelivery, :requested` behind it and nothing
 ever reaching the dead letter topic, which is the shape of the mistake the warning above describes.

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -153,6 +153,16 @@ defmodule Pulsar.Consumer do
   that process and not the callback: every callback function runs inside its worker, so
   `ack(self(), ...)` is a `GenServer` call a process makes to itself, which exits with
   `:calling_self` and takes the consumer down.
+
+  ## Batched messages
+
+  The broker acknowledges entries, not the messages inside them, so acking a batched message
+  only counts it off: its entry is acknowledged once every message in it has been acked. The
+  call is unchanged, but a message left unacked holds the ones batched with it, and a nack
+  brings the whole entry back — including messages already acked from it.
+
+  `:batch_index_ack_enabled` narrows that to just the unacked messages, on brokers configured
+  for it.
   """
   @spec ack(pid(), MessageIdData.t() | [MessageIdData.t()]) :: :ok | {:error, term()}
   def ack(consumer, message_ids) when is_pid(consumer), do: Worker.ack(consumer, message_ids)

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -163,6 +163,9 @@ defmodule Pulsar.Consumer do
 
   `:batch_index_ack_enabled` narrows that to just the unacked messages, on brokers configured
   for it.
+
+  Every message must be acked or nacked eventually. One that is neither holds its entry's
+  bookkeeping for the life of the consumer.
   """
   @spec ack(pid(), MessageIdData.t() | [MessageIdData.t()]) :: :ok | {:error, term()}
   def ack(consumer, message_ids) when is_pid(consumer), do: Worker.ack(consumer, message_ids)

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -164,8 +164,8 @@ defmodule Pulsar.Consumer do
   `:batch_index_ack_enabled` narrows that to just the unacked messages, on brokers configured
   for it.
 
-  Every message must be acked or nacked eventually. One that is neither holds its entry's
-  bookkeeping for the life of the consumer.
+  Every message must be acked eventually, or nacked with a `:redelivery_interval` configured to
+  bring it back. One that is neither holds its entry's bookkeeping for the life of the consumer.
   """
   @spec ack(pid(), MessageIdData.t() | [MessageIdData.t()]) :: :ok | {:error, term()}
   def ack(consumer, message_ids) when is_pid(consumer), do: Worker.ack(consumer, message_ids)

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -15,18 +15,22 @@ defmodule Pulsar.Consumer.Ack do
 
   defstruct [{:acked, %{}}, {:nacked, MapSet.new()}, {:batch_index_ack_enabled, false}]
 
-  @type entry_key :: {non_neg_integer(), non_neg_integer(), integer()}
+  @type entry_key :: {non_neg_integer(), non_neg_integer()}
+
+  @typedoc "Messages of an entry, one bit per batch index."
+  @type bitset :: non_neg_integer()
+
   @type message_id :: Binary.MessageIdData.t()
 
   @type t :: %__MODULE__{
-          acked: %{optional(entry_key()) => MapSet.t(non_neg_integer())},
+          acked: %{optional(entry_key()) => bitset()},
           nacked: MapSet.t(message_id()),
           batch_index_ack_enabled: boolean()
         }
 
   @spec new(boolean()) :: t()
   def new(batch_index_ack_enabled \\ false) do
-    %__MODULE__{batch_index_ack_enabled: !!batch_index_ack_enabled}
+    %__MODULE__{batch_index_ack_enabled: batch_index_ack_enabled}
   end
 
   @doc """
@@ -95,7 +99,8 @@ defmodule Pulsar.Consumer.Ack do
       ...>   %MessageIdData{ledgerId: 7, entryId: 42, batch_index: index, batch_size: 3}
       ...> end
       iex> acks = Ack.record_nack(Ack.new(), [in_batch.(0), in_batch.(2)])
-      iex> Ack.nacked_count(acks)
+      iex> {ids, _acks} = Ack.take_nacked(acks)
+      iex> length(ids)
       1
   """
   @spec record_nack(t(), [message_id()]) :: t()
@@ -121,9 +126,6 @@ defmodule Pulsar.Consumer.Ack do
     %{ack | acked: Map.drop(ack.acked, keys)}
   end
 
-  @spec nacked_count(t()) :: non_neg_integer()
-  def nacked_count(%__MODULE__{nacked: nacked}), do: MapSet.size(nacked)
-
   @spec take_nacked(t()) :: {[message_id()], t()}
   def take_nacked(%__MODULE__{nacked: nacked} = ack) do
     {MapSet.to_list(nacked), %{ack | nacked: MapSet.new()}}
@@ -140,40 +142,43 @@ defmodule Pulsar.Consumer.Ack do
       {-1, nil}
   """
   @spec entry_id(message_id()) :: message_id()
-  def entry_id(%{batch_index: index} = message_id) when is_integer(index) and index >= 0 do
+  def entry_id(%Binary.MessageIdData{batch_index: index} = message_id) when is_integer(index) and index >= 0 do
     %{message_id | batch_index: -1, batch_size: nil, ack_set: []}
   end
 
   def entry_id(message_id), do: message_id
 
   @doc """
-  The messages still owed in a redelivered entry, or `nil` when it carries no set and every
+  The messages still owed in a redelivered entry, or `nil` when it carries none and every
   message in it is to be delivered.
 
-  Set bits are the messages outstanding, so a three-message entry with only its middle
-  message left owed arrives as `0b010`:
+  A partly acknowledged entry is redelivered whole, so pair this with `deliverable?/2` to skip
+  the messages that have already been acked:
 
-      iex> Pulsar.Consumer.Ack.outstanding([0b010])
-      MapSet.new([1])
+      iex> alias Pulsar.Consumer.Ack
+      iex> owed = Ack.outstanding([0b010])
+      iex> {Ack.deliverable?(owed, 0), Ack.deliverable?(owed, 1)}
+      {false, true}
 
-      iex> Pulsar.Consumer.Ack.outstanding([])
-      nil
+      iex> alias Pulsar.Consumer.Ack
+      iex> Ack.deliverable?(Ack.outstanding([]), 7)
+      true
   """
-  @spec outstanding([integer()] | nil) :: MapSet.t(non_neg_integer()) | nil
+  @spec outstanding([integer()] | nil) :: bitset() | nil
   def outstanding(ack_set) when ack_set in [nil, []], do: nil
-  def outstanding(ack_set), do: decode_ack_set(ack_set)
+  def outstanding(words), do: decode_ack_set(words)
 
-  @spec acknowledged?(MapSet.t(non_neg_integer()) | nil, non_neg_integer()) :: boolean()
-  def acknowledged?(nil, _index), do: false
-  def acknowledged?(outstanding, index), do: not MapSet.member?(outstanding, index)
+  @spec deliverable?(bitset() | nil, non_neg_integer()) :: boolean()
+  def deliverable?(nil, _index), do: true
+  def deliverable?(outstanding, index), do: Bitwise.band(outstanding, Bitwise.bsl(1, index)) != 0
 
   ## Private
 
   defp count_off(ack, {key, index, size}, message_id, ackable) do
-    acked = ack.acked |> Map.get(key, MapSet.new()) |> MapSet.put(index)
+    acked = Bitwise.bor(Map.get(ack.acked, key, 0), Bitwise.bsl(1, index))
 
     cond do
-      MapSet.size(acked) == size ->
+      acked == every_message(size) ->
         {[entry_id(message_id) | ackable], %{ack | acked: Map.delete(ack.acked, key)}}
 
       ack.batch_index_ack_enabled ->
@@ -185,9 +190,9 @@ defmodule Pulsar.Consumer.Ack do
   end
 
   # A batch of one needs no tally: its entry is complete on the single ack it takes.
-  defp batch_entry(%{batch_index: index, batch_size: size} = message_id)
+  defp batch_entry(%Binary.MessageIdData{batch_index: index, batch_size: size} = message_id)
        when is_integer(index) and index >= 0 and is_integer(size) and size > 1 do
-    {{message_id.ledgerId, message_id.entryId, message_id.partition}, index, size}
+    {{message_id.ledgerId, message_id.entryId}, index, size}
   end
 
   defp batch_entry(_message_id), do: nil
@@ -200,56 +205,20 @@ defmodule Pulsar.Consumer.Ack do
   # Set bits are the messages still outstanding, not the acked ones: the broker starts an entry
   # with every bit set and deletes it once nothing is left.
   defp encode_ack_set(acked, size) do
-    words = div(size - 1, @word_bits) + 1
+    outstanding = Bitwise.band(Bitwise.bnot(acked), every_message(size))
+    bits = word_count(size) * @word_bits
 
-    0..(words - 1)
-    |> Enum.map(&ack_set_word(acked, &1, size))
-    |> trim_trailing_zeroes()
+    for <<(word::little-signed-size(@word_bits) <- <<outstanding::little-size(bits)>>)>>, do: word
   end
 
-  defp ack_set_word(acked, word, size) do
-    base = word * @word_bits
-
-    bits =
-      Enum.reduce(0..(@word_bits - 1), 0, fn bit, acc ->
-        index = base + bit
-
-        if index < size and not MapSet.member?(acked, index) do
-          Bitwise.bor(acc, Bitwise.bsl(1, bit))
-        else
-          acc
-        end
-      end)
-
-    to_signed(bits)
+  defp decode_ack_set(ack_set) do
+    binary = for word <- ack_set, into: <<>>, do: <<word::little-signed-size(@word_bits)>>
+    bits = bit_size(binary)
+    <<outstanding::little-size(^bits)>> = binary
+    outstanding
   end
 
-  defp decode_ack_set(words) do
-    words
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {word, word_index} ->
-      unsigned = to_unsigned(word)
-      base = word_index * @word_bits
+  defp every_message(size), do: Bitwise.bsl(1, size) - 1
 
-      for bit <- 0..(@word_bits - 1), Bitwise.band(unsigned, Bitwise.bsl(1, bit)) != 0, do: base + bit
-    end)
-    |> MapSet.new()
-  end
-
-  defp to_signed(word) do
-    <<signed::signed-size(@word_bits)>> = <<word::size(@word_bits)>>
-    signed
-  end
-
-  defp to_unsigned(word) do
-    <<unsigned::size(@word_bits)>> = <<word::signed-size(@word_bits)>>
-    unsigned
-  end
-
-  defp trim_trailing_zeroes(words) do
-    words
-    |> Enum.reverse()
-    |> Enum.drop_while(&(&1 == 0))
-    |> Enum.reverse()
-  end
+  defp word_count(size), do: div(size - 1, @word_bits) + 1
 end

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -7,13 +7,15 @@ defmodule Pulsar.Consumer.Ack do
   # siblings unless it carries an `ack_set` — which only a broker with
   # `acknowledgmentAtBatchIndexLevelEnabled` honours.
 
+  import Bitwise
+
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
 
   # An `ack_set` is `repeated int64` (`MessageIdData` in pulsar.proto), holding a bitset in the
   # layout Java's `BitSet.toLongArray/0` produces: 64 bits per signed word, lowest index first.
   @word_bits 64
 
-  defstruct [{:acked, %{}}, {:nacked, MapSet.new()}, {:batch_index_ack_enabled, false}]
+  defstruct acked: %{}, nacked: MapSet.new(), batch_index_ack_enabled: false
 
   @type entry_key :: {non_neg_integer(), non_neg_integer()}
 
@@ -28,18 +30,16 @@ defmodule Pulsar.Consumer.Ack do
           batch_index_ack_enabled: boolean()
         }
 
-  @spec new(boolean()) :: t()
-  def new(batch_index_ack_enabled \\ false) do
-    %__MODULE__{batch_index_ack_enabled: batch_index_ack_enabled}
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    %__MODULE__{batch_index_ack_enabled: Keyword.get(opts, :batch_index_ack_enabled, false)}
   end
 
   @doc """
-  Records an acknowledgement locally. Returns `{ids_to_send, ledger}`.
+  Records an acknowledgement locally, returning `{ids_to_send, ledger}`.
 
-  Nothing here reaches the broker: the caller hands over every id its callback acked, sends
-  whatever comes back — often nothing — and keeps the updated ledger.
-
-      {to_send, acks} = Ack.record_ack(state.acks, message_ids)
+  Nothing here reaches the broker: the caller sends whatever comes back, which for a batched
+  message is usually nothing.
 
   A message that arrived on its own always comes back:
 
@@ -69,7 +69,7 @@ defmodule Pulsar.Consumer.Ack do
       iex> alias Pulsar.Consumer.Ack
       iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
       iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 0, batch_size: 3}
-      iex> {[acked], _acks} = Ack.record_ack(Ack.new(true), [id])
+      iex> {[acked], _acks} = Ack.record_ack(Ack.new(batch_index_ack_enabled: true), [id])
       iex> {acked.ack_set, acked.batch_size}
       {[0b110], 3}
   """
@@ -108,29 +108,6 @@ defmodule Pulsar.Consumer.Ack do
     ack = forget(ack, message_ids)
     %{ack | nacked: MapSet.union(ack.nacked, MapSet.new(message_ids, &entry_id/1))}
   end
-
-  @doc """
-  Drops what has been counted off for the entries these ids belong to.
-
-  Redelivery is whole entries, so a nacked message brings its batch back with it: the tally
-  would otherwise be left unable to complete.
-  """
-  @spec forget(t(), [message_id()]) :: t()
-  def forget(%__MODULE__{} = ack, message_ids) do
-    keys =
-      message_ids
-      |> Enum.map(&batch_entry/1)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.map(fn {key, _index, _size} -> key end)
-
-    %{ack | acked: Map.drop(ack.acked, keys)}
-  end
-
-  @doc """
-  How many entries are part-acknowledged, waiting on the rest of their messages.
-  """
-  @spec held_entries(t()) :: non_neg_integer()
-  def held_entries(%__MODULE__{acked: acked}), do: map_size(acked)
 
   @spec take_nacked(t()) :: {[message_id()], t()}
   def take_nacked(%__MODULE__{nacked: nacked} = ack) do
@@ -176,9 +153,21 @@ defmodule Pulsar.Consumer.Ack do
 
   @spec deliverable?(bitset() | nil, non_neg_integer()) :: boolean()
   def deliverable?(nil, _index), do: true
-  def deliverable?(outstanding, index), do: Bitwise.band(outstanding, Bitwise.bsl(1, index)) != 0
+  def deliverable?(outstanding, index), do: (outstanding &&& 1 <<< index) != 0
 
   ## Private
+
+  # A redelivered entry has to be dealt with in full again before it can be acknowledged, so
+  # what it counted off before is dropped rather than counted on from.
+  defp forget(ack, message_ids) do
+    keys =
+      message_ids
+      |> Enum.map(&batch_entry/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(fn {key, _index, _size} -> key end)
+
+    %{ack | acked: Map.drop(ack.acked, keys)}
+  end
 
   defp count_off(ack, {key, index, size}, message_id, ackable) do
     acked = acked_with(ack, key, index)
@@ -211,7 +200,7 @@ defmodule Pulsar.Consumer.Ack do
   # Set bits are the messages still outstanding, not the acked ones: the broker starts an entry
   # with every bit set and deletes it once nothing is left.
   defp encode_ack_set(acked, size) do
-    outstanding = Bitwise.band(Bitwise.bnot(acked), every_message(size))
+    outstanding = bnot(acked) &&& every_message(size)
     bits = word_count(size) * @word_bits
 
     for <<(word::little-signed-size(@word_bits) <- <<outstanding::little-size(bits)>>)>>, do: word
@@ -220,14 +209,13 @@ defmodule Pulsar.Consumer.Ack do
   defp decode_ack_set(ack_set) do
     binary = for word <- ack_set, into: <<>>, do: <<word::little-signed-size(@word_bits)>>
     bits = bit_size(binary)
-    # Pinned because a size in a match is read, not bound.
     <<outstanding::little-size(^bits)>> = binary
     outstanding
   end
 
-  defp acked_with(ack, key, index), do: Bitwise.bor(Map.get(ack.acked, key, 0), Bitwise.bsl(1, index))
+  defp acked_with(ack, key, index), do: Map.get(ack.acked, key, 0) ||| 1 <<< index
 
-  defp every_message(size), do: Bitwise.bsl(1, size) - 1
+  defp every_message(size), do: (1 <<< size) - 1
 
   defp word_count(size), do: div(size - 1, @word_bits) + 1
 end

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -110,6 +110,18 @@ defmodule Pulsar.Consumer.Ack do
   end
 
   @doc """
+  Counts messages off the entry without anything being sent for them.
+
+  For the messages the broker will not deliver again — ones it has already deleted, or compacted
+  away — which it still counts when sizing the entry. Their entry could otherwise never complete,
+  and so would never be acknowledged at all.
+  """
+  @spec mark_acked(t(), [message_id()]) :: t()
+  def mark_acked(%__MODULE__{} = ack, message_ids) do
+    Enum.reduce(message_ids, ack, &mark(&2, batch_entry(&1)))
+  end
+
+  @doc """
   Drops what has been counted off for the entries these ids belong to.
 
   Redelivery is whole entries, so a nacked message brings its batch back with it: the tally
@@ -125,6 +137,12 @@ defmodule Pulsar.Consumer.Ack do
 
     %{ack | acked: Map.drop(ack.acked, keys)}
   end
+
+  @doc """
+  How many entries are part-acknowledged, waiting on the rest of their messages.
+  """
+  @spec held_entries(t()) :: non_neg_integer()
+  def held_entries(%__MODULE__{acked: acked}), do: map_size(acked)
 
   @spec take_nacked(t()) :: {[message_id()], t()}
   def take_nacked(%__MODULE__{nacked: nacked} = ack) do
@@ -174,8 +192,20 @@ defmodule Pulsar.Consumer.Ack do
 
   ## Private
 
+  defp mark(ack, nil), do: ack
+
+  defp mark(ack, {key, index, size}) do
+    acked = acked_with(ack, key, index)
+
+    if acked == every_message(size) do
+      %{ack | acked: Map.delete(ack.acked, key)}
+    else
+      %{ack | acked: Map.put(ack.acked, key, acked)}
+    end
+  end
+
   defp count_off(ack, {key, index, size}, message_id, ackable) do
-    acked = Bitwise.bor(Map.get(ack.acked, key, 0), Bitwise.bsl(1, index))
+    acked = acked_with(ack, key, index)
 
     cond do
       acked == every_message(size) ->
@@ -214,9 +244,12 @@ defmodule Pulsar.Consumer.Ack do
   defp decode_ack_set(ack_set) do
     binary = for word <- ack_set, into: <<>>, do: <<word::little-signed-size(@word_bits)>>
     bits = bit_size(binary)
+    # Pinned because a size in a match is read, not bound.
     <<outstanding::little-size(^bits)>> = binary
     outstanding
   end
+
+  defp acked_with(ack, key, index), do: Bitwise.bor(Map.get(ack.acked, key, 0), Bitwise.bsl(1, index))
 
   defp every_message(size), do: Bitwise.bsl(1, size) - 1
 

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -1,0 +1,255 @@
+defmodule Pulsar.Consumer.Ack do
+  @moduledoc false
+
+  # Tracks what a consumer still owes the broker, and works out which message ids can be sent.
+  #
+  # An ack names the entry it lands in, so acking one message of a batch acknowledges its
+  # siblings unless it carries an `ack_set` — which only a broker with
+  # `acknowledgmentAtBatchIndexLevelEnabled` honours.
+
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+
+  # An `ack_set` is `repeated int64` (`MessageIdData` in pulsar.proto), holding a bitset in the
+  # layout Java's `BitSet.toLongArray/0` produces: 64 bits per signed word, lowest index first.
+  @word_bits 64
+
+  defstruct [{:acked, %{}}, {:nacked, MapSet.new()}, {:batch_index_ack_enabled, false}]
+
+  @type entry_key :: {non_neg_integer(), non_neg_integer(), integer()}
+  @type message_id :: Binary.MessageIdData.t()
+
+  @type t :: %__MODULE__{
+          acked: %{optional(entry_key()) => MapSet.t(non_neg_integer())},
+          nacked: MapSet.t(message_id()),
+          batch_index_ack_enabled: boolean()
+        }
+
+  @spec new(boolean()) :: t()
+  def new(batch_index_ack_enabled \\ false) do
+    %__MODULE__{batch_index_ack_enabled: !!batch_index_ack_enabled}
+  end
+
+  @doc """
+  Records an acknowledgement locally. Returns `{ids_to_send, ledger}`.
+
+  Nothing here reaches the broker: the caller hands over every id its callback acked, sends
+  whatever comes back — often nothing — and keeps the updated ledger.
+
+      {to_send, acks} = Ack.record_ack(state.acks, message_ids)
+
+  A message that arrived on its own always comes back:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> {[id], _acks} = Ack.record_ack(Ack.new(), [%MessageIdData{ledgerId: 7, entryId: 42}])
+      iex> {id.entryId, id.batch_index}
+      {42, -1}
+
+  One from a batch comes back only once its entry is complete, since an ack names the entry it
+  lands in. The id that goes out then names the entry rather than a message in it:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> in_batch = fn index ->
+      ...>   %MessageIdData{ledgerId: 7, entryId: 42, batch_index: index, batch_size: 3}
+      ...> end
+      iex> {[], acks} = Ack.record_ack(Ack.new(), [in_batch.(0)])
+      iex> {[], acks} = Ack.record_ack(acks, [in_batch.(1)])
+      iex> {[entry], _acks} = Ack.record_ack(acks, [in_batch.(2)])
+      iex> {entry.entryId, entry.batch_index}
+      {42, -1}
+
+  With `:batch_index_ack_enabled` every ack goes out instead, carrying the entry's still
+  outstanding messages as a bitset:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 0, batch_size: 3}
+      iex> {[acked], _acks} = Ack.record_ack(Ack.new(true), [id])
+      iex> {acked.ack_set, acked.batch_size}
+      {[0b110], 3}
+  """
+  @spec record_ack(t(), [message_id()]) :: {[message_id()], t()}
+  def record_ack(%__MODULE__{} = ack, message_ids) do
+    {ackable, new_ack} =
+      Enum.reduce(message_ids, {[], ack}, fn message_id, {ackable, acc} ->
+        case batch_entry(message_id) do
+          nil -> {[entry_id(message_id) | ackable], acc}
+          entry -> count_off(acc, entry, message_id, ackable)
+        end
+      end)
+
+    {Enum.reverse(ackable), new_ack}
+  end
+
+  @doc """
+  Records a negative acknowledgement locally, to be drained by `take_nacked/1` when the
+  redelivery request is due.
+
+  Redelivery is whole entries, so two nacked messages of one batch are one thing to ask for
+  again:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> in_batch = fn index ->
+      ...>   %MessageIdData{ledgerId: 7, entryId: 42, batch_index: index, batch_size: 3}
+      ...> end
+      iex> acks = Ack.record_nack(Ack.new(), [in_batch.(0), in_batch.(2)])
+      iex> Ack.nacked_count(acks)
+      1
+  """
+  @spec record_nack(t(), [message_id()]) :: t()
+  def record_nack(%__MODULE__{} = ack, message_ids) do
+    ack = forget(ack, message_ids)
+    %{ack | nacked: MapSet.union(ack.nacked, MapSet.new(message_ids, &entry_id/1))}
+  end
+
+  @doc """
+  Drops what has been counted off for the entries these ids belong to.
+
+  Redelivery is whole entries, so a nacked message brings its batch back with it: the tally
+  would otherwise be left unable to complete.
+  """
+  @spec forget(t(), [message_id()]) :: t()
+  def forget(%__MODULE__{} = ack, message_ids) do
+    keys =
+      message_ids
+      |> Enum.map(&batch_entry/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(fn {key, _index, _size} -> key end)
+
+    %{ack | acked: Map.drop(ack.acked, keys)}
+  end
+
+  @spec nacked_count(t()) :: non_neg_integer()
+  def nacked_count(%__MODULE__{nacked: nacked}), do: MapSet.size(nacked)
+
+  @spec take_nacked(t()) :: {[message_id()], t()}
+  def take_nacked(%__MODULE__{nacked: nacked} = ack) do
+    {MapSet.to_list(nacked), %{ack | nacked: MapSet.new()}}
+  end
+
+  @doc """
+  The entry an id belongs to, which is what the broker acknowledges and redelivers.
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 2, batch_size: 3}
+      iex> entry = Ack.entry_id(id)
+      iex> {entry.batch_index, entry.batch_size}
+      {-1, nil}
+  """
+  @spec entry_id(message_id()) :: message_id()
+  def entry_id(%{batch_index: index} = message_id) when is_integer(index) and index >= 0 do
+    %{message_id | batch_index: -1, batch_size: nil, ack_set: []}
+  end
+
+  def entry_id(message_id), do: message_id
+
+  @doc """
+  The messages still owed in a redelivered entry, or `nil` when it carries no set and every
+  message in it is to be delivered.
+
+  Set bits are the messages outstanding, so a three-message entry with only its middle
+  message left owed arrives as `0b010`:
+
+      iex> Pulsar.Consumer.Ack.outstanding([0b010])
+      MapSet.new([1])
+
+      iex> Pulsar.Consumer.Ack.outstanding([])
+      nil
+  """
+  @spec outstanding([integer()] | nil) :: MapSet.t(non_neg_integer()) | nil
+  def outstanding(ack_set) when ack_set in [nil, []], do: nil
+  def outstanding(ack_set), do: decode_ack_set(ack_set)
+
+  @spec acknowledged?(MapSet.t(non_neg_integer()) | nil, non_neg_integer()) :: boolean()
+  def acknowledged?(nil, _index), do: false
+  def acknowledged?(outstanding, index), do: not MapSet.member?(outstanding, index)
+
+  ## Private
+
+  defp count_off(ack, {key, index, size}, message_id, ackable) do
+    acked = ack.acked |> Map.get(key, MapSet.new()) |> MapSet.put(index)
+
+    cond do
+      MapSet.size(acked) == size ->
+        {[entry_id(message_id) | ackable], %{ack | acked: Map.delete(ack.acked, key)}}
+
+      ack.batch_index_ack_enabled ->
+        {[batch_index_ack_id(message_id, acked, size) | ackable], %{ack | acked: Map.put(ack.acked, key, acked)}}
+
+      true ->
+        {ackable, %{ack | acked: Map.put(ack.acked, key, acked)}}
+    end
+  end
+
+  # A batch of one needs no tally: its entry is complete on the single ack it takes.
+  defp batch_entry(%{batch_index: index, batch_size: size} = message_id)
+       when is_integer(index) and index >= 0 and is_integer(size) and size > 1 do
+    {{message_id.ledgerId, message_id.entryId, message_id.partition}, index, size}
+  end
+
+  defp batch_entry(_message_id), do: nil
+
+  # `batch_size` is what the broker sizes its own bitset from.
+  defp batch_index_ack_id(message_id, acked, size) do
+    %{message_id | batch_index: -1, batch_size: size, ack_set: encode_ack_set(acked, size)}
+  end
+
+  # Set bits are the messages still outstanding, not the acked ones: the broker starts an entry
+  # with every bit set and deletes it once nothing is left.
+  defp encode_ack_set(acked, size) do
+    words = div(size - 1, @word_bits) + 1
+
+    0..(words - 1)
+    |> Enum.map(&ack_set_word(acked, &1, size))
+    |> trim_trailing_zeroes()
+  end
+
+  defp ack_set_word(acked, word, size) do
+    base = word * @word_bits
+
+    bits =
+      Enum.reduce(0..(@word_bits - 1), 0, fn bit, acc ->
+        index = base + bit
+
+        if index < size and not MapSet.member?(acked, index) do
+          Bitwise.bor(acc, Bitwise.bsl(1, bit))
+        else
+          acc
+        end
+      end)
+
+    to_signed(bits)
+  end
+
+  defp decode_ack_set(words) do
+    words
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {word, word_index} ->
+      unsigned = to_unsigned(word)
+      base = word_index * @word_bits
+
+      for bit <- 0..(@word_bits - 1), Bitwise.band(unsigned, Bitwise.bsl(1, bit)) != 0, do: base + bit
+    end)
+    |> MapSet.new()
+  end
+
+  defp to_signed(word) do
+    <<signed::signed-size(@word_bits)>> = <<word::size(@word_bits)>>
+    signed
+  end
+
+  defp to_unsigned(word) do
+    <<unsigned::size(@word_bits)>> = <<word::signed-size(@word_bits)>>
+    unsigned
+  end
+
+  defp trim_trailing_zeroes(words) do
+    words
+    |> Enum.reverse()
+    |> Enum.drop_while(&(&1 == 0))
+    |> Enum.reverse()
+  end
+end

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -30,7 +30,9 @@ defmodule Pulsar.Consumer.Ack do
           batch_index_ack_enabled: boolean()
         }
 
-  @spec new(keyword()) :: t()
+  @type opt :: {:batch_index_ack_enabled, boolean()}
+
+  @spec new([opt()]) :: t()
   def new(opts \\ []) do
     %__MODULE__{batch_index_ack_enabled: Keyword.get(opts, :batch_index_ack_enabled, false)}
   end
@@ -75,15 +77,15 @@ defmodule Pulsar.Consumer.Ack do
   """
   @spec record_ack(t(), [message_id()]) :: {[message_id()], t()}
   def record_ack(%__MODULE__{} = ack, message_ids) do
-    {ackable, new_ack} =
-      Enum.reduce(message_ids, {[], ack}, fn message_id, {ackable, acc} ->
-        case batch_entry(message_id) do
-          nil -> {[entry_id(message_id) | ackable], acc}
-          entry -> count_off(acc, entry, message_id, ackable)
+    {to_send, new_ack} =
+      Enum.reduce(message_ids, {[], ack}, fn message_id, {to_send, acc} ->
+        case count_off(acc, message_id) do
+          {nil, acc} -> {to_send, acc}
+          {id, acc} -> {[id | to_send], acc}
         end
       end)
 
-    {Enum.reverse(ackable), new_ack}
+    {Enum.reverse(to_send), new_ack}
   end
 
   @doc """
@@ -169,18 +171,26 @@ defmodule Pulsar.Consumer.Ack do
     %{ack | acked: Map.drop(ack.acked, keys)}
   end
 
-  defp count_off(ack, {key, index, size}, message_id, ackable) do
-    acked = acked_with(ack, key, index)
+  defp count_off(ack, message_id) do
+    case batch_entry(message_id) do
+      nil ->
+        {entry_id(message_id), ack}
 
-    cond do
-      acked == every_message(size) ->
-        {[entry_id(message_id) | ackable], %{ack | acked: Map.delete(ack.acked, key)}}
+      {key, index, size} ->
+        acked = acked_with(ack, key, index)
 
-      ack.batch_index_ack_enabled ->
-        {[batch_index_ack_id(message_id, acked, size) | ackable], %{ack | acked: Map.put(ack.acked, key, acked)}}
+        cond do
+          # Only real acks and messages the broker will not deliver again reach the width, so
+          # there is nothing left in the entry for this to acknowledge unread.
+          acked == every_message(size) ->
+            {entry_id(message_id), %{ack | acked: Map.delete(ack.acked, key)}}
 
-      true ->
-        {ackable, %{ack | acked: Map.put(ack.acked, key, acked)}}
+          ack.batch_index_ack_enabled ->
+            {batch_index_ack_id(message_id, acked, size), %{ack | acked: Map.put(ack.acked, key, acked)}}
+
+          true ->
+            {nil, %{ack | acked: Map.put(ack.acked, key, acked)}}
+        end
     end
   end
 

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -110,18 +110,6 @@ defmodule Pulsar.Consumer.Ack do
   end
 
   @doc """
-  Counts messages off the entry without anything being sent for them.
-
-  For the messages the broker will not deliver again — ones it has already deleted, or compacted
-  away — which it still counts when sizing the entry. Their entry could otherwise never complete,
-  and so would never be acknowledged at all.
-  """
-  @spec mark_acked(t(), [message_id()]) :: t()
-  def mark_acked(%__MODULE__{} = ack, message_ids) do
-    Enum.reduce(message_ids, ack, &mark(&2, batch_entry(&1)))
-  end
-
-  @doc """
   Drops what has been counted off for the entries these ids belong to.
 
   Redelivery is whole entries, so a nacked message brings its batch back with it: the tally
@@ -191,18 +179,6 @@ defmodule Pulsar.Consumer.Ack do
   def deliverable?(outstanding, index), do: Bitwise.band(outstanding, Bitwise.bsl(1, index)) != 0
 
   ## Private
-
-  defp mark(ack, nil), do: ack
-
-  defp mark(ack, {key, index, size}) do
-    acked = acked_with(ack, key, index)
-
-    if acked == every_message(size) do
-      %{ack | acked: Map.delete(ack.acked, key)}
-    else
-      %{ack | acked: Map.put(ack.acked, key, acked)}
-    end
-  end
 
   defp count_off(ack, {key, index, size}, message_id, ackable) do
     acked = acked_with(ack, key, index)

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -92,6 +92,20 @@ defmodule Pulsar.Consumer.Options do
       default: true,
       doc: "Create the topic if it does not exist."
     ],
+    batch_index_ack_enabled: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Tell the broker which messages of a batch an ack was for, so that a nack redelivers only
+      the rest of the entry instead of all of it. Costs one ack command per message rather
+      than one per entry.
+
+      **Requires `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker.** Without it the
+      broker ignores the set and acknowledges the whole entry, losing the messages batched
+      alongside the acked one. Nothing in the protocol reports the setting, so this cannot be
+      detected: Pulsar's shipped `broker.conf` enables it, `standalone.conf` does not.
+      """
+    ],
     redelivery_interval: [
       type: :pos_integer,
       doc: """

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -145,6 +145,10 @@ defmodule Pulsar.Consumer.Options do
       A diverted message keeps its key, ordering key, properties and event time, and gains
       `REAL_TOPIC` and `ORIGIN_MESSAGE_ID` properties naming where it came from.
 
+      A batch diverts as one entry, so if any message in it fails to publish the entry is
+      redelivered and the rest are diverted a second time. Deduplicate on `ORIGIN_MESSAGE_ID`
+      if that matters.
+
       Diverting replaces delivery rather than accompanying it, so neither
       `c:Pulsar.Consumer.Callback.handle_message/2` nor
       `c:Pulsar.Consumer.Callback.handle_invalid_message/2` is called for a message that

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -85,7 +85,10 @@ defmodule Pulsar.Consumer.Options do
     read_compacted: [
       type: :boolean,
       default: false,
-      doc: "Read only the latest value per key from a compacted topic."
+      doc: """
+      Read only the latest value per key from a compacted topic. Messages compaction has
+      replaced are filtered out of a batch rather than delivered, whatever this is set to.
+      """
     ],
     force_create_topic: [
       type: :boolean,
@@ -110,7 +113,8 @@ defmodule Pulsar.Consumer.Options do
       type: :pos_integer,
       doc: """
       Milliseconds between redelivery requests for negatively acknowledged messages.
-      Absent by default, in which case they are not redelivered.
+      Absent by default, in which case they are not redelivered and a nacked message from a
+      batch leaves its entry unacknowledged until it is acked or the consumer restarts.
       """
     ],
     dead_letter_policy: [

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -406,26 +406,13 @@ defmodule Pulsar.Consumer.Worker do
   @impl true
   def handle_info(:trigger_redelivery, state) do
     new_state =
-      if Ack.nacked_count(state.acks) > 0 do
-        {nacked_list, acks} = Ack.take_nacked(state.acks)
+      case Ack.take_nacked(state.acks) do
+        {[], _acks} ->
+          state
 
-        redeliver_command = %Binary.CommandRedeliverUnacknowledgedMessages{
-          consumer_id: state.consumer_id,
-          message_ids: nacked_list
-        }
-
-        :ok = Pulsar.Broker.send_command(state.broker_pid, redeliver_command)
-        Logger.warning("Requested redelivery of #{length(nacked_list)} NACKed messages")
-
-        :telemetry.execute(
-          [:pulsar, :consumer, :redelivery, :requested],
-          %{count: length(nacked_list)},
-          consumer_metadata(state)
-        )
-
-        %{state | acks: acks}
-      else
-        state
+        {entry_ids, acks} ->
+          request_redelivery(state, entry_ids)
+          %{state | acks: acks}
       end
 
     schedule_redelivery(state.redelivery_interval)
@@ -510,7 +497,7 @@ defmodule Pulsar.Consumer.Worker do
                                                     {acc_state, diverted, nacked_acc, reason} ->
         message_ids_list = List.wrap(message.message_id)
 
-        case publish_to_dead_letter(producer, message, state.topic) do
+        case publish_to_dead_letter(producer, message, acc_state.topic) do
           :ok ->
             acked_state = ack_message_ids(acc_state, message_ids_list, validation_error(message))
             {acked_state, diverted + 1, nacked_acc, reason}
@@ -578,8 +565,24 @@ defmodule Pulsar.Consumer.Worker do
     track_nacked(new_state, nacked_ids)
   end
 
-  # :trigger_redelivery drains this set and only fires when a redelivery interval is configured,
-  # so without one an id is deliberately not tracked rather than left in a set nothing empties.
+  defp request_redelivery(state, entry_ids) do
+    redeliver_command = %Binary.CommandRedeliverUnacknowledgedMessages{
+      consumer_id: state.consumer_id,
+      message_ids: entry_ids
+    }
+
+    :ok = Pulsar.Broker.send_command(state.broker_pid, redeliver_command)
+    Logger.warning("Requested redelivery of #{length(entry_ids)} NACKed messages")
+
+    :telemetry.execute(
+      [:pulsar, :consumer, :redelivery, :requested],
+      %{count: length(entry_ids)},
+      consumer_metadata(state)
+    )
+  end
+
+  # :trigger_redelivery only fires when a redelivery interval is configured, so without one an
+  # id is deliberately not recorded.
   defp track_nacked(state, []), do: state
 
   defp track_nacked(%__MODULE__{redelivery_interval: nil} = state, nacked_ids) do
@@ -903,7 +906,7 @@ defmodule Pulsar.Consumer.Worker do
     messages =
       unwrapped_messages
       |> Enum.with_index()
-      |> Enum.reject(fn {_unwrapped, index} -> Ack.acknowledged?(outstanding, index) end)
+      |> Enum.filter(fn {_unwrapped, index} -> Ack.deliverable?(outstanding, index) end)
       |> Enum.map(fn {{single_metadata, payload}, index} ->
         # The width travels on the id so a deferred ack, arriving with nothing else, can still
         # tell when its entry is complete.

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -177,7 +177,7 @@ defmodule Pulsar.Consumer.Worker do
       struct(__MODULE__, opts)
       | consumer_id: System.unique_integer([:positive, :monotonic]),
         consumer_name: Keyword.get(opts, :name),
-        acks: Ack.new(Keyword.get(opts, :batch_index_ack_enabled, false)),
+        acks: Ack.new(Keyword.take(opts, [:batch_index_ack_enabled])),
         schema: build_schema(Keyword.get(opts, :schema)),
         max_redelivery: max_redelivery(Keyword.get(opts, :dead_letter_policy))
     }
@@ -276,7 +276,7 @@ defmodule Pulsar.Consumer.Worker do
   def handle_continue({:send_initial_flow, init_args}, state) do
     result =
       if state.flow_initial > 0 do
-        send_initial_flow(state.broker_pid, state.consumer_id, state.flow_initial)
+        send_flow_command(state, state.flow_initial)
       else
         :ok
       end
@@ -392,8 +392,7 @@ defmodule Pulsar.Consumer.Worker do
     # A skipped message was still sent, and still charged a permit.
     permits_consumed = length(skipped_ids) + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
 
-    # A skipped message is one nothing will ever ack, so it is counted off here instead. That
-    # also covers an entry with nothing left to deliver, which only this can acknowledge.
+    # No callback runs for a skipped message, so nothing else can count it off its entry.
     new_state =
       new_state
       |> decrement_permits(permits_consumed)
@@ -585,17 +584,20 @@ defmodule Pulsar.Consumer.Worker do
       %{count: length(entry_ids)},
       consumer_metadata(state)
     )
-
-    :ok
   end
 
-  # :trigger_redelivery only fires when a redelivery interval is configured, so without one an
-  # id is deliberately not recorded.
   defp track_nacked(state, []), do: state
 
+  # Nothing drains the nacked set without an interval to fire :trigger_redelivery, so the entry
+  # is not coming back and its tally is left as it is: acking the message later still completes
+  # it.
   defp track_nacked(%__MODULE__{redelivery_interval: nil} = state, nacked_ids) do
-    Logger.debug("NACKed #{length(nacked_ids)} message(s), but no redelivery_interval configured")
-    %{state | acks: Ack.forget(state.acks, nacked_ids)}
+    Logger.warning(
+      "NACKed #{length(nacked_ids)} message(s) with no redelivery_interval configured: " <>
+        "nothing will ask for them back"
+    )
+
+    state
   end
 
   defp track_nacked(%__MODULE__{} = state, nacked_ids) do
@@ -682,13 +684,7 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_call({:send_flow, permits}, _from, state) do
-    case send_flow_command(
-           state.broker_pid,
-           state.consumer_id,
-           permits,
-           state.flow_outstanding_permits,
-           Ack.held_entries(state.acks)
-         ) do
+    case send_flow_command(state, permits) do
       :ok ->
         new_permits = state.flow_outstanding_permits + permits
         {:reply, :ok, %{state | flow_outstanding_permits: new_permits}}
@@ -810,10 +806,6 @@ defmodule Pulsar.Consumer.Worker do
     %{state | flow_outstanding_permits: new_permits}
   end
 
-  defp send_initial_flow(broker_pid, consumer_id, permits) do
-    send_flow_command(broker_pid, consumer_id, permits, 0, 0)
-  end
-
   defp check_and_refill_permits(%{flow_initial: 0} = state) do
     state
   end
@@ -831,13 +823,7 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp do_refill_permits(state, refill_amount, current_permits) do
-    case send_flow_command(
-           state.broker_pid,
-           state.consumer_id,
-           refill_amount,
-           current_permits,
-           Ack.held_entries(state.acks)
-         ) do
+    case send_flow_command(state, refill_amount) do
       :ok ->
         %{state | flow_outstanding_permits: current_permits + refill_amount}
 
@@ -847,24 +833,25 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp send_flow_command(broker_pid, consumer_id, permits, outstanding_permits, held_entries) do
+  defp send_flow_command(state, permits) do
     flow_command = %Binary.CommandFlow{
-      consumer_id: consumer_id,
+      consumer_id: state.consumer_id,
       messagePermits: permits
     }
 
+    outstanding_permits = state.flow_outstanding_permits
+
     start_metadata = %{
-      consumer_id: consumer_id,
+      consumer_id: state.consumer_id,
       permits_requested: permits,
-      permits_before: outstanding_permits,
-      held_entries: held_entries
+      permits_before: outstanding_permits
     }
 
     :telemetry.span(
       [:pulsar, :consumer, :flow_control],
       start_metadata,
       fn ->
-        result = Pulsar.Broker.send_command(broker_pid, flow_command)
+        result = Pulsar.Broker.send_command(state.broker_pid, flow_command)
 
         stop_metadata = %{success: true, permits_after: outstanding_permits + permits}
 
@@ -919,8 +906,8 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   # A partly acknowledged entry is redelivered whole, carrying a set of what is still owed, and a
-  # compacted topic leaves entries holding messages compaction has replaced. Neither is delivered
-  # again; both still count towards the entry, so both come back to be counted off.
+  # compacted topic leaves entries holding messages compaction has replaced. Neither is delivered,
+  # and both still count towards their entry, so they come back to be counted off.
   defp build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped_messages) do
     base_message_id = command.message_id
     batch_size = length(unwrapped_messages)

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -7,6 +7,7 @@ defmodule Pulsar.Consumer.Worker do
   use GenServer
 
   alias Pulsar.Backoff
+  alias Pulsar.Consumer.Ack
   alias Pulsar.Consumer.ChunkedMessageContext
   alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Protocol
@@ -51,7 +52,7 @@ defmodule Pulsar.Consumer.Worker do
     :read_compacted,
     :start_message_id,
     :start_timestamp,
-    {:nacked_messages, MapSet.new()},
+    :acks,
     :redelivery_interval,
     :max_redelivery,
     :dead_letter_root,
@@ -85,7 +86,7 @@ defmodule Pulsar.Consumer.Worker do
           force_create_topic: boolean(),
           start_message_id: {non_neg_integer(), non_neg_integer()},
           start_timestamp: non_neg_integer(),
-          nacked_messages: MapSet.t(),
+          acks: Ack.t(),
           redelivery_interval: non_neg_integer() | nil,
           max_redelivery: non_neg_integer() | nil,
           dead_letter_root: pid() | nil,
@@ -176,6 +177,7 @@ defmodule Pulsar.Consumer.Worker do
       struct(__MODULE__, opts)
       | consumer_id: System.unique_integer([:positive, :monotonic]),
         consumer_name: Keyword.get(opts, :name),
+        acks: Ack.new(Keyword.get(opts, :batch_index_ack_enabled, false)),
         schema: build_schema(Keyword.get(opts, :schema)),
         max_redelivery: max_redelivery(Keyword.get(opts, :dead_letter_policy))
     }
@@ -357,25 +359,23 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_info({:broker_message, message_data}, state) do
-    {messages, new_state} =
+    {messages, skipped, new_state} =
       case message_data do
         {:invalid, command, bytes, validation_error} ->
-          {[build_invalid_message(command, bytes, validation_error)], state}
+          {[build_invalid_message(command, bytes, validation_error)], 0, state}
 
         {command, metadata, payload, broker_metadata} ->
-          {state_after, msgs} =
-            if chunked_message?(metadata) do
-              # A chunk is a slice of the compressed message, so it cannot be decompressed
-              # before the rest of the slices are back around it.
-              maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
-            else
-              payload = maybe_uncompress(metadata, payload)
-              unwrapped = unwrap_messages(metadata, payload)
-              pulsar_messages = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
-              {state, pulsar_messages}
-            end
-
-          {msgs, state_after}
+          if chunked_message?(metadata) do
+            # A chunk is a slice of the compressed message, so it cannot be decompressed
+            # before the rest of the slices are back around it.
+            {state_after, msgs} = maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
+            {msgs, 0, state_after}
+          else
+            payload = maybe_uncompress(metadata, payload)
+            unwrapped = unwrap_messages(metadata, payload)
+            {msgs, skipped} = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+            {msgs, skipped, state}
+          end
 
         {commands, metadatas, payload, broker_metadatas, chunk_metadata} ->
           chunk_metadata_full =
@@ -386,10 +386,11 @@ defmodule Pulsar.Consumer.Worker do
             })
 
           message = build_message_from_chunk(chunk_metadata_full, payload)
-          {[message], state}
+          {[message], 0, state}
       end
 
-    permits_consumed = Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
+    # A skipped message was still sent, and still charged a permit.
+    permits_consumed = skipped + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
     new_state = decrement_permits(new_state, permits_consumed)
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
@@ -405,8 +406,8 @@ defmodule Pulsar.Consumer.Worker do
   @impl true
   def handle_info(:trigger_redelivery, state) do
     new_state =
-      if MapSet.size(state.nacked_messages) > 0 do
-        nacked_list = MapSet.to_list(state.nacked_messages)
+      if Ack.nacked_count(state.acks) > 0 do
+        {nacked_list, acks} = Ack.take_nacked(state.acks)
 
         redeliver_command = %Binary.CommandRedeliverUnacknowledgedMessages{
           consumer_id: state.consumer_id,
@@ -422,7 +423,7 @@ defmodule Pulsar.Consumer.Worker do
           consumer_metadata(state)
         )
 
-        %{state | nacked_messages: MapSet.new()}
+        %{state | acks: acks}
       else
         state
       end
@@ -504,25 +505,19 @@ defmodule Pulsar.Consumer.Worker do
     # supervisor discovery adds partitions to.
     producer = DeadLetter.producer(state.dead_letter_root)
 
-    {diverted, nacked_ids, reason} =
-      Enum.reduce(messages, {0, [], nil}, fn %Pulsar.Message{} = message, {diverted, nacked_acc, reason} ->
+    {state, diverted, nacked_ids, reason} =
+      Enum.reduce(messages, {state, 0, [], nil}, fn %Pulsar.Message{} = message,
+                                                    {acc_state, diverted, nacked_acc, reason} ->
         message_ids_list = List.wrap(message.message_id)
 
         case publish_to_dead_letter(producer, message, state.topic) do
           :ok ->
-            ack_command = %Binary.CommandAck{
-              consumer_id: state.consumer_id,
-              ack_type: :Individual,
-              message_id: message_ids_list,
-              validation_error: validation_error(message)
-            }
-
-            :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
-            {diverted + 1, nacked_acc, reason}
+            acked_state = ack_message_ids(acc_state, message_ids_list, validation_error(message))
+            {acked_state, diverted + 1, nacked_acc, reason}
 
           {:error, dlq_reason} ->
             Logger.error("Failed to send message to dead letter topic: #{inspect(dlq_reason)}, leaving as nacked")
-            {diverted, message_ids_list ++ nacked_acc, reason || dlq_reason}
+            {acc_state, diverted, message_ids_list ++ nacked_acc, reason || dlq_reason}
         end
       end)
 
@@ -567,9 +562,9 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp process_messages_normally(state, messages) when is_list(messages) do
-    {final_callback_state, nacked_ids} =
-      Enum.reduce(messages, {state.callback_state, []}, fn message, {callback_state, nacked_acc} ->
-        process_single_message(state, message, callback_state, nacked_acc)
+    {new_state, nacked_ids} =
+      Enum.reduce(messages, {state, []}, fn message, {acc_state, nacked_acc} ->
+        process_single_message(acc_state, message, nacked_acc)
       end)
 
     if nacked_ids != [] do
@@ -580,7 +575,7 @@ defmodule Pulsar.Consumer.Worker do
       )
     end
 
-    %{track_nacked(state, nacked_ids) | callback_state: final_callback_state}
+    track_nacked(new_state, nacked_ids)
   end
 
   # :trigger_redelivery drains this set and only fires when a redelivery interval is configured,
@@ -589,39 +584,53 @@ defmodule Pulsar.Consumer.Worker do
 
   defp track_nacked(%__MODULE__{redelivery_interval: nil} = state, nacked_ids) do
     Logger.debug("NACKed #{length(nacked_ids)} message(s), but no redelivery_interval configured")
-    state
+    %{state | acks: Ack.forget(state.acks, nacked_ids)}
   end
 
   defp track_nacked(%__MODULE__{} = state, nacked_ids) do
-    %{state | nacked_messages: MapSet.union(state.nacked_messages, MapSet.new(nacked_ids))}
+    %{state | acks: Ack.record_nack(state.acks, nacked_ids)}
   end
 
-  defp process_single_message(state, %Pulsar.Message{} = message, callback_state, nacked_acc) do
+  defp ack_message_ids(state, message_ids, validation_error \\ nil) do
+    {to_send, acks} = Ack.record_ack(state.acks, message_ids)
+
+    case to_send do
+      [] -> %{state | acks: acks}
+      ids -> send_ack(%{state | acks: acks}, ids, validation_error)
+    end
+  end
+
+  defp send_ack(state, message_ids, validation_error) do
+    ack_command = %Binary.CommandAck{
+      consumer_id: state.consumer_id,
+      ack_type: :Individual,
+      message_id: message_ids,
+      validation_error: validation_error
+    }
+
+    :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
+    state
+  end
+
+  defp process_single_message(state, %Pulsar.Message{} = message, nacked_acc) do
     # Call callback for ALL messages (including incomplete chunks). An invalid one
     # goes to its own callback, so handle_message/2 can trust what it is given.
     result =
       if Pulsar.Message.valid?(message) do
-        state.callback_module.handle_message(message, callback_state)
+        state.callback_module.handle_message(message, state.callback_state)
       else
-        state.callback_module.handle_invalid_message(message, callback_state)
+        state.callback_module.handle_invalid_message(message, state.callback_state)
       end
 
     message_ids_list = List.wrap(message.message_id)
 
     case result do
       {:ok, new_callback_state} ->
-        ack_command = %Binary.CommandAck{
-          consumer_id: state.consumer_id,
-          ack_type: :Individual,
-          message_id: message_ids_list,
-          validation_error: validation_error(message)
-        }
-
-        :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
-        {new_callback_state, nacked_acc}
+        state = ack_message_ids(state, message_ids_list, validation_error(message))
+        {%{state | callback_state: new_callback_state}, nacked_acc}
 
       {:noreply, new_callback_state} ->
-        {new_callback_state, nacked_acc}
+        {%{state | callback_state: new_callback_state}, nacked_acc}
 
       {:error, reason, new_callback_state} ->
         redelivery_count = Pulsar.Message.redelivery_count(message)
@@ -630,11 +639,11 @@ defmodule Pulsar.Consumer.Worker do
           "Message processing failed: #{inspect(reason)}, tracking for redelivery (count: #{redelivery_count})"
         )
 
-        {new_callback_state, message_ids_list ++ nacked_acc}
+        {%{state | callback_state: new_callback_state}, message_ids_list ++ nacked_acc}
 
       unexpected_result ->
         Logger.warning("Unexpected callback result: #{inspect(unexpected_result)}, not acknowledging")
-        {callback_state, nacked_acc}
+        {state, nacked_acc}
     end
   end
 
@@ -673,14 +682,7 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_call({:ack, message_ids}, _from, state) when is_list(message_ids) do
-    ack_command = %Binary.CommandAck{
-      consumer_id: state.consumer_id,
-      ack_type: :Individual,
-      message_id: message_ids
-    }
-
-    :ok = Pulsar.Broker.send_command(state.broker_pid, ack_command)
-    {:reply, :ok, state}
+    {:reply, :ok, ack_message_ids(state, message_ids)}
   end
 
   def handle_call({:nack, message_ids}, _from, state) when is_list(message_ids) do
@@ -892,31 +894,40 @@ defmodule Pulsar.Consumer.Worker do
     payload
   end
 
+  # A partly acknowledged entry is redelivered whole, carrying a set of what is still owed.
   defp build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped_messages) do
     base_message_id = command.message_id
+    batch_size = length(unwrapped_messages)
+    outstanding = Ack.outstanding(command.ack_set)
 
-    unwrapped_messages
-    |> Enum.with_index()
-    |> Enum.map(fn {{single_metadata, payload}, index} ->
-      message_id =
-        if single_metadata == nil do
-          base_message_id
-        else
-          %{base_message_id | batch_index: index}
-        end
+    messages =
+      unwrapped_messages
+      |> Enum.with_index()
+      |> Enum.reject(fn {_unwrapped, index} -> Ack.acknowledged?(outstanding, index) end)
+      |> Enum.map(fn {{single_metadata, payload}, index} ->
+        # The width travels on the id so a deferred ack, arriving with nothing else, can still
+        # tell when its entry is complete.
+        message_id =
+          if single_metadata == nil do
+            base_message_id
+          else
+            %{base_message_id | batch_index: index, batch_size: batch_size}
+          end
 
-      %Pulsar.Message{
-        payload: payload,
-        message_id: message_id,
-        chunk_metadata: nil,
-        raw: %{
-          command: command,
-          metadata: metadata,
-          single_metadata: single_metadata,
-          broker_metadata: broker_metadata
+        %Pulsar.Message{
+          payload: payload,
+          message_id: message_id,
+          chunk_metadata: nil,
+          raw: %{
+            command: command,
+            metadata: metadata,
+            single_metadata: single_metadata,
+            broker_metadata: broker_metadata
+          }
         }
-      }
-    end)
+      end)
+
+    {messages, batch_size - length(messages)}
   end
 
   # Pulsar's validation errors all describe damaged message contents, with nothing

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -811,7 +811,7 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp send_initial_flow(broker_pid, consumer_id, permits) do
-    send_flow_command(broker_pid, consumer_id, permits, 0)
+    send_flow_command(broker_pid, consumer_id, permits, 0, 0)
   end
 
   defp check_and_refill_permits(%{flow_initial: 0} = state) do
@@ -847,7 +847,7 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp send_flow_command(broker_pid, consumer_id, permits, outstanding_permits, held_entries \\ 0) do
+  defp send_flow_command(broker_pid, consumer_id, permits, outstanding_permits, held_entries) do
     flow_command = %Binary.CommandFlow{
       consumer_id: consumer_id,
       messagePermits: permits

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -392,10 +392,12 @@ defmodule Pulsar.Consumer.Worker do
     # A skipped message was still sent, and still charged a permit.
     permits_consumed = length(skipped_ids) + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
 
+    # A skipped message is one nothing will ever ack, so it is counted off here instead. That
+    # also covers an entry with nothing left to deliver, which only this can acknowledge.
     new_state =
       new_state
       |> decrement_permits(permits_consumed)
-      |> Map.update!(:acks, &Ack.mark_acked(&1, skipped_ids))
+      |> ack_message_ids(skipped_ids)
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
     new_state =

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -359,22 +359,22 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_info({:broker_message, message_data}, state) do
-    {messages, skipped, new_state} =
+    {messages, skipped_ids, new_state} =
       case message_data do
         {:invalid, command, bytes, validation_error} ->
-          {[build_invalid_message(command, bytes, validation_error)], 0, state}
+          {[build_invalid_message(command, bytes, validation_error)], [], state}
 
         {command, metadata, payload, broker_metadata} ->
           if chunked_message?(metadata) do
             # A chunk is a slice of the compressed message, so it cannot be decompressed
             # before the rest of the slices are back around it.
             {state_after, msgs} = maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
-            {msgs, 0, state_after}
+            {msgs, [], state_after}
           else
             payload = maybe_uncompress(metadata, payload)
             unwrapped = unwrap_messages(metadata, payload)
-            {msgs, skipped} = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
-            {msgs, skipped, state}
+            {msgs, skipped_ids} = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+            {msgs, skipped_ids, state}
           end
 
         {commands, metadatas, payload, broker_metadatas, chunk_metadata} ->
@@ -386,12 +386,16 @@ defmodule Pulsar.Consumer.Worker do
             })
 
           message = build_message_from_chunk(chunk_metadata_full, payload)
-          {[message], 0, state}
+          {[message], [], state}
       end
 
     # A skipped message was still sent, and still charged a permit.
-    permits_consumed = skipped + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
-    new_state = decrement_permits(new_state, permits_consumed)
+    permits_consumed = length(skipped_ids) + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
+
+    new_state =
+      new_state
+      |> decrement_permits(permits_consumed)
+      |> Map.update!(:acks, &Ack.mark_acked(&1, skipped_ids))
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
     new_state =
@@ -579,6 +583,8 @@ defmodule Pulsar.Consumer.Worker do
       %{count: length(entry_ids)},
       consumer_metadata(state)
     )
+
+    :ok
   end
 
   # :trigger_redelivery only fires when a redelivery interval is configured, so without one an
@@ -674,7 +680,13 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_call({:send_flow, permits}, _from, state) do
-    case send_flow_command(state.broker_pid, state.consumer_id, permits, state.flow_outstanding_permits) do
+    case send_flow_command(
+           state.broker_pid,
+           state.consumer_id,
+           permits,
+           state.flow_outstanding_permits,
+           Ack.held_entries(state.acks)
+         ) do
       :ok ->
         new_permits = state.flow_outstanding_permits + permits
         {:reply, :ok, %{state | flow_outstanding_permits: new_permits}}
@@ -817,7 +829,13 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp do_refill_permits(state, refill_amount, current_permits) do
-    case send_flow_command(state.broker_pid, state.consumer_id, refill_amount, current_permits) do
+    case send_flow_command(
+           state.broker_pid,
+           state.consumer_id,
+           refill_amount,
+           current_permits,
+           Ack.held_entries(state.acks)
+         ) do
       :ok ->
         %{state | flow_outstanding_permits: current_permits + refill_amount}
 
@@ -827,7 +845,7 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp send_flow_command(broker_pid, consumer_id, permits, outstanding_permits) do
+  defp send_flow_command(broker_pid, consumer_id, permits, outstanding_permits, held_entries \\ 0) do
     flow_command = %Binary.CommandFlow{
       consumer_id: consumer_id,
       messagePermits: permits
@@ -836,7 +854,8 @@ defmodule Pulsar.Consumer.Worker do
     start_metadata = %{
       consumer_id: consumer_id,
       permits_requested: permits,
-      permits_before: outstanding_permits
+      permits_before: outstanding_permits,
+      held_entries: held_entries
     }
 
     :telemetry.span(
@@ -897,29 +916,26 @@ defmodule Pulsar.Consumer.Worker do
     payload
   end
 
-  # A partly acknowledged entry is redelivered whole, carrying a set of what is still owed.
+  # A partly acknowledged entry is redelivered whole, carrying a set of what is still owed, and a
+  # compacted topic leaves entries holding messages compaction has replaced. Neither is delivered
+  # again; both still count towards the entry, so both come back to be counted off.
   defp build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped_messages) do
     base_message_id = command.message_id
     batch_size = length(unwrapped_messages)
     outstanding = Ack.outstanding(command.ack_set)
 
-    messages =
+    {delivered, skipped} =
       unwrapped_messages
       |> Enum.with_index()
-      |> Enum.filter(fn {_unwrapped, index} -> Ack.deliverable?(outstanding, index) end)
-      |> Enum.map(fn {{single_metadata, payload}, index} ->
-        # The width travels on the id so a deferred ack, arriving with nothing else, can still
-        # tell when its entry is complete.
-        message_id =
-          if single_metadata == nil do
-            base_message_id
-          else
-            %{base_message_id | batch_index: index, batch_size: batch_size}
-          end
+      |> Enum.split_with(fn {{single_metadata, _payload}, index} ->
+        Ack.deliverable?(outstanding, index) and not compacted_out?(single_metadata)
+      end)
 
+    messages =
+      Enum.map(delivered, fn {{single_metadata, payload}, index} ->
         %Pulsar.Message{
           payload: payload,
-          message_id: message_id,
+          message_id: unwrapped_message_id(base_message_id, single_metadata, index, batch_size),
           chunk_metadata: nil,
           raw: %{
             command: command,
@@ -930,8 +946,24 @@ defmodule Pulsar.Consumer.Worker do
         }
       end)
 
-    {messages, batch_size - length(messages)}
+    skipped_ids =
+      Enum.map(skipped, fn {{single_metadata, _payload}, index} ->
+        unwrapped_message_id(base_message_id, single_metadata, index, batch_size)
+      end)
+
+    {messages, skipped_ids}
   end
+
+  # The width travels on the id so a deferred ack, arriving with nothing else, can still tell
+  # when its entry is complete.
+  defp unwrapped_message_id(base_message_id, nil, _index, _batch_size), do: base_message_id
+
+  defp unwrapped_message_id(base_message_id, _single_metadata, index, batch_size) do
+    %{base_message_id | batch_index: index, batch_size: batch_size}
+  end
+
+  defp compacted_out?(%Binary.SingleMessageMetadata{compacted_out: true}), do: true
+  defp compacted_out?(_single_metadata), do: false
 
   # Pulsar's validation errors all describe damaged message contents, with nothing
   # for a frame that was malformed around them, so every reason is reported as the

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -588,15 +588,10 @@ defmodule Pulsar.Consumer.Worker do
 
   defp track_nacked(state, []), do: state
 
-  # Nothing drains the nacked set without an interval to fire :trigger_redelivery, so the entry
-  # is not coming back and its tally is left as it is: acking the message later still completes
-  # it.
+  # Nothing fires :trigger_redelivery without an interval, so the entry is not coming back and
+  # its tally is deliberately kept: acking the message later still completes it.
   defp track_nacked(%__MODULE__{redelivery_interval: nil} = state, nacked_ids) do
-    Logger.warning(
-      "NACKed #{length(nacked_ids)} message(s) with no redelivery_interval configured: " <>
-        "nothing will ask for them back"
-    )
-
+    Logger.debug("NACKed #{length(nacked_ids)} message(s), but no redelivery_interval configured")
     state
   end
 
@@ -917,7 +912,7 @@ defmodule Pulsar.Consumer.Worker do
       unwrapped_messages
       |> Enum.with_index()
       |> Enum.split_with(fn {{single_metadata, _payload}, index} ->
-        Ack.deliverable?(outstanding, index) and not compacted_out?(single_metadata)
+        deliverable?(single_metadata, outstanding, index)
       end)
 
     messages =
@@ -949,6 +944,13 @@ defmodule Pulsar.Consumer.Worker do
 
   defp unwrapped_message_id(base_message_id, _single_metadata, index, batch_size) do
     %{base_message_id | batch_index: index, batch_size: batch_size}
+  end
+
+  # A delivery with no batch framing is one message, whatever set the entry arrived with.
+  defp deliverable?(nil, _outstanding, _index), do: true
+
+  defp deliverable?(single_metadata, outstanding, index) do
+    Ack.deliverable?(outstanding, index) and not compacted_out?(single_metadata)
   end
 
   defp compacted_out?(%Binary.SingleMessageMetadata{compacted_out: true}), do: true

--- a/test/integration/consumer/batch_ack_test.exs
+++ b/test/integration/consumer/batch_ack_test.exs
@@ -68,6 +68,25 @@ defmodule Pulsar.Integration.Consumer.BatchAckTest do
     refute_receive {:received, "msg-1"}, 2_000
   end
 
+  # The second consumer never acks msg-1, so every ack it sends re-asserts msg-1 as outstanding.
+  # The entry only clears if the broker ands those sets into what it has already deleted.
+  test "batch index acks clear the entry once every message has been acked, across consumers" do
+    topic = @topic <> "-index-complete"
+    subscription = "index-complete-sub"
+    :ok = produce_one_batch(topic, "index-complete")
+
+    consumer = start_consumer(topic, subscription, [ack: ["msg-1"]], batch_index_ack_enabled: true)
+    for payload <- @batch, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    consumer = start_consumer(topic, subscription, [ack: :all], batch_index_ack_enabled: true)
+    for payload <- tl(@batch), do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    _consumer = start_consumer(topic, subscription, [ack: :all], batch_index_ack_enabled: true)
+    refute_receive {:received, _payload}, 3_000
+  end
+
   test "acking every message of a batch acknowledges its entry" do
     topic = @topic <> "-complete"
     subscription = "complete-sub"

--- a/test/integration/consumer/batch_ack_test.exs
+++ b/test/integration/consumer/batch_ack_test.exs
@@ -1,0 +1,128 @@
+defmodule Pulsar.Integration.Consumer.BatchAckTest do
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Test.Support.System
+  alias Pulsar.Test.Support.Utils
+
+  @moduletag :integration
+  @client :consumer_batch_ack_test_client
+  @topic "persistent://public/default/consumer-batch-ack-test"
+  @batch ["msg-1", "msg-2", "msg-3", "msg-4", "msg-5"]
+
+  # Leaves part of a batch unacknowledged, the way a consumer dying mid-entry would.
+  defmodule PartialAckConsumer do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(opts, _context) do
+      notify_pid = Keyword.fetch!(opts, :notify_pid)
+      send(notify_pid, {:consumer_ready, self()})
+
+      {:ok, %{notify_pid: notify_pid, ack: Keyword.fetch!(opts, :ack)}}
+    end
+
+    def handle_message(message, state) do
+      send(state.notify_pid, {:received, message.payload})
+
+      if state.ack == :all or message.payload in state.ack do
+        {:ok, state}
+      else
+        {:noreply, state}
+      end
+    end
+  end
+
+  setup_all do
+    broker = System.broker()
+    {:ok, _} = Pulsar.Client.start_link(name: @client, host: broker.service_url)
+    on_exit(fn -> Pulsar.Client.stop(@client) end)
+    :ok
+  end
+
+  test "acking one message of a batch does not acknowledge the rest of its entry" do
+    topic = @topic <> "-partial"
+    subscription = "partial-sub"
+    :ok = produce_one_batch(topic, "partial")
+
+    consumer = start_consumer(topic, subscription, ack: ["msg-1"])
+    for payload <- @batch, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    # The entry is redelivered whole, so the acked message comes back with its siblings.
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- @batch, do: assert_receive({:received, ^payload}, 10_000)
+  end
+
+  test "batch index acks redeliver only the messages that were not acked" do
+    topic = @topic <> "-index"
+    subscription = "index-sub"
+    :ok = produce_one_batch(topic, "index")
+
+    consumer = start_consumer(topic, subscription, [ack: ["msg-1"]], batch_index_ack_enabled: true)
+    for payload <- @batch, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    # The broker was told which message the ack was for, so it does not come back.
+    _consumer = start_consumer(topic, subscription, [ack: :all], batch_index_ack_enabled: true)
+    for payload <- tl(@batch), do: assert_receive({:received, ^payload}, 10_000)
+    refute_receive {:received, "msg-1"}, 2_000
+  end
+
+  test "acking every message of a batch acknowledges its entry" do
+    topic = @topic <> "-complete"
+    subscription = "complete-sub"
+    :ok = produce_one_batch(topic, "complete")
+
+    consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- @batch, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    refute_receive {:received, _payload}, 3_000
+  end
+
+  ## Helpers
+
+  # One batch, so all five messages share a single entry.
+  defp produce_one_batch(topic, name) do
+    :ok = System.create_topic(topic)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(topic,
+        client: @client,
+        name: "#{name}-producer",
+        batch_enabled: true,
+        batch_size: length(@batch),
+        flush_interval: 30_000
+      )
+
+    :ok = Pulsar.Producer.await_ready(producer)
+
+    results =
+      @batch
+      |> Enum.map(fn payload -> Task.async(fn -> Pulsar.Producer.send(producer, payload) end) end)
+      |> Task.await_many(10_000)
+
+    assert Enum.all?(results, &match?({:ok, _}, &1))
+
+    :ok
+  end
+
+  defp start_consumer(topic, subscription, init_args, consumer_opts \\ []) do
+    {:ok, consumer} =
+      Pulsar.Consumer.start(
+        topic,
+        subscription,
+        PartialAckConsumer,
+        [
+          client: @client,
+          initial_position: :earliest,
+          init_args: [notify_pid: self()] ++ init_args
+        ] ++ consumer_opts
+      )
+
+    Utils.wait_for_consumer_ready(1)
+
+    consumer
+  end
+end

--- a/test/unit/consumer_ack_test.exs
+++ b/test/unit/consumer_ack_test.exs
@@ -20,6 +20,42 @@ defmodule Pulsar.Consumer.AckTest do
     end
   end
 
+  describe "forget/2" do
+    test "drops what an entry had counted off, so a redelivery starts again" do
+      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
+      {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+
+      ack = Ack.forget(ack, [batch_id(1, 3)])
+      assert ack.acked == %{}
+
+      # Counting on from the first delivery would acknowledge the entry an ack early.
+      assert {[], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+      assert {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+      assert {[_entry], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
+    end
+
+    test "leaves entries the ids do not belong to alone" do
+      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
+
+      ack = Ack.forget(ack, [batch_id(0, 3, entry: 43), id()])
+
+      assert map_size(ack.acked) == 1
+    end
+  end
+
+  describe "entry_id/1" do
+    test "leaves an id that names no batch untouched" do
+      assert Ack.entry_id(id()) == id()
+    end
+
+    test "drops what an ack of the whole entry must not carry" do
+      entry = Ack.entry_id(%{batch_id(2, 3) | ack_set: [0b101]})
+
+      assert {entry.batch_index, entry.batch_size, entry.ack_set} == {-1, nil, []}
+      assert {entry.ledgerId, entry.entryId} == {7, 42}
+    end
+  end
+
   describe "ack sets" do
     test "round trip through the wire encoding, including the sign bit" do
       for size <- [2, 63, 64, 65, 100, 129] do

--- a/test/unit/consumer_ack_test.exs
+++ b/test/unit/consumer_ack_test.exs
@@ -20,29 +20,6 @@ defmodule Pulsar.Consumer.AckTest do
     end
   end
 
-  describe "forget/2" do
-    test "drops what an entry had counted off, so a redelivery starts again" do
-      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
-      {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
-
-      ack = Ack.forget(ack, [batch_id(1, 3)])
-      assert ack.acked == %{}
-
-      # Counting on from the first delivery would acknowledge the entry an ack early.
-      assert {[], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
-      assert {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
-      assert {[_entry], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
-    end
-
-    test "leaves entries the ids do not belong to alone" do
-      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
-
-      ack = Ack.forget(ack, [batch_id(0, 3, entry: 43), id()])
-
-      assert map_size(ack.acked) == 1
-    end
-  end
-
   describe "entry_id/1" do
     test "leaves an id that names no batch untouched" do
       assert Ack.entry_id(id()) == id()
@@ -99,6 +76,27 @@ defmodule Pulsar.Consumer.AckTest do
       assert {[%{batch_index: -1, entryId: 42}], ack} = Ack.take_nacked(ack)
       assert {[], _ack} = Ack.take_nacked(ack)
     end
+
+    test "makes the redelivered entry answer for every message again" do
+      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
+      {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+
+      ack = Ack.record_nack(ack, [batch_id(1, 3)])
+
+      # Counting on from the first delivery would acknowledge the entry on the redelivery of
+      # message 1, before message 2 had been dealt with.
+      assert {[], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+      assert {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+      assert {[_entry], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
+    end
+
+    test "leaves entries the nacked ids do not belong to alone" do
+      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
+
+      ack = Ack.record_nack(ack, [batch_id(0, 3, entry: 43), id()])
+
+      assert map_size(ack.acked) == 1
+    end
   end
 
   ## Helpers
@@ -108,7 +106,7 @@ defmodule Pulsar.Consumer.AckTest do
     acked = Enum.reject(0..(size - 1), &(&1 in owed))
 
     {ids, _ack} =
-      Enum.reduce(acked, {[], Ack.new(true)}, fn index, {ids, ack} ->
+      Enum.reduce(acked, {[], Ack.new(batch_index_ack_enabled: true)}, fn index, {ids, ack} ->
         {ackable, ack} = Ack.record_ack(ack, [batch_id(index, size)])
         {ids ++ ackable, ack}
       end)

--- a/test/unit/consumer_ack_test.exs
+++ b/test/unit/consumer_ack_test.exs
@@ -1,0 +1,86 @@
+defmodule Pulsar.Consumer.AckTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Consumer.Ack
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+
+  doctest Ack
+
+  describe "record_ack/2" do
+    test "counts messages from different entries independently" do
+      {ackable, _ack} = Ack.record_ack(Ack.new(), [batch_id(0, 2), batch_id(0, 2, entry: 43)])
+
+      assert ackable == []
+    end
+
+    test "treats a batch of one as a plain message" do
+      assert {[_id], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 1)])
+      assert ack.acked == %{}
+    end
+  end
+
+  describe "ack sets" do
+    test "round trip through the wire encoding, including the sign bit" do
+      for size <- [2, 63, 64, 65, 100, 129] do
+        outstanding = MapSet.new(Enum.take_every(0..(size - 1), 3))
+
+        assert Ack.outstanding(encode(outstanding, size)) == outstanding
+      end
+    end
+
+    test "writes a word with its top bit set as a negative int64" do
+      # Bits 1..63 outstanding of a 64-message entry.
+      assert [word] = encode(MapSet.new(1..63), 64)
+      assert word == -2
+      assert word >= -0x8000_0000_0000_0000
+    end
+
+    test "survives a protobuf round trip, so the broker sees what was meant" do
+      outstanding = MapSet.new([0, 63, 64, 99])
+
+      message_id = %{id() | batch_index: -1, batch_size: 100, ack_set: encode(outstanding, 100)}
+      decoded = Binary.MessageIdData.decode(Binary.MessageIdData.encode(message_id))
+
+      assert Ack.outstanding(decoded.ack_set) == outstanding
+    end
+
+    test "treats every message as outstanding when the entry carries no set" do
+      refute Ack.acknowledged?(nil, 7)
+    end
+  end
+
+  describe "record_nack/2" do
+    test "collapses ids to their entry and drops what was counted off" do
+      {[], ack} = Ack.record_ack(Ack.new(), [batch_id(0, 3)])
+      ack = Ack.record_nack(ack, [batch_id(1, 3)])
+
+      assert ack.acked == %{}
+      assert {[%{batch_index: -1, entryId: 42}], ack} = Ack.take_nacked(ack)
+      assert Ack.nacked_count(ack) == 0
+    end
+  end
+
+  ## Helpers
+
+  # The set the broker would be sent once everything outside `outstanding` has been acked.
+  defp encode(outstanding, size) do
+    acked = Enum.reject(0..(size - 1), &MapSet.member?(outstanding, &1))
+
+    {ids, _ack} =
+      Enum.reduce(acked, {[], Ack.new(true)}, fn index, {ids, ack} ->
+        {ackable, ack} = Ack.record_ack(ack, [batch_id(index, size)])
+        {ids ++ ackable, ack}
+      end)
+
+    ids |> List.last() |> Map.fetch!(:ack_set)
+  end
+
+  defp id(entry \\ 42) do
+    %Binary.MessageIdData{ledgerId: 7, entryId: entry, partition: -1, batch_index: -1}
+  end
+
+  defp batch_id(index, size, opts \\ []) do
+    %{id(Keyword.get(opts, :entry, 42)) | batch_index: index, batch_size: size}
+  end
+end

--- a/test/unit/consumer_ack_test.exs
+++ b/test/unit/consumer_ack_test.exs
@@ -23,30 +23,34 @@ defmodule Pulsar.Consumer.AckTest do
   describe "ack sets" do
     test "round trip through the wire encoding, including the sign bit" do
       for size <- [2, 63, 64, 65, 100, 129] do
-        outstanding = MapSet.new(Enum.take_every(0..(size - 1), 3))
+        owed = Enum.take_every(0..(size - 1), 3)
+        decoded = Ack.outstanding(encode(owed, size))
 
-        assert Ack.outstanding(encode(outstanding, size)) == outstanding
+        for index <- 0..(size - 1) do
+          assert Ack.deliverable?(decoded, index) == index in owed
+        end
       end
     end
 
     test "writes a word with its top bit set as a negative int64" do
       # Bits 1..63 outstanding of a 64-message entry.
-      assert [word] = encode(MapSet.new(1..63), 64)
+      assert [word] = encode(1..63, 64)
       assert word == -2
       assert word >= -0x8000_0000_0000_0000
     end
 
     test "survives a protobuf round trip, so the broker sees what was meant" do
-      outstanding = MapSet.new([0, 63, 64, 99])
+      owed = [0, 63, 64, 99]
 
-      message_id = %{id() | batch_index: -1, batch_size: 100, ack_set: encode(outstanding, 100)}
+      message_id = %{id() | batch_index: -1, batch_size: 100, ack_set: encode(owed, 100)}
       decoded = Binary.MessageIdData.decode(Binary.MessageIdData.encode(message_id))
 
-      assert Ack.outstanding(decoded.ack_set) == outstanding
+      assert Ack.outstanding(decoded.ack_set) == Ack.outstanding(encode(owed, 100))
+      for index <- owed, do: assert(Ack.deliverable?(Ack.outstanding(decoded.ack_set), index))
     end
 
-    test "treats every message as outstanding when the entry carries no set" do
-      refute Ack.acknowledged?(nil, 7)
+    test "treats every message as deliverable when the entry carries no set" do
+      assert Ack.deliverable?(nil, 7)
     end
   end
 
@@ -57,15 +61,15 @@ defmodule Pulsar.Consumer.AckTest do
 
       assert ack.acked == %{}
       assert {[%{batch_index: -1, entryId: 42}], ack} = Ack.take_nacked(ack)
-      assert Ack.nacked_count(ack) == 0
+      assert {[], _ack} = Ack.take_nacked(ack)
     end
   end
 
   ## Helpers
 
-  # The set the broker would be sent once everything outside `outstanding` has been acked.
-  defp encode(outstanding, size) do
-    acked = Enum.reject(0..(size - 1), &MapSet.member?(outstanding, &1))
+  # The set the broker would be sent once everything outside `owed` has been acked.
+  defp encode(owed, size) do
+    acked = Enum.reject(0..(size - 1), &(&1 in owed))
 
     {ids, _ack} =
       Enum.reduce(acked, {[], Ack.new(true)}, fn index, {ids, ack} ->

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -24,6 +24,29 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
+  # Stands in for the dead letter producer. `Pulsar.Producer.send/3` routes a bare pid through
+  # `Topology.kind/1`, which calls anything that is not a topology or group supervisor a worker,
+  # so answering `{:send_message, ...}` is all it takes to be one.
+  defmodule DeadLetterProducer do
+    @moduledoc false
+    use GenServer
+
+    def start_link({refuse, notify_pid}), do: GenServer.start_link(__MODULE__, {refuse, notify_pid})
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:send_message, payload, _opts}, _from, {refuse, notify_pid} = state) do
+      if payload in refuse do
+        {:reply, {:error, :message_too_large}, state}
+      else
+        send(notify_pid, {:diverted, payload})
+        {:reply, {:ok, %Binary.MessageIdData{ledgerId: 9, entryId: 1, partition: -1}}, state}
+      end
+    end
+  end
+
   @topic "persistent://public/default/orders"
   @ledger 7
   @entry 42
@@ -215,7 +238,112 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
+  describe "reporting the ledger" do
+    test "counts the entries it is holding when it asks for more permits" do
+      handler = "held-entries-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:pulsar, :consumer, :flow_control, :stop],
+        fn _event, _measurements, metadata, pid -> send(pid, {:flow_control, metadata}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      # The threshold is high enough that this delivery triggers a refill on its way out.
+      state = %{
+        worker_state(%{"b" => :defer})
+        | flow_initial: 100,
+          flow_threshold: 100,
+          flow_refill: 50,
+          flow_outstanding_permits: 100
+      }
+
+      deliver(state, ["a", "b", "c"])
+
+      assert_received {:flow_control, %{held_entries: 1}}
+    end
+
+    test "counts nothing once the entries it was holding complete" do
+      handler = "held-entries-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:pulsar, :consumer, :flow_control, :stop],
+        fn _event, _measurements, metadata, pid -> send(pid, {:flow_control, metadata}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      state = %{
+        worker_state(%{})
+        | flow_initial: 100,
+          flow_threshold: 100,
+          flow_refill: 50,
+          flow_outstanding_permits: 100
+      }
+
+      deliver(state, ["a", "b", "c"])
+
+      assert_received {:flow_control, %{held_entries: 0}}
+    end
+  end
+
+  describe "diverting a batch to the dead letter topic" do
+    test "does not acknowledge the entry when one message of it fails to divert" do
+      state = diverting_state(refuse: ["b"])
+
+      state = deliver(state, ["a", "b", "c"], redelivery_count: 1)
+
+      # "a" and "c" reached the dead letter topic, but "b" did not, so the entry is still owed.
+      assert diverted_payloads() == ["a", "c"]
+      assert [] == acks()
+
+      # Its tally goes too: the entry comes back whole, and "a" and "c" divert a second time.
+      assert state.acks.acked == %{}
+    end
+
+    test "acknowledges the entry once every message of it has been diverted" do
+      state = diverting_state(refuse: [])
+
+      state = deliver(state, ["a", "b", "c"], redelivery_count: 1)
+
+      assert diverted_payloads() == ["a", "b", "c"]
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+  end
+
   ## Helpers
+
+  # A consumer whose dead letter producer is the stub above, past its redelivery limit.
+  # DeadLetter.producer/1 looks for a `{:dead_letter, topic}` child reported as a supervisor.
+  defp diverting_state(opts) do
+    child = %{
+      id: {:dead_letter, "dlq"},
+      start: {DeadLetterProducer, :start_link, [{Keyword.fetch!(opts, :refuse), self()}]},
+      type: :supervisor
+    }
+
+    root =
+      start_supervised!(%{
+        id: :dead_letter_root,
+        start: {Supervisor, :start_link, [[child], [strategy: :one_for_one]]}
+      })
+
+    %{worker_state(%{}) | dead_letter_root: root, dead_letter_topic: "dlq", max_redelivery: 1}
+  end
+
+  defp diverted_payloads(acc \\ []) do
+    receive do
+      {:diverted, payload} -> diverted_payloads([payload | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
 
   defp worker_state(answers, opts \\ []) do
     {batch_index_ack_enabled, opts} = Keyword.pop(opts, :batch_index_ack_enabled, false)
@@ -242,7 +370,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     command = %Binary.CommandMessage{
       consumer_id: 1,
       message_id: message_id(),
-      redelivery_count: 0,
+      redelivery_count: Keyword.get(opts, :redelivery_count, 0),
       ack_set: Keyword.get(opts, :ack_set, [])
     }
 
@@ -291,7 +419,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     %{message_id() | batch_index: index, batch_size: 3}
   end
 
-  defp encode_single_message(payload, compacted_out \\ false) do
+  defp encode_single_message(payload, compacted_out) do
     metadata =
       Binary.SingleMessageMetadata.encode(%Binary.SingleMessageMetadata{
         payload_size: byte_size(payload),

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -1,0 +1,269 @@
+defmodule Pulsar.Consumer.BatchAckTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Consumer.Ack
+  alias Pulsar.Consumer.Worker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+
+  defmodule Callback do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(answers, _context), do: {:ok, answers}
+
+    def handle_message(message, answers) do
+      # The worker is driven inline, so this lands in the test process.
+      send(self(), {:delivered, message.payload})
+
+      case Map.get(answers, message.payload, :ack) do
+        :ack -> {:ok, answers}
+        :defer -> {:noreply, answers}
+        :nack -> {:error, :rejected, answers}
+      end
+    end
+  end
+
+  @topic "persistent://public/default/orders"
+  @ledger 7
+  @entry 42
+
+  describe "acking a batched message" do
+    test "acknowledges the entry once, after the last message in it is acked" do
+      deliver(worker_state(%{}), ["a", "b", "c"])
+
+      assert [ack] = acks()
+      assert [message_id] = ack.message_id
+      assert {@ledger, @entry} == {message_id.ledgerId, message_id.entryId}
+
+      assert message_id.batch_index == -1
+    end
+
+    test "leaves the entry unacknowledged while any message in it is still outstanding" do
+      deliver(worker_state(%{"b" => :defer}), ["a", "b", "c"])
+
+      assert [] == acks()
+    end
+
+    test "does not acknowledge the entry when a message in it is nacked" do
+      deliver(worker_state(%{"b" => :nack}), ["a", "b", "c"])
+
+      assert [] == acks()
+    end
+
+    test "completes the entry when a deferred ack arrives later" do
+      state = deliver(worker_state(%{"b" => :defer}), ["a", "b", "c"])
+      assert [] == acks()
+
+      {:reply, :ok, _state} = Worker.handle_call({:ack, [batch_id(1)]}, self(), state)
+
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+    end
+
+    test "counts a redelivered entry from scratch, having dropped what a nack invalidated" do
+      state = deliver(worker_state(%{"c" => :nack}), ["a", "b", "c"])
+      assert [] == acks()
+
+      state = deliver(%{state | callback_state: %{"c" => :ack}}, ["a", "b", "c"])
+
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
+    test "forgets the entry once it has been acknowledged" do
+      state = deliver(worker_state(%{}), ["a", "b", "c"])
+
+      assert state.acks.acked == %{}
+    end
+  end
+
+  describe "nacking a batched message" do
+    test "collapses ids to the entry the broker would redeliver" do
+      state = deliver(worker_state(%{"a" => :nack, "c" => :nack}, redelivery_interval: 1000), ["a", "b", "c"])
+
+      assert [%{batch_index: -1} = id] = MapSet.to_list(state.acks.nacked)
+      assert {@ledger, @entry} == {id.ledgerId, id.entryId}
+    end
+  end
+
+  describe "acking a message that was not batched" do
+    test "acknowledges it on its own" do
+      deliver_unbatched(worker_state(%{}), "solo")
+
+      assert [ack] = acks()
+      assert [%{ledgerId: @ledger, entryId: @entry, batch_index: -1}] = ack.message_id
+    end
+
+    test "is unaffected by an entry still being counted off" do
+      state = deliver(worker_state(%{"b" => :defer}), ["a", "b", "c"])
+      assert [] == acks()
+
+      deliver_unbatched(state, "solo", entry: @entry + 1)
+
+      assert [ack] = acks()
+      assert [%{entryId: 43}] = ack.message_id
+    end
+  end
+
+  describe "batch index acking" do
+    test "reports what is still outstanding in the entry as each message is acked" do
+      deliver(worker_state(%{}, batch_index_ack_enabled: true), ["a", "b", "c"])
+
+      # Set bits are the messages still owed, clearing as the acks come in.
+      assert [first, second, third] = Enum.map(acks(), fn ack -> hd(ack.message_id) end)
+      assert first.ack_set == [0b110]
+      assert second.ack_set == [0b100]
+      assert third.ack_set == []
+
+      assert first.batch_size == 3
+      assert third.batch_size == nil
+    end
+
+    test "holds the entry back instead when it is turned off" do
+      deliver(worker_state(%{}), ["a", "b", "c"])
+
+      assert [ack] = acks()
+      assert [%{ack_set: []}] = ack.message_id
+    end
+
+    test "spans several words for a batch wider than one, writing int64 as signed" do
+      payloads = Enum.map(1..70, &"msg-#{&1}")
+      # Everything but message 0 is deferred, so one ack goes out reporting the other 69.
+      answers = Map.new(tl(payloads), &{&1, :defer})
+
+      deliver(worker_state(answers, batch_index_ack_enabled: true), payloads)
+
+      assert [ack] = acks()
+      assert [%{ack_set: [low, high], batch_size: 70}] = ack.message_id
+
+      # Bits 1..63 of the first word, which sets the sign bit, and 64..69 of the second.
+      assert low == -2
+      assert high == 0b111111
+    end
+  end
+
+  describe "a redelivered entry" do
+    test "skips the messages it reports as already acknowledged" do
+      state = worker_state(%{})
+
+      # Bits set are the messages still outstanding: "a" and "c" were acked before.
+      deliver(state, ["a", "b", "c"], ack_set: [0b010])
+
+      assert [received] = delivered_payloads()
+      assert received == "b"
+    end
+
+    test "still spends a permit on each message the broker sent" do
+      state = %{worker_state(%{}) | flow_initial: 100, flow_threshold: 0, flow_outstanding_permits: 100}
+
+      new_state = deliver(state, ["a", "b", "c"], ack_set: [0b010])
+
+      # One message was delivered, but the broker charged for the whole entry.
+      assert new_state.flow_outstanding_permits == 97
+    end
+
+    test "delivers everything when the entry carries no set" do
+      deliver(worker_state(%{}), ["a", "b", "c"])
+
+      assert delivered_payloads() == ["a", "b", "c"]
+    end
+  end
+
+  ## Helpers
+
+  defp worker_state(answers, opts \\ []) do
+    {batch_index_ack_enabled, opts} = Keyword.pop(opts, :batch_index_ack_enabled, false)
+
+    struct(
+      Worker,
+      [
+        acks: Ack.new(batch_index_ack_enabled),
+        topic: @topic,
+        base_topic: @topic,
+        subscription_name: "order-service",
+        subscription_type: :shared,
+        callback_module: Callback,
+        callback_state: answers,
+        broker_pid: self(),
+        consumer_id: 1,
+        flow_initial: 0
+      ] ++ opts
+    )
+  end
+
+  # Broker commands are casts, so they arrive in the test process mailbox.
+  defp deliver(state, payloads, opts \\ []) do
+    command = %Binary.CommandMessage{
+      consumer_id: 1,
+      message_id: message_id(),
+      redelivery_count: 0,
+      ack_set: Keyword.get(opts, :ack_set, [])
+    }
+
+    metadata = %Binary.MessageMetadata{
+      producer_name: "orders-api",
+      sequence_id: 0,
+      publish_time: 0,
+      compression: :NONE,
+      num_messages_in_batch: length(payloads)
+    }
+
+    payload = payloads |> Enum.map(&encode_single_message/1) |> :erlang.iolist_to_binary()
+
+    {:noreply, new_state} = Worker.handle_info({:broker_message, {command, metadata, payload, nil}}, state)
+    new_state
+  end
+
+  defp deliver_unbatched(state, payload, opts \\ []) do
+    entry = Keyword.get(opts, :entry, @entry)
+    command = %Binary.CommandMessage{consumer_id: 1, message_id: message_id(entry), redelivery_count: 0}
+
+    # No batch framing, so unwrapping falls back to the payload as it stands.
+    metadata = %Binary.MessageMetadata{
+      producer_name: "orders-api",
+      sequence_id: 0,
+      publish_time: 0,
+      compression: :NONE,
+      num_messages_in_batch: 1
+    }
+
+    {:noreply, new_state} = Worker.handle_info({:broker_message, {command, metadata, payload, nil}}, state)
+    new_state
+  end
+
+  defp message_id(entry \\ @entry) do
+    %Binary.MessageIdData{ledgerId: @ledger, entryId: entry, partition: -1, batch_index: -1}
+  end
+
+  defp batch_id(index) do
+    %{message_id() | batch_index: index, batch_size: 3}
+  end
+
+  defp encode_single_message(payload) do
+    metadata = Binary.SingleMessageMetadata.encode(%Binary.SingleMessageMetadata{payload_size: byte_size(payload)})
+
+    <<byte_size(metadata)::32, metadata::binary, payload::binary>>
+  end
+
+  defp acks do
+    Enum.filter(receive_commands(), &match?(%Binary.CommandAck{}, &1))
+  end
+
+  defp delivered_payloads(acc \\ []) do
+    receive do
+      {:delivered, payload} -> delivered_payloads([payload | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp receive_commands(acc \\ []) do
+    receive do
+      {:"$gen_cast", {:send_command, command}} -> receive_commands([command | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -100,14 +100,47 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
       assert state.acks.acked == %{}
     end
+
+    test "starts a tally nothing will finish when a completed entry is acked again" do
+      state = deliver(worker_state(%{}), ["a", "b", "c"])
+      assert [_ack] = acks()
+
+      {:reply, :ok, state} = Worker.handle_call({:ack, [batch_id(1)]}, self(), state)
+
+      # The entry is gone, so the second ack counts one message of three off an empty tally.
+      assert [] == acks()
+      assert map_size(state.acks.acked) == 1
+    end
   end
 
   describe "nacking a batched message" do
+    test "does not queue a nack for a redelivery that will never be requested" do
+      state = deliver(worker_state(%{"b" => :nack}), ["a", "b", "c"])
+
+      # :trigger_redelivery is only scheduled when an interval is configured, so anything
+      # recorded here would sit forever with nothing to drain it.
+      assert {[], _acks} = Ack.take_nacked(state.acks)
+    end
+
     test "collapses ids to the entry the broker would redeliver" do
       state = deliver(worker_state(%{"a" => :nack, "c" => :nack}, redelivery_interval: 1000), ["a", "b", "c"])
 
       assert [%{batch_index: -1} = id] = MapSet.to_list(state.acks.nacked)
       assert {@ledger, @entry} == {id.ledgerId, id.entryId}
+    end
+
+    test "keeps the entry's tally when nothing will ask the nacked message back" do
+      state = deliver(worker_state(%{"b" => :nack}), ["a", "b", "c"])
+
+      assert [] == acks()
+      assert map_size(state.acks.acked) == 1
+
+      # "a" and "c" were acked before the nack, so acking "b" out of band completes the entry.
+      {:reply, :ok, state} = Worker.handle_call({:ack, [batch_id(1)]}, self(), state)
+
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
     end
   end
 
@@ -187,6 +220,20 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert new_state.flow_outstanding_permits == 97
     end
 
+    test "reads a set that spans words, and the sign the broker wrote it with" do
+      payloads = Enum.map(0..69, &"msg-#{&1}")
+
+      # Bits 1..63 of the first word, which sets its sign bit, and 64..69 of the second: only
+      # "msg-0" was acked before.
+      state = deliver(worker_state(%{}), payloads, ack_set: [-2, 0b111111])
+
+      assert delivered_payloads() == tl(payloads)
+
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
     test "delivers everything when the entry carries no set" do
       deliver(worker_state(%{}), ["a", "b", "c"])
 
@@ -204,6 +251,23 @@ defmodule Pulsar.Consumer.BatchAckTest do
       # Acking what arrived has to finish the entry: nothing will ever deliver "a" again.
       assert [ack] = acks()
       assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
+    test "keeps its full width under batch index acking, so it can still complete" do
+      state = worker_state(%{}, batch_index_ack_enabled: true)
+
+      # "a" was acked by whoever held the entry before, so only "b" and "c" are delivered.
+      state = deliver(state, ["a", "b", "c"], ack_set: [0b110])
+
+      assert delivered_payloads() == ["b", "c"]
+
+      # batch_size comes from the entry's own metadata, not from how much of it was delivered,
+      # so counting "a" off and acking the two that arrived still reaches the whole entry.
+      assert [first, second, third] = Enum.map(acks(), fn ack -> hd(ack.message_id) end)
+      assert {first.ack_set, first.batch_size} == {[0b110], 3}
+      assert {second.ack_set, second.batch_size} == {[0b100], 3}
+      assert third.batch_index == -1
       assert state.acks.acked == %{}
     end
 
@@ -238,59 +302,6 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
-  describe "reporting the ledger" do
-    test "counts the entries it is holding when it asks for more permits" do
-      handler = "held-entries-#{System.unique_integer([:positive])}"
-
-      :telemetry.attach(
-        handler,
-        [:pulsar, :consumer, :flow_control, :stop],
-        fn _event, _measurements, metadata, pid -> send(pid, {:flow_control, metadata}) end,
-        self()
-      )
-
-      on_exit(fn -> :telemetry.detach(handler) end)
-
-      # The threshold is high enough that this delivery triggers a refill on its way out.
-      state = %{
-        worker_state(%{"b" => :defer})
-        | flow_initial: 100,
-          flow_threshold: 100,
-          flow_refill: 50,
-          flow_outstanding_permits: 100
-      }
-
-      deliver(state, ["a", "b", "c"])
-
-      assert_received {:flow_control, %{held_entries: 1}}
-    end
-
-    test "counts nothing once the entries it was holding complete" do
-      handler = "held-entries-#{System.unique_integer([:positive])}"
-
-      :telemetry.attach(
-        handler,
-        [:pulsar, :consumer, :flow_control, :stop],
-        fn _event, _measurements, metadata, pid -> send(pid, {:flow_control, metadata}) end,
-        self()
-      )
-
-      on_exit(fn -> :telemetry.detach(handler) end)
-
-      state = %{
-        worker_state(%{})
-        | flow_initial: 100,
-          flow_threshold: 100,
-          flow_refill: 50,
-          flow_outstanding_permits: 100
-      }
-
-      deliver(state, ["a", "b", "c"])
-
-      assert_received {:flow_control, %{held_entries: 0}}
-    end
-  end
-
   describe "diverting a batch to the dead letter topic" do
     test "does not acknowledge the entry when one message of it fails to divert" do
       state = diverting_state(refuse: ["b"])
@@ -301,7 +312,9 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert diverted_payloads() == ["a", "c"]
       assert [] == acks()
 
-      # Its tally goes too: the entry comes back whole, and "a" and "c" divert a second time.
+      # It is asked for again, so its tally goes: the entry comes back whole and has to answer
+      # for "a" and "c" a second time before it can be acknowledged.
+      assert {[%{batch_index: -1}], _acks} = Ack.take_nacked(state.acks)
       assert state.acks.acked == %{}
     end
 
@@ -334,7 +347,13 @@ defmodule Pulsar.Consumer.BatchAckTest do
         start: {Supervisor, :start_link, [[child], [strategy: :one_for_one]]}
       })
 
-    %{worker_state(%{}) | dead_letter_root: root, dead_letter_topic: "dlq", max_redelivery: 1}
+    # A failed divert is nacked, so the consumer needs an interval for it to come back at all.
+    %{
+      worker_state(%{}, redelivery_interval: 1000)
+      | dead_letter_root: root,
+        dead_letter_topic: "dlq",
+        max_redelivery: 1
+    }
   end
 
   defp diverted_payloads(acc \\ []) do
@@ -346,12 +365,12 @@ defmodule Pulsar.Consumer.BatchAckTest do
   end
 
   defp worker_state(answers, opts \\ []) do
-    {batch_index_ack_enabled, opts} = Keyword.pop(opts, :batch_index_ack_enabled, false)
+    {ack_opts, opts} = Keyword.split(opts, [:batch_index_ack_enabled])
 
     struct(
       Worker,
       [
-        acks: Ack.new(batch_index_ack_enabled),
+        acks: Ack.new(ack_opts),
         topic: @topic,
         base_topic: @topic,
         subscription_name: "order-service",

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -194,6 +194,17 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert state.acks.acked == %{}
     end
 
+    test "is acknowledged when it has nothing left to deliver at all" do
+      state = deliver(worker_state(%{}), ["a", "b", "c"], compacted_out: [0, 1, 2])
+
+      assert delivered_payloads() == []
+
+      # No callback runs, so nothing else could ever acknowledge this entry.
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
     test "charges a permit for every message the broker sent, delivered or not" do
       state = %{worker_state(%{}) | flow_initial: 100, flow_threshold: 0, flow_outstanding_permits: 100}
 

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -171,6 +171,39 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
+  describe "an entry the broker will not deliver in full" do
+    test "still completes when part of it was acknowledged before" do
+      # Bits set are the messages still owed, so "a" was acked by whoever held the entry before.
+      state = deliver(worker_state(%{}), ["a", "b", "c"], ack_set: [0b110])
+
+      assert delivered_payloads() == ["b", "c"]
+
+      # Acking what arrived has to finish the entry: nothing will ever deliver "a" again.
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
+    test "still completes when part of it was compacted away" do
+      state = deliver(worker_state(%{}), ["a", "b", "c"], compacted_out: [1])
+
+      assert delivered_payloads() == ["a", "c"]
+
+      assert [ack] = acks()
+      assert [%{batch_index: -1}] = ack.message_id
+      assert state.acks.acked == %{}
+    end
+
+    test "charges a permit for every message the broker sent, delivered or not" do
+      state = %{worker_state(%{}) | flow_initial: 100, flow_threshold: 0, flow_outstanding_permits: 100}
+
+      new_state = deliver(state, ["a", "b", "c"], compacted_out: [1], ack_set: [0b011])
+
+      assert delivered_payloads() == ["a"]
+      assert new_state.flow_outstanding_permits == 97
+    end
+  end
+
   ## Helpers
 
   defp worker_state(answers, opts \\ []) do
@@ -210,7 +243,13 @@ defmodule Pulsar.Consumer.BatchAckTest do
       num_messages_in_batch: length(payloads)
     }
 
-    payload = payloads |> Enum.map(&encode_single_message/1) |> :erlang.iolist_to_binary()
+    compacted_out = Keyword.get(opts, :compacted_out, [])
+
+    payload =
+      payloads
+      |> Enum.with_index()
+      |> Enum.map(fn {payload, index} -> encode_single_message(payload, index in compacted_out) end)
+      |> :erlang.iolist_to_binary()
 
     {:noreply, new_state} = Worker.handle_info({:broker_message, {command, metadata, payload, nil}}, state)
     new_state
@@ -241,8 +280,12 @@ defmodule Pulsar.Consumer.BatchAckTest do
     %{message_id() | batch_index: index, batch_size: 3}
   end
 
-  defp encode_single_message(payload) do
-    metadata = Binary.SingleMessageMetadata.encode(%Binary.SingleMessageMetadata{payload_size: byte_size(payload)})
+  defp encode_single_message(payload, compacted_out \\ false) do
+    metadata =
+      Binary.SingleMessageMetadata.encode(%Binary.SingleMessageMetadata{
+        payload_size: byte_size(payload),
+        compacted_out: compacted_out
+      })
 
     <<byte_size(metadata)::32, metadata::binary, payload::binary>>
   end

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -129,6 +129,15 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert {@ledger, @entry} == {id.ledgerId, id.entryId}
     end
 
+    test "collapses ids handed to Pulsar.Consumer.nack/2 to their entry" do
+      state = worker_state(%{}, redelivery_interval: 1000)
+
+      {:reply, :ok, state} = Worker.handle_call({:nack, [batch_id(0), batch_id(2)]}, self(), state)
+
+      assert [%{batch_index: -1} = id] = MapSet.to_list(state.acks.nacked)
+      assert {@ledger, @entry} == {id.ledgerId, id.entryId}
+    end
+
     test "keeps the entry's tally when nothing will ask the nacked message back" do
       state = deliver(worker_state(%{"b" => :nack}), ["a", "b", "c"])
 


### PR DESCRIPTION
## Summary

A consumer's acknowledgements now describe the messages they are for. An ack of one message in a batch no longer acknowledges the messages batched alongside it, a nack of one no longer disappears because a sibling was acked first, and consumers whose broker supports it can opt into telling the broker exactly which messages of an entry an ack covered, so that a redelivery brings back only the rest.

The first is a data-loss fix and stands on its own. The second is an opt-in option layered on top of it. Both depend on the consumer agreeing with the broker about how wide an entry is, which is where the third part comes in — and where two subscription stalls were found and fixed during review.

## Motivation

A batch is one entry on the topic. The broker acknowledges entries, and an ack resolves to the `(ledger, entry)` position it names — unless it carries an `ack_set`, which only a broker with `acknowledgmentAtBatchIndexLevelEnabled` honours.

This client set `batch_index` on every message id it unwrapped from a batch and sent that id on the ack, with no `ack_set` anywhere in the module. The ack said "message 3 of this entry"; the broker read it as "this entry".

| What the protocol expects | What this client did (before this change) |
| --- | --- |
| An individual ack of one message in a batch carries an `ack_set`, or the entry is acknowledged whole | `batch_index` set on the id, `ack_set` never set |
| A partially acknowledged entry is redelivered whole, with `CommandMessage.ack_set` naming what is still owed | `ack_set` on the incoming command was ignored; every message in the entry was delivered again |
| `SingleMessageMetadata.compacted_out` marks messages compaction has replaced, and `pulsar.proto:174` says it "must be checked to identify and filter out compacted messages" | Never read; compacted-away messages were delivered as data |
| Redelivery is requested per entry | Nacked ids kept their `batch_index`, so two nacks from one batch asked for the same entry twice |

## 1. An ack of one message acknowledged its whole batch

`process_single_message/3` acked each message as its callback returned. For a 100-message batch that was 100 ack commands, and the first of them acknowledged the entry.

- A consumer that went down part way through an entry lost every message in it that had not been processed yet. They were acknowledged, so they were never redelivered.
- `{:error, reason, state}` on message 5, after 0–4 returned `{:ok, state}`, produced no redelivery — the entry was already gone.
- Diverting one message to the dead letter topic acknowledged, and so discarded, its siblings.

Messages from a batch are now counted off against their entry, and the entry is acknowledged once the last of them is acked. This is what the Java client does by default. It is correct on any broker, whatever `acknowledgmentAtBatchIndexLevelEnabled` is set to, and it reduces the command count for a fully-acked batch from one per message to one per entry.

**A nacked message takes its batch with it.** The entry is redelivered whole, so messages already acked from it arrive again. Delivery was already at-least-once; a batch widens what one failure repeats. Section 2 is the way to narrow it.

**Unless nothing will bring it back.** A nack with no `:redelivery_interval` configured is not redelivered by anything, so the entry's tally is left as it stands rather than dropped: acking that message later still completes the entry, where dropping the tally would have stranded it with every one of its messages acked. The misconfiguration itself is the one `docs/dead_letter_policies.md` already warns about, and shows up in telemetry as `:nacked` with no `:requested` behind it.

## 2. `:batch_index_ack_enabled`

Off by default. Turned on, each ack goes out as it happens carrying `ack_set` — the messages of the entry still outstanding — and `batch_size`, which is what the broker sizes its own bitset from. The broker then redelivers only what is still owed.

Set bits are the messages **outstanding**, not the acked ones: the broker starts an entry with every bit set and deletes it once nothing is left. Words are `int64` in the layout Java's `BitSet.toLongArray` produces, so a batch wider than 63 sets the top bit of the first word and it goes on the wire as a negative.

**It cannot be detected, so it is opt-in.** `FeatureFlags` (`pulsar.proto:311-319`) carries seven flags and none of them is this; nothing in `CommandConnected` reports it either. A broker without the setting ignores the `ack_set` and acknowledges the whole entry — the exact loss section 1 fixes. Worth checking rather than assuming: Pulsar's shipped `broker.conf` sets it to `true`, and `standalone.conf` does not set it at all.

**The cost is one ack command per message rather than one per entry.** It only buys anything when messages in a batch meet different fates. The Java client softens this with a time-based ack grouping tracker; there is no equivalent here.

## 3. Counting off what the broker will not deliver again

Two kinds of message arrive inside an entry and are not handed to the callback: ones a previous holder already acked, named by `CommandMessage.ack_set` (`pulsar.proto:568`) on a redelivered entry, and ones compaction has replaced, marked `compacted_out`. Both still count towards the entry's width.

**This is where both stalls lived.** Filtering them out of delivery without counting them off leaves a tally that can never complete, so the entry is never acknowledged and the subscription stops advancing past it — silently, with no error anywhere. It took two forms:

```
# entry redelivered with ack_set 0b110 -- index 0 acked by a previous holder
acks sent: []
ledger: %{{7, 42} => 6}      # completion needs 0b111 == 7
```

```
# every message in the entry compacted away: no callback runs, so nothing can ack it
delivered: []
acks sent: []
ledger: %{}
```

The first is reachable whenever a partially acked entry meets a consumer with `:batch_index_ack_enabled` **off** — another client on the subscription using batch-index acks, a Java consumer with `enableBatchIndexAcknowledgment`, or the option having been turned off. The option being *on* masked it, because each ack then carries its own `ack_set`, which is why the integration tests did not catch it.

Both are fixed the same way: skipped messages go through `record_ack/2` like any other acknowledgement. They are counted off, and when they are the last of their entry the completing ack goes out — which is the only thing that can acknowledge an entry with nothing left to deliver.

They still spend their flow-control permit. The broker sent them and charged for them.

**An entry never narrows.** `batch_size` comes from the entry's own `num_messages_in_batch`, which the broker does not rewrite when it redelivers a partly acked entry, so the width a consumer counts against is the same on every delivery no matter how much of it has already been deleted. That is what lets a consumer that receives two messages of a three-message entry still reach the width and acknowledge it.

## 4. `Pulsar.Consumer.Ack`

The ledger and the wire codec moved out of `Pulsar.Consumer.Worker` into a pure module, following `ChunkedMessageContext`: it owns a struct, the worker owns the connection and sends whatever it hands back. Seven public functions, 231 lines, holding what would otherwise have kept growing inside a worker already at 1206 lines.

The ledger is an integer bitmask per entry, one bit per batch index, holding the messages **acked** so the field name is literal and the initial state is empty rather than a set of every index. Completion is `acked == every_message(size)`; the wire encoding takes the complement. Elixir's bit syntax does the word splitting and the two's complement, so there is no sign handling to get wrong:

```elixir
for <<(word::little-signed-size(@word_bits) <- <<outstanding::little-size(bits)>>)>>, do: word
```

`record_ack/2` returns `{ids_to_send, ledger}` — deliberately not named for acknowledging, because nothing in this module reaches the broker and for a batched message it usually returns nothing at all.

`forget/2` is private, reached only through `record_nack/2`. A redelivered entry has to answer for every one of its messages again before it can be acknowledged, and that is not bookkeeping tidiness: without it, an entry redelivered into the dead letter path can hit its width part way through the divert loop and send the entry ack before the last message of it has been attempted, losing that message if its divert then fails.

**An entry stays in the ledger while any of its messages is unacked.** A callback that defers with `{:noreply, state}` and then neither acks nor nacks holds it for the life of the consumer, as does acking a message of an entry that has already been acknowledged, which starts a tally nothing will finish. Both are documented on `Pulsar.Consumer.ack/2`.

## Verification

**The data-loss fix is measured against a real broker, not argued.** `apachepulsar/pulsar:4.2.4` via `docker-compose.yml`. Producing one batch of five, acking `msg-1`, restarting the consumer on the same subscription — against the parent commit's consumer, the other four never come back:

```
1) test acking one message of a batch does not acknowledge the rest of its entry
   Assertion failed, no matching message after 10000ms
   The following variables were pinned:
     payload = "msg-1"
   The process mailbox is empty.
Result: 1/3 passed
```

The mailbox is empty, not short — the entry was acknowledged and nothing was redelivered. The sibling test acks all five and asserts a restarted consumer receives nothing, so the fix is not just "never acknowledge anything".

**The broker's ack-set semantics are pinned, because the client depends on them.** Every ack a consumer sends names the messages *it* has not acked, so a consumer picking up a partly acked entry re-asserts the earlier ones as outstanding on every ack. The entry only clears if the broker ands those sets into what it has already deleted rather than replacing it. `batch index acks clear the entry once every message has been acked, across consumers` covers exactly that, and weakening it — having the second consumer ack one message instead of all — fails it with `Unexpectedly received message {:received, "msg-3"}`, so it is not passing by construction.

**The receive-side filter is load-bearing, and that was checked by removing it.** With `Ack.outstanding/1` stubbed to `nil`, the broker's redelivery of a partially acked entry brings the acked message back:

```
1) test batch index acks redeliver only the messages that were not acked
   Unexpectedly received message {:received, "msg-1"} (which matched {:received, "msg-1"})
```

That also settles what the broker does: it redelivers the whole entry and expects the client to filter, rather than re-encoding the batch.

**The stall fixes have their own tests, and they fail without the fix.** An entry part-acked before, an entry part-compacted, an entry with nothing left to deliver at all, an entry whose set spans two words and uses the sign bit, and an entry that has to reach its full width under batch index acking — plus the two that pin a permit being spent on every message the broker sent. Stubbing the skipped ids to `[]` fails seven of them (`Result: 20/27`).

**The `ack_set` codec is tested at the widths where it breaks.** Round trip at 2, 63, 64, 65, 100 and 129 messages, and a `MessageIdData` protobuf round trip confirming the negative `int64` survives encoding — the case a batch wider than 63 reaches and nothing else would catch. `writes a word with its top bit set as a negative int64` pins `-2` for bits 1..63.

**A partial dead letter failure is covered without a mocking library.** `Pulsar.Producer.send/3` routes a bare pid through `Topology.kind/1`, which calls anything that is not a topology or group supervisor a worker — so a plain `GenServer` answering `{:send_message, payload, opts}` is a dead letter producer as far as the consumer is concerned, and it can refuse one payload and accept the rest. The consumer under test carries a `:redelivery_interval`, since a failed divert is nacked and nothing else would ask for it again. Two tests pin the result: successful diverts do not acknowledge the entry while one message of it is still owed, and a failed divert clears the tally so the redelivered entry counts from scratch. Acking the entry on each successful divert — the behaviour before this change — fails both.

**Suite:** 445 tests (28 doctests) against the broker in `docker-compose.yml`, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean. One of three full runs failed `ProducerTest partition routing keeps the old modulus until a growing topology is contiguous`, which is the pre-existing flakiness listed under follow-ups and is not touched by this branch.

**Known gaps.** `managedLedgerMaxBatchDeletedIndexToPersist` (10000) caps how many partially acked batches a subscription persists; past it the indexes are memory-only and, per the config's own comment, "will be cleared while redelivering the messages to consumers" on restart or load balancing. Section 1 is what keeps that a duplicate-delivery problem rather than a loss.

## Behaviour changes

No API is removed and nothing changes on the wire for producers. Four things are observable:

### 1. A partially acked batch stays in the backlog

Acking part of a batch no longer clears its entry. The backlog now reflects what has actually been processed, where before it dropped as soon as any one message in the entry was acked. Anything alerting on subscription backlog against a batching producer will see the number move — that is the bug being fixed, not a regression.

### 2. Compacted-away messages are no longer delivered

A batched message marked `compacted_out` used to reach `handle_message/2` carrying whatever payload the compacted entry still held. It is now skipped and counted off. A consumer on a compacted topic that was processing those will stop seeing them, which is the point. `Pulsar.Reader` runs on the same consumer, so a reader on a compacted topic sees the same change.

### 3. Message ids carry `batch_size`

`Pulsar.Message`'s `message_id` gains `batch_size` for batched messages, so a deferred ack arriving on its own can still tell when its entry is complete. The field is documented as opaque and `message_id_string/1` is unchanged.

### 4. `[:pulsar, :consumer, :redelivery, :requested]` counts entries

Nacked ids collapse to the entry they belong to instead of repeating it once per message, so against a batching producer the count falls and no longer lines up with `[:pulsar, :consumer, :message, :nacked]`, which still counts messages. Asking for the same entry once per message in it was part of the bug; `docs/dead_letter_policies.md` notes the difference.

## Follow-ups

Not in this PR:

- `null_value` on `SingleMessageMetadata` marks a tombstone — a key deleted rather than set to an empty value. It is delivered, correctly, but as an empty payload, so a consumer on a compacted topic cannot tell the two apart. The Java client exposes it as a null value.
- `:deliver_at_time` / `:deliver_after` are silently dropped by a batching producer — the batch path never captures them. The Java client sends delayed messages outside the batch.
- No max-batch-bytes. A batch is only size-capped by the broker's frame check, so one large message fails every caller batched with it. Java flushes early at `batchingMaxBytes`.
- No key-based batching. The batch-level `MessageMetadata` carries no `partition_key`, so a mixed-key batch dispatches under no key and `Key_Shared` per-key ordering is not preserved.
- `terminate/2` drops a pending batch with `{:error, :producer_terminated}` instead of flushing it, and there is no public `flush/1`.
- Suite stability: `ProducerTest`, `ChunkingTest` and both reader tests each flake under parallel load and pass in isolation, independently of this branch. Worth its own issue before it starts failing CI.
- A batching guide, alongside `docs/chunking.md`.

