### PR TITLE
fix(producer): a batching producer dropped delayed delivery

### DIFF
--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -150,7 +150,8 @@ defmodule Pulsar.Producer do
     subscription can use it. Must be a binary; before 3.0 any term was accepted here
   - `:properties` - a map of user properties carried with the message
   - `:event_time` - the message's event time, in milliseconds
-  - `:deliver_at_time` / `:deliver_after` - delayed delivery
+  - `:deliver_at_time` / `:deliver_after` - delayed delivery. The broker delays whole entries, so
+    a delayed message is published on its own rather than joining a batch
   - `:client` - the client to resolve a producer name against
 
   ## Examples

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -57,7 +57,10 @@ defmodule Pulsar.Producer.Options do
     batch_enabled: [
       type: :boolean,
       default: false,
-      doc: "Collect messages and publish them as one batch."
+      doc: """
+      Collect messages and publish them as one batch. A message sent with `:deliver_at_time` or
+      `:deliver_after` goes on its own, since the broker delays whole entries.
+      """
     ],
     batch_size: [
       type: :pos_integer,

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -236,6 +236,20 @@ defmodule Pulsar.Producer.Worker do
   end
 
   def handle_call({:send_message, payload, opts}, from, %{batch_enabled: true} = state) do
+    if delayed?(opts) do
+      # A delay names the entry and SingleMessageMetadata has no field for one, so this cannot
+      # ride in a batch. What is pending goes first, or it would overtake earlier messages.
+      send_unbatched(payload, opts, from, do_flush_batch(state))
+    else
+      add_to_batch(payload, opts, from, state)
+    end
+  end
+
+  def handle_call({:send_message, payload, opts}, from, state) do
+    send_unbatched(payload, opts, from, state)
+  end
+
+  defp add_to_batch(payload, opts, from, state) do
     message = %{
       payload: payload,
       partition_key: Keyword.get(opts, :partition_key),
@@ -255,7 +269,7 @@ defmodule Pulsar.Producer.Worker do
     end
   end
 
-  def handle_call({:send_message, payload, opts}, from, state) do
+  defp send_unbatched(payload, opts, from, state) do
     # Compression covers the whole message and the split comes after it, so a chunk is a slice
     # of compressed bytes rather than compressed on its own.
     base_metadata = build_message_metadata(payload, opts, state)
@@ -753,6 +767,8 @@ defmodule Pulsar.Producer.Worker do
 
   defp to_timestamp(%DateTime{} = dt), do: DateTime.to_unix(dt, :millisecond)
   defp to_timestamp(ms), do: ms
+
+  defp delayed?(opts), do: not is_nil(resolve_deliver_at_time(opts))
 
   defp resolve_deliver_at_time(opts) do
     case {Keyword.get(opts, :deliver_at_time), Keyword.get(opts, :deliver_after)} do

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -151,6 +151,40 @@ defmodule Pulsar.Integration.Producer.BatchTest do
       # Reaching the broker with this would have closed the connection.
       assert [{:ok, _}, {:ok, _}] = send_concurrently(producer_pid, ["a", "b"])
     end
+
+    test "a delayed message keeps its delay, and flushes the batch it could not join" do
+      {consumer_pid, producer_pid} =
+        setup_producer_consumer("delayed", batch_size: 10, flush_interval: 30_000)
+
+      deliver_at = DateTime.shift(DateTime.utc_now(), second: 1)
+      deliver_at_ms = DateTime.to_unix(deliver_at, :millisecond)
+
+      [producer] = Utils.wait_for(fn -> Topology.workers(producer_pid) end, until: &match?([_], &1))
+
+      # Neither fills the batch, so both wait for a flush that nothing has scheduled yet.
+      pending =
+        Enum.map(["batched-1", "batched-2"], fn payload ->
+          Task.async(fn -> Pulsar.Producer.send(producer_pid, payload) end)
+        end)
+
+      # Both are queued before the delayed one arrives, so it is what flushes them.
+      Utils.wait_for(fn -> :sys.get_state(producer).batched == 2 end)
+
+      assert {:ok, _message_id} = Pulsar.Producer.send(producer_pid, "delayed-1", deliver_at_time: deliver_at)
+
+      assert Enum.all?(Task.await_many(pending, 10_000), &match?({:ok, _}, &1))
+
+      assert_messages_received(consumer_pid, ["batched-1", "batched-2", "delayed-1"])
+      messages = DummyConsumer.get_messages(consumer_pid)
+      delayed = Enum.find(messages, &(&1.payload == "delayed-1"))
+      batched = Enum.find(messages, &(&1.payload == "batched-1"))
+
+      assert delayed.raw.metadata.deliver_at_time == deliver_at_ms
+
+      # It arrived as an entry of its own: a batched message carries an index into its entry.
+      assert delayed.message_id.batch_index == -1
+      assert batched.message_id.batch_index >= 0
+    end
   end
 
   # Helpers

--- a/test/unit/producer_delayed_delivery_test.exs
+++ b/test/unit/producer_delayed_delivery_test.exs
@@ -1,0 +1,132 @@
+defmodule Pulsar.Producer.DelayedDeliveryTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Pulsar.Producer.Worker
+  alias Pulsar.Protocol
+
+  # Answers the :gen_statem.call publish_message/2 makes, and hands the frame to the test.
+  defmodule BrokerStub do
+    @moduledoc false
+    use GenServer
+
+    def start_link(notify_pid), do: GenServer.start_link(__MODULE__, notify_pid)
+
+    @impl true
+    def init(notify_pid), do: {:ok, notify_pid}
+
+    @impl true
+    def handle_call({:publish_message, frame}, _from, notify_pid) do
+      send(notify_pid, {:published, frame})
+      {:reply, :ok, notify_pid}
+    end
+  end
+
+  @at_time 1_900_000_000_000
+
+  setup do
+    broker = start_supervised!({BrokerStub, self()})
+
+    %{state: producer_state(broker)}
+  end
+
+  describe "a delayed message on a batching producer" do
+    test "carries the delay the caller asked for", ctx do
+      send_message(ctx.state, "later", deliver_at_time: @at_time)
+
+      assert [sent] = published()
+      assert sent.metadata.deliver_at_time == @at_time
+    end
+
+    test "goes out on its own, so the delay applies to it alone", ctx do
+      send_message(ctx.state, "later", deliver_at_time: @at_time)
+
+      # Batch framing would have wrapped the payload in a SingleMessageMetadata.
+      assert [sent] = published()
+      assert sent.payload == "later"
+    end
+
+    test "resolves :deliver_after against the clock", ctx do
+      before = System.system_time(:millisecond)
+      send_message(ctx.state, "later", deliver_after: 60_000)
+
+      assert [sent] = published()
+      assert sent.metadata.deliver_at_time >= before + 60_000
+      assert sent.metadata.deliver_at_time <= System.system_time(:millisecond) + 60_000
+    end
+
+    test "publishes what was already batched first, so it does not overtake it", ctx do
+      {:noreply, state} = send_message(ctx.state, "first", [])
+      {:noreply, state} = send_message(state, "second", [])
+      assert [] == published(), "batched messages wait for a flush"
+
+      send_message(state, "later", deliver_after: 60_000)
+
+      assert [batch, delayed] = published()
+      assert batch.metadata.num_messages_in_batch == 2
+      assert batch.metadata.deliver_at_time == nil
+      assert delayed.metadata.deliver_at_time
+    end
+
+    test "takes a sequence id after the batch it flushed", ctx do
+      {:noreply, state} = send_message(ctx.state, "first", [])
+      {:noreply, state} = send_message(state, "second", [])
+
+      {:noreply, state} = send_message(state, "later", deliver_after: 60_000)
+
+      assert [batch, delayed] = published()
+      assert {batch.command.sequence_id, batch.command.highest_sequence_id} == {1, 2}
+      assert delayed.command.sequence_id == 3
+      assert state.sequence_id == 3
+    end
+
+    test "leaves the batch alone when no delay was asked for", ctx do
+      {:noreply, state} = send_message(ctx.state, "a", properties: %{"k" => "v"})
+
+      assert [] == published()
+      assert state.batched == 1
+    end
+  end
+
+  describe "a delayed message on a producer that is not batching" do
+    test "carries the delay, as it always did", ctx do
+      send_message(%{ctx.state | batch_enabled: false}, "later", deliver_at_time: @at_time)
+
+      assert [sent] = published()
+      assert sent.metadata.deliver_at_time == @at_time
+    end
+  end
+
+  ## Helpers
+
+  defp send_message(state, payload, opts) do
+    Worker.handle_call({:send_message, payload, opts}, {self(), make_ref()}, state)
+  end
+
+  defp producer_state(broker) do
+    struct(Worker, %{
+      topic: "persistent://public/default/orders",
+      base_topic: "persistent://public/default/orders",
+      producer_id: 1,
+      producer_name: "orders-api",
+      broker_pid: broker,
+      ready: true,
+      compression: :none,
+      chunking_enabled: false,
+      max_message_size: 5_242_880,
+      batch_enabled: true,
+      batch_size: 10,
+      flush_interval: 30_000
+    })
+  end
+
+  defp published(acc \\ []) do
+    receive do
+      {:published, frame} ->
+        {:ok, {command, metadata, payload, _broker_metadata}} = Protocol.decode(frame)
+        published([%{command: command, metadata: metadata, payload: payload} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`:deliver_at_time` and `:deliver_after` were silently discarded by a producer with `:batch_enabled` set. A message asked to arrive in an hour was published immediately, and the call still answered `{:ok, message_id}`.

A delayed message is now published on its own rather than joining a batch, flushing whatever the producer had pending first.

## Motivation

The batch path captured five of a send's options:

```elixir
message = %{
  payload: payload,
  partition_key: Keyword.get(opts, :partition_key),
  ordering_key: Keyword.get(opts, :ordering_key),
  properties: Keyword.get(opts, :properties),
  event_time: Keyword.get(opts, :event_time)
}
```

Delivery time was not among them, and there was nowhere to put it: `do_flush_batch/1` builds the entry's `MessageMetadata` from producer state alone, with no per-message options in scope. The unbatched path has always set it.

**A delay names the entry, not a message inside it.** `deliver_at_time` is field 19 on `MessageMetadata`, and the broker's delayed delivery tracker keys on `(ledgerId, entryId)`. `SingleMessageMetadata` carries properties, keys, event time and sequence id — there is no delay field, so a message batched with others cannot ask for one of its own.

That leaves keeping delayed messages out of batches, which is what the other clients do. Java's `canAddToBatch` is `... && isBatchMessagingEnabled() && !msg.getMessageBuilder().hasDeliverAtTime()`, and `processOpSendMsg` opens with `if (op.msg != null && isBatchMessagingEnabled()) { batchMessageAndSend(false); }` — excluded from the batch, and the pending batch goes out first so the individual message does not overtake it. This branch does the same.

Go excludes by the same rule — `sendAsBatch = !p.options.DisableBatching && sr.msg.ReplicationClusters == nil && deliverAt.UnixNano() < 0` — but `internalSingleSend` writes without flushing, so there a delayed message can reach the wire ahead of messages accepted before it.

## Verification

**Seven unit tests, five of which fail against the parent commit** (`Result: 2/7`). The two that pass are the controls: a producer that is not batching, and a batching producer sent a message with no delay. They cover the delay surviving, `:deliver_after` resolving against the clock, the message going out unbatched, the pending batch being published first, and the sequence ids that follow from that.

`num_messages_in_batch` and `CommandSend.num_messages` both default to `1` in proto2, so neither distinguishes a batch of one from an unbatched message after a decode. The payload does: batch framing would have wrapped it in a `SingleMessageMetadata`.

**Measured against a real broker.** `a delayed message keeps its delay, and flushes the batch it could not join` produces two messages that do not fill the batch, waits until the worker is holding both, then sends a delayed one. It asserts the two complete — they only can if the delayed message flushed them — and that the consumer sees `deliver_at_time` on the delayed message with `batch_index == -1`, where its siblings carry an index into their entry. It fails on the parent commit (`Result: 6/7`).

**Suite:** 453 tests (28 doctests) against the broker in `docker-compose.yml`, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean.

## Behaviour changes

Only producers with `:batch_enabled` are affected, and it defaults to `false`.

### 1. Delayed messages are delayed

They were published immediately. Anything relying on the old behaviour was relying on a bug, but a consumer that was receiving these at once will now receive them when they were asked for.

### 2. A delayed send flushes the batch

A workload interleaving delayed and ordinary messages will produce smaller batches, since each delayed message closes the one in progress. The alternative is letting it overtake messages accepted before it, which is the trade Go makes and Java does not.
