### PR TITLE
feat(producer): key-based batching

### DIFF
--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -58,7 +58,7 @@ defmodule Pulsar.Producer.Options do
       type: :boolean,
       default: false,
       doc: """
-      Collect messages and publish them as one batch. A message sent with `:deliver_at_time` or
+      Collect messages and publish them together. A message sent with `:deliver_at_time` or
       `:deliver_after` goes on its own, since the broker delays whole entries.
       """
     ],
@@ -66,6 +66,19 @@ defmodule Pulsar.Producer.Options do
       type: :pos_integer,
       default: 100,
       doc: "Messages to collect before flushing a batch. Only used when batching."
+    ],
+    batch_builder: [
+      type: {:in, [:default, :key_based]},
+      default: :default,
+      doc: """
+      How a flushed batch is divided into entries. Only used when batching.
+
+      `:default` publishes it as one entry, under the key of its first message. `:key_based`
+      publishes one entry per key, so a `:key_shared` subscription dispatches every message on
+      its own key. It regroups the batch — order holds within a key, not across them — and
+      suits a small key space: `:batch_size` caps the whole batch, so mostly unique keys leave
+      an entry per message and batching only adds overhead.
+      """
     ],
     flush_interval: [
       type: :pos_integer,

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -59,6 +59,7 @@ defmodule Pulsar.Producer.Worker do
     {:batch, []},
     {:batched, 0},
     :batch_size,
+    :batch_builder,
     :batch_flush_timer,
     :flush_interval,
     :schema,
@@ -87,6 +88,7 @@ defmodule Pulsar.Producer.Worker do
           batch: list({map(), GenServer.from()}),
           batched: non_neg_integer(),
           batch_size: non_neg_integer(),
+          batch_builder: :default | :key_based,
           batch_flush_timer: reference() | nil,
           flush_interval: non_neg_integer(),
           schema: Schema.t() | nil,
@@ -467,7 +469,31 @@ defmodule Pulsar.Producer.Worker do
   defp do_flush_batch(%{batch: []} = state), do: state
 
   defp do_flush_batch(state) do
-    batch = Enum.reverse(state.batch)
+    new_state =
+      state.batch
+      |> Enum.reverse()
+      |> batch_entries(state.batch_builder)
+      |> Enum.reduce(state, &publish_batch/2)
+
+    %{new_state | batch: [], batched: 0}
+  end
+
+  # Grouping on the ordering key ahead of the partition key is the order the broker resolves a
+  # sticky key in, so messages bound for one consumer stay in one entry.
+  defp batch_entries(batch, :key_based) do
+    grouped = Enum.group_by(batch, &batch_key/1)
+
+    batch
+    |> Enum.map(&batch_key/1)
+    |> Enum.uniq()
+    |> Enum.map(&Map.fetch!(grouped, &1))
+  end
+
+  defp batch_entries(batch, :default), do: [batch]
+
+  defp batch_key({message, _from}), do: message.ordering_key || message.partition_key
+
+  defp publish_batch(batch, state) do
     messages = Enum.map(batch, fn {message, _from} -> message end)
     callers = Enum.map(batch, fn {_message, from} -> from end)
     messages_count = length(messages)
@@ -526,12 +552,14 @@ defmodule Pulsar.Producer.Worker do
         # Keyed on the first id, which is the one the receipt comes back on.
         new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}})
 
-        %{state | sequence_id: highest_sequence_id, pending_sends: new_pending, batch: [], batched: 0}
+        %{state | sequence_id: highest_sequence_id, pending_sends: new_pending}
 
+      # Only this entry's callers hear about it; the ones published before it are still owed
+      # their receipts.
       {:error, reason} ->
         Logger.error("Failed to send batch: #{inspect(reason)}")
         Enum.each(callers, fn from -> GenServer.reply(from, {:error, reason}) end)
-        %{state | batch: [], batched: 0}
+        state
     end
   end
 

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -84,6 +84,42 @@ defmodule Pulsar.Integration.Producer.BatchTest do
     end
 
     @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
+    test "key-based batching gives every key an entry of its own, not just the first" do
+      {consumer_pid, producer_pid} =
+        setup_producer_consumer("key-based",
+          batch_size: 4,
+          flush_interval: 30_000,
+          batch_builder: :key_based
+        )
+
+      [producer] = Utils.wait_for(fn -> Topology.workers(producer_pid) end, until: &match?([_], &1))
+      producer_name = :sys.get_state(producer).producer_name
+
+      keys = ["tenant-1", "tenant-2", "tenant-1", "tenant-2"]
+
+      sends =
+        keys
+        |> Enum.with_index()
+        |> Enum.map(fn {key, i} ->
+          Task.async(fn -> Pulsar.Producer.send(producer_pid, "keyed-#{i}", partition_key: key) end)
+        end)
+
+      assert Enum.all?(Task.await_many(sends, 10_000), &match?({:ok, _}, &1))
+
+      expected_payloads = Enum.map(0..3, &"keyed-#{&1}")
+      assert_messages_received(consumer_pid, expected_payloads)
+
+      # One entry per key, rather than the single entry the default builder would have sent.
+      events = Utils.collect_events([:pulsar, :producer, :batch, :published], producer_names: [producer_name])
+      assert [%{count: 2}, %{count: 2}] = events
+
+      # Every message dispatches on its own key, not on whichever one led the batch.
+      for message <- DummyConsumer.get_messages(consumer_pid) do
+        assert message.raw.metadata.partition_key == Pulsar.Message.key(message)
+      end
+    end
+
+    @tag telemetry_listen: [[:pulsar, :producer, :batch, :published]]
     test "the entry a batch arrives as carries a key for Key_Shared to dispatch on" do
       {consumer_pid, producer_pid} =
         setup_producer_consumer("entry-key", batch_size: 2, flush_interval: 30_000)

--- a/test/support/broker_stub.ex
+++ b/test/support/broker_stub.ex
@@ -8,7 +8,12 @@ defmodule Pulsar.Test.Support.BrokerStub do
 
   alias Pulsar.Protocol
 
-  def start_link(notify_pid), do: GenServer.start_link(__MODULE__, notify_pid)
+  @doc """
+  Starts a stub that accepts everything, or one that refuses the publishes whose zero-based
+  position is in `refuse`.
+  """
+  def start_link({notify_pid, refuse}), do: GenServer.start_link(__MODULE__, {notify_pid, refuse})
+  def start_link(notify_pid), do: start_link({notify_pid, []})
 
   @doc """
   Every frame published so far, decoded, oldest first.
@@ -24,11 +29,17 @@ defmodule Pulsar.Test.Support.BrokerStub do
   end
 
   @impl true
-  def init(notify_pid), do: {:ok, notify_pid}
+  def init({notify_pid, refuse}), do: {:ok, %{notify_pid: notify_pid, refuse: refuse, attempts: 0}}
 
   @impl true
-  def handle_call({:publish_message, frame}, _from, notify_pid) do
-    send(notify_pid, {:published, frame})
-    {:reply, :ok, notify_pid}
+  def handle_call({:publish_message, frame}, _from, %{attempts: attempt} = state) do
+    state = %{state | attempts: attempt + 1}
+
+    if attempt in state.refuse do
+      {:reply, {:error, :message_too_large}, state}
+    else
+      send(state.notify_pid, {:published, frame})
+      {:reply, :ok, state}
+    end
   end
 end

--- a/test/unit/producer_batch_test.exs
+++ b/test/unit/producer_batch_test.exs
@@ -55,6 +55,119 @@ defmodule Pulsar.Producer.BatchTest do
     end
   end
 
+  describe "key-based batching" do
+    test "publishes one entry per key, each carrying its own", ctx do
+      flush(key_based(ctx.state), [
+        [partition_key: "tenant-1"],
+        [partition_key: "tenant-2"],
+        [partition_key: "tenant-1"]
+      ])
+
+      assert [first, second] = published()
+      assert first.metadata.partition_key == "tenant-1"
+      assert second.metadata.partition_key == "tenant-2"
+
+      assert first.metadata.num_messages_in_batch == 2
+      assert second.metadata.num_messages_in_batch == 1
+    end
+
+    test "orders entries by the key that appeared first", ctx do
+      flush(key_based(ctx.state), [[partition_key: "b"], [partition_key: "a"]])
+
+      assert [first, second] = published()
+      assert {first.metadata.partition_key, second.metadata.partition_key} == {"b", "a"}
+    end
+
+    test "gives each entry a sequence id range of its own", ctx do
+      flush(key_based(ctx.state), [
+        [partition_key: "tenant-1"],
+        [partition_key: "tenant-2"],
+        [partition_key: "tenant-1"]
+      ])
+
+      assert [first, second] = published()
+      assert {first.command.sequence_id, first.command.highest_sequence_id} == {1, 2}
+      assert {second.command.sequence_id, second.command.highest_sequence_id} == {3, 3}
+    end
+
+    test "groups on the ordering key when a message carries one", ctx do
+      flush(key_based(ctx.state), [
+        [ordering_key: "shared", partition_key: "tenant-1"],
+        [ordering_key: "shared", partition_key: "tenant-2"]
+      ])
+
+      assert [entry] = published()
+      assert entry.metadata.ordering_key == "shared"
+      assert entry.metadata.num_messages_in_batch == 2
+    end
+
+    test "keeps keyless messages together in one entry", ctx do
+      flush(key_based(ctx.state), [[], [partition_key: "tenant-1"], []])
+
+      assert [keyless, keyed] = published()
+      assert keyless.metadata.partition_key == nil
+      assert keyless.metadata.num_messages_in_batch == 2
+      assert keyed.metadata.partition_key == "tenant-1"
+    end
+
+    test "leaves the whole batch as one entry when it is off", ctx do
+      flush(ctx.state, [[partition_key: "tenant-1"], [partition_key: "tenant-2"]])
+
+      assert [entry] = published()
+      assert entry.metadata.num_messages_in_batch == 2
+    end
+
+    # "msg-1" was sent before "msg-2" and is published after it.
+    test "keeps order within a key, not across them", ctx do
+      flush(key_based(ctx.state), [[partition_key: "a"], [partition_key: "b"], [partition_key: "a"]])
+
+      assert [first, second] = published()
+      assert payloads_in_batch(first.payload) == ["msg-0", "msg-2"]
+      assert payloads_in_batch(second.payload) == ["msg-1"]
+    end
+
+    test "an entry the broker refuses fails its own callers and leaves the rest alone", ctx do
+      # The second entry published is the one carrying "b".
+      broker = start_supervised!({BrokerStub, {self(), [1]}}, id: :refusing_broker)
+      state = %{key_based(ctx.state) | broker_pid: broker, batch_size: 3}
+
+      froms = Enum.map(0..2, fn _ -> {self(), make_ref()} end)
+
+      state =
+        [froms, ["a", "b", "a"], 0..2]
+        |> Enum.zip()
+        |> Enum.reduce(state, fn {from, key, index}, acc ->
+          {:noreply, next} = Worker.handle_call({:send_message, "msg-#{index}", [partition_key: key]}, from, acc)
+          next
+        end)
+
+      assert [entry] = published()
+      assert payloads_in_batch(entry.payload) == ["msg-0", "msg-2"]
+
+      # Ids 1 and 2 went to the entry that landed; the refused one claimed none.
+      assert state.sequence_id == 2
+      assert map_size(state.pending_sends) == 1
+
+      # Only "b" hears about it. The others are still waiting on the receipt for their entry.
+      [{_, a_ref}, {_, b_ref}, _] = froms
+      assert_received {^b_ref, {:error, :message_too_large}}
+      refute_received {^a_ref, _reply}
+    end
+
+    test "keeps the ids of a refused entry for the next one, having sent nothing", ctx do
+      broker = start_supervised!({BrokerStub, {self(), [0]}}, id: :refusing_first)
+      state = %{key_based(ctx.state) | broker_pid: broker}
+
+      state = flush(state, [[partition_key: "a"], [partition_key: "b"]])
+
+      # The refused entry claimed nothing, so the one after it starts where it would have.
+      assert [entry] = published()
+      assert entry.command.sequence_id == 1
+      assert state.sequence_id == 1
+      assert map_size(state.pending_sends) == 1
+    end
+  end
+
   describe "a delayed message on a batching producer" do
     test "carries the delay the caller asked for", ctx do
       send_message(ctx.state, "later", deliver_at_time: @at_time)
@@ -128,24 +241,32 @@ defmodule Pulsar.Producer.BatchTest do
     Worker.handle_call({:send_message, payload, opts}, {self(), make_ref()}, state)
   end
 
+  defp key_based(state), do: %{state | batch_builder: :key_based}
+
   # Fills the batch so the last send flushes it.
   defp flush(state, sends) do
-    Enum.reduce(sends, %{state | batch_size: length(sends)}, fn opts, acc ->
-      {:noreply, next} = send_message(acc, "payload", opts)
+    sends
+    |> Enum.with_index()
+    |> Enum.reduce(%{state | batch_size: length(sends)}, fn {opts, index}, acc ->
+      {:noreply, next} = send_message(acc, "msg-#{index}", opts)
       next
     end)
   end
 
-  defp keys_in_batch(payload), do: keys_in_batch(payload, [])
+  defp keys_in_batch(payload), do: Enum.map(messages_in_batch(payload), &elem(&1, 0))
 
-  defp keys_in_batch(<<>>, acc), do: Enum.reverse(acc)
+  defp payloads_in_batch(payload), do: Enum.map(messages_in_batch(payload), &elem(&1, 1))
 
-  defp keys_in_batch(<<size::32, metadata::bytes-size(size), rest::binary>>, acc) do
+  defp messages_in_batch(batch), do: messages_in_batch(batch, [])
+
+  defp messages_in_batch(<<>>, acc), do: Enum.reverse(acc)
+
+  defp messages_in_batch(<<size::32, metadata::bytes-size(size), rest::binary>>, acc) do
     single = Binary.SingleMessageMetadata.decode(metadata)
     payload_size = single.payload_size
-    <<_payload::bytes-size(^payload_size), tail::binary>> = rest
+    <<payload::bytes-size(^payload_size), tail::binary>> = rest
 
-    keys_in_batch(tail, [single.partition_key | acc])
+    messages_in_batch(tail, [{single.partition_key, payload} | acc])
   end
 
   defp producer_state(broker) do
@@ -161,6 +282,7 @@ defmodule Pulsar.Producer.BatchTest do
       max_message_size: 5_242_880,
       batch_enabled: true,
       batch_size: 10,
+      batch_builder: :default,
       flush_interval: 30_000
     })
   end


### PR DESCRIPTION
## Summary

`batch_builder: :key_based` groups a batch by key at flush and publishes one entry per key, so a `:key_shared` subscription dispatches every message of the batch on its own key.

Off by default, as it is in the Java and Go clients.

## Motivation

#182 gave the entry the key of the batch's first message, which is what both reference clients do by default. It fixes a uniform-key batch. A mixed-key batch still dispatches entirely on that first key, so the rest of its messages go to whichever consumer owns a key that is not theirs.

The broker cannot do better with one entry: `Commands.resolveStickyKey` reads the entry, and `SingleMessageMetadata` has no field it could read instead. The only way to give every message its own key is to stop putting them in the same entry.

That is what Java's `BatchMessageKeyBasedContainer` does — `Map<String, BatchMessageContainerImpl> batches`, keyed by ordering key else partition key — and what Go's `KeyBasedBatchBuilder` does. Both are opt-in: Java defaults to `BatcherBuilder.DEFAULT`, Go to `DefaultBatchBuilder`, because an entry per key costs throughput and only `:key_shared` reads the key.

```elixir
Pulsar.Producer.start("orders", batch_enabled: true, batch_builder: :key_based)
```

**Grouping is on the ordering key ahead of the partition key**, which is the order `resolveStickyKey` resolves in, so messages the broker would send to one consumer stay in one entry. This is deliberately not what Java does — it base64-encodes the ordering key before using it as a map key, so a message with ordering key `"a"` and one with partition key `"a"` end up in different entries despite resolving to the same sticky key. Grouping on the raw value matches the broker and sends one entry where Java sends two.

## What changed

`do_flush_batch/1` assumed one entry per flush throughout: one sequence id range, one encode, one publish, one `pending_sends` entry, one telemetry event. It now divides the batch first and reduces over the result, so each entry gets its own of all five, and `:default` is the single-group case of the same path.

Entries are ordered by the key that appeared first in the batch, so sequence ids follow the order sends were accepted rather than map iteration order.

## Behaviour changes

Nothing changes unless `:batch_builder` is set, and `:default` is the existing path.

**`:key_based` orders a batch by key, not by send order.** Messages sent `A(k1), B(k2), C(k1)` are published as `[A, C]` then `[B]`, so a subscription reading the topic in order sees `A, C, B`. Ordering within a key is kept, which is the ordering `:key_shared` is about, but a consumer on any other subscription type sees the regrouping. Java's key-based batcher behaves the same way.

**A failed entry no longer fails the whole batch.** With `:key_based` a batch can be several publishes, so an error replies to that entry's callers alone and entries already published keep their pending receipts. A refused entry claims no sequence ids — its frame never reached the broker, so the entry after it starts where the refused one would have. Under `:default` there is one entry and the behaviour is unchanged.

**`[:pulsar, :producer, :batch, :published]` fires once per entry**, so a `:key_based` flush of three keys emits three events rather than one. Its `count` is that entry's messages.

## Verification

**Six tests fail against the parent commit** (`Result: 21/27`): one entry per key each carrying its own, entry ordering by first appearance, per-entry sequence id ranges, ordering-key precedence, keyless messages sharing one entry, and the integration test below. Two controls pass on both sides — a batch with `:default` stays one entry, and each message keeps its own key inside the payload.

**The failure path is covered, and the coverage was checked by mutation.** Two tests drive a stub broker that refuses one publish: one asserts only the refused entry's callers are told while the rest wait on their receipt, the other that the refused entry claims no sequence ids. Making the error branch advance the counter fails the second and nothing else (`Result: 20/21`).

**A test pins the regrouping**, so the ordering above is locked down rather than merely documented.

**Measured against a real broker.** `key-based batching gives every key an entry of its own, not just the first` produces four messages alternating between two keys, asserts two `batch published` telemetry events of two messages each rather than one of four, and asserts every consumed message's entry key equals its own key.

**Suite:** 469 tests (28 doctests) against the broker in `docker-compose.yml`, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean.

## Follow-ups

- `batch_size` counts messages across the whole batch, not per entry, so a `:key_based` flush of one key behaves as before while many keys produce many small entries. Java counts the same way. A per-entry cap would need its own option.

