### PR TITLE
fix(producer): a batch carried no key for Key_Shared to dispatch on

### DIFF
--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -471,6 +471,7 @@ defmodule Pulsar.Producer.Worker do
     messages = Enum.map(batch, fn {message, _from} -> message end)
     callers = Enum.map(batch, fn {_message, from} -> from end)
     messages_count = length(messages)
+    [first_message | _] = messages
 
     # A batch spends one sequence id per message it carries, so the next one starts past the
     # whole range. Advertising only the first repeats the ids consumers see and leaves the
@@ -495,6 +496,8 @@ defmodule Pulsar.Producer.Worker do
 
     uncompressed_size = byte_size(single_messages_payload)
 
+    # Key_Shared reads the sticky key off the entry rather than the messages inside it, and
+    # invents one per entry when it finds none, scattering a key across consumers.
     message_metadata = %Binary.MessageMetadata{
       producer_name: state.producer_name,
       sequence_id: sequence_id,
@@ -503,6 +506,8 @@ defmodule Pulsar.Producer.Worker do
       compression: Protocol.to_compression(state.compression),
       uncompressed_size: uncompressed_size,
       num_messages_in_batch: messages_count,
+      partition_key: first_message.partition_key,
+      ordering_key: first_message.ordering_key,
       schema_version: state.schema_version
     }
 

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -83,6 +83,29 @@ defmodule Pulsar.Integration.Producer.BatchTest do
       end
     end
 
+    @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
+    test "the entry a batch arrives as carries a key for Key_Shared to dispatch on" do
+      {consumer_pid, producer_pid} =
+        setup_producer_consumer("entry-key", batch_size: 2, flush_interval: 30_000)
+
+      [producer] = Utils.wait_for(fn -> Topology.workers(producer_pid) end, until: &match?([_], &1))
+      producer_name = :sys.get_state(producer).producer_name
+
+      sends =
+        Enum.map(1..2, fn i ->
+          Task.async(fn -> Pulsar.Producer.send(producer_pid, "keyed-#{i}", partition_key: "tenant-1") end)
+        end)
+
+      assert Enum.all?(Task.await_many(sends, 10_000), &match?({:ok, _}, &1))
+
+      assert_messages_received(consumer_pid, ["keyed-1", "keyed-2"])
+      assert_batch_telemetry(count: 2, producer_name: producer_name)
+
+      for message <- DummyConsumer.get_messages(consumer_pid) do
+        assert message.raw.metadata.partition_key == "tenant-1"
+      end
+    end
+
     # A batch spends one sequence id per message it carries, so the next batch has to start
     # past the whole range. Starting at the previous batch's first id repeats the ids consumers
     # see and understates the high-water mark the broker reports back on reconnect.

--- a/test/support/broker_stub.ex
+++ b/test/support/broker_stub.ex
@@ -1,0 +1,34 @@
+defmodule Pulsar.Test.Support.BrokerStub do
+  @moduledoc """
+  Answers the `:gen_statem.call` `Pulsar.Broker.publish_message/2` makes, and hands the frame to
+  the test process so it can be decoded.
+  """
+
+  use GenServer
+
+  alias Pulsar.Protocol
+
+  def start_link(notify_pid), do: GenServer.start_link(__MODULE__, notify_pid)
+
+  @doc """
+  Every frame published so far, decoded, oldest first.
+  """
+  def published(acc \\ []) do
+    receive do
+      {:published, frame} ->
+        {:ok, {command, metadata, payload, _broker_metadata}} = Protocol.decode(frame)
+        published([%{command: command, metadata: metadata, payload: payload} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  @impl true
+  def init(notify_pid), do: {:ok, notify_pid}
+
+  @impl true
+  def handle_call({:publish_message, frame}, _from, notify_pid) do
+    send(notify_pid, {:published, frame})
+    {:reply, :ok, notify_pid}
+  end
+end

--- a/test/unit/producer_batch_test.exs
+++ b/test/unit/producer_batch_test.exs
@@ -1,26 +1,12 @@
-defmodule Pulsar.Producer.DelayedDeliveryTest do
+defmodule Pulsar.Producer.BatchTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Pulsar.Test.Support.BrokerStub, only: [published: 0]
+
   alias Pulsar.Producer.Worker
-  alias Pulsar.Protocol
-
-  # Answers the :gen_statem.call publish_message/2 makes, and hands the frame to the test.
-  defmodule BrokerStub do
-    @moduledoc false
-    use GenServer
-
-    def start_link(notify_pid), do: GenServer.start_link(__MODULE__, notify_pid)
-
-    @impl true
-    def init(notify_pid), do: {:ok, notify_pid}
-
-    @impl true
-    def handle_call({:publish_message, frame}, _from, notify_pid) do
-      send(notify_pid, {:published, frame})
-      {:reply, :ok, notify_pid}
-    end
-  end
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+  alias Pulsar.Test.Support.BrokerStub
 
   @at_time 1_900_000_000_000
 
@@ -28,6 +14,45 @@ defmodule Pulsar.Producer.DelayedDeliveryTest do
     broker = start_supervised!({BrokerStub, self()})
 
     %{state: producer_state(broker)}
+  end
+
+  describe "the entry a batch is published as" do
+    test "carries the key its messages share", ctx do
+      flush(ctx.state, [[partition_key: "tenant-1"], [partition_key: "tenant-1"]])
+
+      assert [entry] = published()
+      assert entry.metadata.partition_key == "tenant-1"
+    end
+
+    test "carries the ordering key its messages share", ctx do
+      flush(ctx.state, [[ordering_key: "order-1"], [ordering_key: "order-1"]])
+
+      assert [entry] = published()
+      assert entry.metadata.ordering_key == "order-1"
+    end
+
+    test "carries no key when its messages have none", ctx do
+      flush(ctx.state, [[], []])
+
+      assert [entry] = published()
+      assert entry.metadata.partition_key == nil
+      assert entry.metadata.ordering_key == nil
+    end
+
+    # What Java and Go do. Only key-based batching would give the rest of the entry their own.
+    test "carries the first message's key when they differ", ctx do
+      flush(ctx.state, [[partition_key: "tenant-1"], [partition_key: "tenant-2"]])
+
+      assert [entry] = published()
+      assert entry.metadata.partition_key == "tenant-1"
+    end
+
+    test "leaves each message its own key", ctx do
+      flush(ctx.state, [[partition_key: "tenant-1"], [partition_key: "tenant-2"]])
+
+      assert [entry] = published()
+      assert keys_in_batch(entry.payload) == ["tenant-1", "tenant-2"]
+    end
   end
 
   describe "a delayed message on a batching producer" do
@@ -103,6 +128,26 @@ defmodule Pulsar.Producer.DelayedDeliveryTest do
     Worker.handle_call({:send_message, payload, opts}, {self(), make_ref()}, state)
   end
 
+  # Fills the batch so the last send flushes it.
+  defp flush(state, sends) do
+    Enum.reduce(sends, %{state | batch_size: length(sends)}, fn opts, acc ->
+      {:noreply, next} = send_message(acc, "payload", opts)
+      next
+    end)
+  end
+
+  defp keys_in_batch(payload), do: keys_in_batch(payload, [])
+
+  defp keys_in_batch(<<>>, acc), do: Enum.reverse(acc)
+
+  defp keys_in_batch(<<size::32, metadata::bytes-size(size), rest::binary>>, acc) do
+    single = Binary.SingleMessageMetadata.decode(metadata)
+    payload_size = single.payload_size
+    <<_payload::bytes-size(^payload_size), tail::binary>> = rest
+
+    keys_in_batch(tail, [single.partition_key | acc])
+  end
+
   defp producer_state(broker) do
     struct(Worker, %{
       topic: "persistent://public/default/orders",
@@ -118,15 +163,5 @@ defmodule Pulsar.Producer.DelayedDeliveryTest do
       batch_size: 10,
       flush_interval: 30_000
     })
-  end
-
-  defp published(acc \\ []) do
-    receive do
-      {:published, frame} ->
-        {:ok, {command, metadata, payload, _broker_metadata}} = Protocol.decode(frame)
-        published([%{command: command, metadata: metadata, payload: payload} | acc])
-    after
-      0 -> Enum.reverse(acc)
-    end
   end
 end


### PR DESCRIPTION
## Summary

A batch was published with no key on its entry, so `Key_Shared` had nothing to dispatch on and one message key scattered across the consumer set instead of sticking to one consumer.

The entry now carries the first message's key, which is what the Java and Go clients do.

## Motivation

Per-message keys were never the problem: `encode_single_message/2` writes `partition_key` and `ordering_key` into each `SingleMessageMetadata`, and consumers read them back correctly. The entry wrapping them carried neither.

The broker resolves a sticky key from the entry alone, in `Commands.resolveStickyKey`:

```java
if (metadata.hasOrderingKey())        stickyKey = metadata.getOrderingKey();
else if (metadata.hasPartitionKey())  stickyKey = metadata.getPartitionKey()...;
else if (metadata.hasProducerName() && metadata.hasSequenceId()) {
    String fallbackKey = metadata.getProducerName() + "-" + metadata.getSequenceId();
```

So a batch from this client did not dispatch under *no* key — it fell to the third branch and got a synthetic one, and because the sequence id changes with every batch, so did the key. Consecutive batches hashed to different consumers, and a message key landed wherever the batch it happened to ride in was sent. `Key_Shared`'s one guarantee, per-key ordering, was not upheld.

The fallback also distributes evenly, so there is no hot consumer to notice. The only symptom is out-of-order per-key processing.

Both reference clients copy the first message's key onto the batch metadata: Java in `Commands.initBatchMessageMetadata`, called on the batch's first message, which copies `partition_key` and `ordering_key`; Go in `batch_builder.go` under `if bc.numMessages == 0`, which copies `PartitionKey`. This branch does the same.

**A mixed-key batch still dispatches under the first message's key** — as it does in Java and Go. Giving the rest of the entry their own needs key-based batching, which groups the pending batch by key and publishes one entry per key. That is opt-in in Java (`BatcherBuilder.KEY_BASED`) and is left as a follow-up here.

## Verification

**Twelve unit tests, three of which fail against the parent commit** (`Result: 9/12`). They cover the shared key, the shared ordering key, a mixed-key batch taking the first key, and the two controls: an entry with no keys carries none, and each message keeps its own key inside the batch payload.

**Measured against a real broker.** `the entry a batch arrives as carries a key for Key_Shared to dispatch on` produces two messages under one key, confirms via telemetry that they arrived as a single batch, and asserts the entry metadata the consumer sees carries the key. It fails on the parent commit.

**Suite:** 334 unit tests and the producer batch integration suite, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean. Four `ChunkingTest` failures under a full parallel run are the pre-existing flakiness already listed as a follow-up — that file passes 16/16 in isolation, both on this branch and on `main`.

## Tests

The two producer batching unit files are now one. `producer_delayed_delivery_test.exs` and the new key tests were duplicating their `producer_state/1` helper verbatim, so they are merged into `test/unit/producer_batch_test.exs` — hence the deletion in the diff.

`Pulsar.Test.Support.BrokerStub` answers the `:gen_statem.call` that `Pulsar.Broker.publish_message/2` makes and decodes the frames, which is what lets a producer be driven headless and its wire output asserted. Nothing else needs it today: the producer worker is the only caller of `publish_message/2`, and consumer tests stub `send_command/2`, which is a cast and so already lands in the test process with `broker_pid: self()`.

## Behaviour changes

Only producers with `:batch_enabled`, and only visible to `Key_Shared` subscriptions — Shared, Exclusive and Failover do not consult sticky keys.

A `Key_Shared` consumer of a batching producer will see keys settle onto consumers instead of moving with every batch. Anything that depended on the old spread was depending on batches being dispatched at random.

## Follow-ups

- Key-based batching: group the pending batch by key at flush and publish one entry per key, so a mixed-key batch preserves per-key ordering for all of it rather than the first key only.
