### PR TITLE
feat(producer): send timeout and backpressure

### DIFF
--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -134,6 +134,14 @@ defmodule Pulsar.Producer do
   - `{:error, :metadata_too_large}` with `:chunking_enabled`, when `:properties` and the rest
     of the metadata leave no room for a payload to be split into
 
+  A producer already carrying `:max_pending_messages` refuses with
+  `{:error, :producer_queue_full}` rather than taking on more.
+
+  `{:error, :send_timeout}` is the other shape: the broker did not acknowledge the message
+  within `:send_timeout`. **It does not say the message was not published**, only that nothing
+  came back in time. A retry publishes under a fresh sequence id, which the broker's
+  deduplication does not match against the first attempt, so it can duplicate the message.
+
   A successful send answers with the broker's message id, or with a `t:chunked_message_id/0`
   when `:chunking_enabled` split the payload.
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -160,6 +160,10 @@ defmodule Pulsar.Producer do
   - `:event_time` - the message's event time, in milliseconds
   - `:deliver_at_time` / `:deliver_after` - delayed delivery. The broker delays whole entries, so
     a delayed message is published on its own rather than joining a batch
+  - `:timeout` - how long to wait for the call itself, in milliseconds. Defaults to `:infinity`,
+    leaving `:send_timeout` as the deadline. `:send_timeout` is counted from when the producer
+    takes the message, so a producer that has not finished registering has not started it: this
+    is what bounds that wait
   - `:client` - the client to resolve a producer name against
 
   ## Examples

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -115,7 +115,8 @@ defmodule Pulsar.Producer.Options do
       `{:error, :producer_queue_full}`. `false` removes the limit; `nil` is an alias.
 
       Counts every send taken and not yet answered, waiting to be batched or waiting for a
-      receipt. A chunked message counts once, however many frames carry it.
+      receipt. A chunked message counts once, however many frames carry it, so a producer
+      chunking large payloads tracks more frames than this bounds.
       """
     ],
     max_message_size: [

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -94,6 +94,29 @@ defmodule Pulsar.Producer.Options do
       one that compresses below the limit is sent whole.
       """
     ],
+    send_timeout: [
+      type: {:or, [:pos_integer, {:in, [false, nil]}]},
+      default: 30_000,
+      doc: """
+      Milliseconds to wait for the broker to acknowledge a published message before answering
+      its caller `{:error, :send_timeout}`. `false` waits indefinitely; `nil` is an alias.
+
+      This is the deadline a caller waits on, so leave it on unless something else bounds the
+      wait: an unacknowledged send otherwise holds its caller until the producer restarts, and
+      holds its place in `:max_pending_messages` with it.
+      """
+    ],
+    max_pending_messages: [
+      type: {:or, [:pos_integer, {:in, [false, nil]}]},
+      default: 1000,
+      doc: """
+      How many sends a producer will carry before refusing more with
+      `{:error, :producer_queue_full}`. `false` removes the limit; `nil` is an alias.
+
+      Counts every send taken and not yet answered, waiting to be batched or waiting for a
+      receipt. A chunked message counts once, however many frames carry it.
+      """
+    ],
     max_message_size: [
       type: :pos_integer,
       default: 5_242_880,

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -98,12 +98,13 @@ defmodule Pulsar.Producer.Options do
       type: {:or, [:pos_integer, {:in, [false, nil]}]},
       default: 30_000,
       doc: """
-      Milliseconds to wait for the broker to acknowledge a published message before answering
-      its caller `{:error, :send_timeout}`. `false` waits indefinitely; `nil` is an alias.
+      Milliseconds a send may wait before its caller is answered `{:error, :send_timeout}`,
+      counted from when the producer takes it rather than from when it reaches the broker.
+      `false` waits indefinitely; `nil` is an alias.
 
-      This is the deadline a caller waits on, so leave it on unless something else bounds the
-      wait: an unacknowledged send otherwise holds its caller until the producer restarts, and
-      holds its place in `:max_pending_messages` with it.
+      Leave it on unless something else bounds the wait: an unacknowledged send otherwise holds
+      its caller, and its place in `:max_pending_messages`, until the producer restarts. Keep
+      `:flush_interval` well below it.
       """
     ],
     max_pending_messages: [

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -62,6 +62,7 @@ defmodule Pulsar.Producer.Worker do
     :batch_enabled,
     {:batch, []},
     {:batched, 0},
+    :batch_started_at,
     :batch_size,
     :batch_builder,
     :batch_flush_timer,
@@ -95,6 +96,7 @@ defmodule Pulsar.Producer.Worker do
           batch_enabled: boolean(),
           batch: list({map(), GenServer.from()}),
           batched: non_neg_integer(),
+          batch_started_at: integer() | nil,
           batch_size: non_neg_integer(),
           batch_builder: :default | :key_based,
           batch_flush_timer: reference() | nil,
@@ -311,12 +313,14 @@ defmodule Pulsar.Producer.Worker do
     state = park_send(state)
     new_batch = [{message, from} | state.batch]
     new_batched = state.batched + 1
+    started_at = state.batch_started_at || System.monotonic_time(:millisecond)
+
+    state = %{state | batch: new_batch, batched: new_batched, batch_started_at: started_at}
 
     if new_batched >= state.batch_size do
-      state = do_flush_batch(%{state | batch: new_batch, batched: new_batched})
-      {:noreply, state}
+      {:noreply, do_flush_batch(state)}
     else
-      {:noreply, %{state | batch: new_batch, batched: new_batched}}
+      {:noreply, maybe_schedule_send_timeout(state)}
     end
   end
 
@@ -518,7 +522,7 @@ defmodule Pulsar.Producer.Worker do
       |> batch_entries(state.batch_builder)
       |> Enum.reduce(state, &publish_batch/2)
 
-    %{new_state | batch: [], batched: 0}
+    %{new_state | batch: [], batched: 0, batch_started_at: nil}
   end
 
   # Grouping on the ordering key ahead of the partition key is the order the broker resolves a
@@ -616,16 +620,21 @@ defmodule Pulsar.Producer.Worker do
       nil ->
         state
 
-      sent_at ->
-        due_in = max(sent_at + state.send_timeout - System.monotonic_time(:millisecond), 0)
+      due_at ->
+        due_in = max(due_at - System.monotonic_time(:millisecond), 0)
         %{state | send_timeout_timer: Process.send_after(self(), :expire_sends, due_in)}
     end
   end
 
-  defp oldest_send(%__MODULE__{pending_sends: pending}) do
-    pending
-    |> Enum.map(fn {_sequence_id, {_callers, _metadata, sent_at}} -> sent_at end)
-    |> Enum.min(fn -> nil end)
+  # A message waiting to be batched is owed an answer too, counted from when it was taken.
+  defp oldest_send(%__MODULE__{} = state) do
+    published = for {_sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends, do: sent_at
+    batched = List.wrap(state.batch_started_at)
+
+    case Enum.min(published ++ batched, fn -> nil end) do
+      nil -> nil
+      oldest -> oldest + state.send_timeout
+    end
   end
 
   defp expire_due_sends(%__MODULE__{} = state) do
@@ -639,6 +648,20 @@ defmodule Pulsar.Producer.Worker do
     due
     |> Enum.sort()
     |> Enum.reduce(state, &expire_send/2)
+    |> expire_due_batch()
+  end
+
+  defp expire_due_batch(%__MODULE__{batch_started_at: nil} = state), do: state
+
+  defp expire_due_batch(%__MODULE__{} = state) do
+    if state.batch_started_at + state.send_timeout <= System.monotonic_time(:millisecond) do
+      callers = Enum.map(state.batch, fn {_message, from} -> from end)
+      report_send_timeout(length(callers), :batched, state)
+
+      answer(%{state | batch: [], batched: 0, batch_started_at: nil}, callers, {:error, :send_timeout})
+    else
+      state
+    end
   end
 
   defp expire_send(sequence_id, state) do

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -622,20 +622,21 @@ defmodule Pulsar.Producer.Worker do
     end
   end
 
-  defp oldest_send(%__MODULE__{pending_sends: pending}) when map_size(pending) == 0, do: nil
-
   defp oldest_send(%__MODULE__{pending_sends: pending}) do
     pending
     |> Enum.map(fn {_sequence_id, {_callers, _metadata, sent_at}} -> sent_at end)
-    |> Enum.min()
+    |> Enum.min(fn -> nil end)
   end
 
   defp expire_due_sends(%__MODULE__{} = state) do
     cutoff = System.monotonic_time(:millisecond) - state.send_timeout
 
-    state.pending_sends
-    |> Enum.filter(fn {_sequence_id, {_callers, _metadata, sent_at}} -> sent_at <= cutoff end)
-    |> Enum.map(fn {sequence_id, _entry} -> sequence_id end)
+    due =
+      for {sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends,
+          sent_at <= cutoff,
+          do: sequence_id
+
+    due
     |> Enum.sort()
     |> Enum.reduce(state, &expire_send/2)
   end

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -79,7 +79,7 @@ defmodule Pulsar.Producer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           sequence_id: integer(),
-          pending_sends: %{integer() => {GenServer.from() | [GenServer.from()], map() | nil, integer()}},
+          pending_sends: %{integer() => {[GenServer.from()], map() | nil, integer()}},
           pending_messages: non_neg_integer(),
           send_timeout: pos_integer() | false | nil,
           send_timeout_timer: reference() | nil,
@@ -266,11 +266,26 @@ defmodule Pulsar.Producer.Worker do
 
   # The only decrement, so the count cannot drift. `terminate/2` is the exception: no state left.
   defp answer(%__MODULE__{} = state, callers, reply) do
-    callers = List.wrap(callers)
     Enum.each(callers, fn from -> GenServer.reply(from, reply) end)
 
     %{state | pending_messages: state.pending_messages - length(callers)}
   end
+
+  # Answers everyone a pending send owes and stops tracking it. A chunk takes the rest of its
+  # message with it: nothing can complete it now.
+  defp resolve_send(%__MODULE__{} = state, sequence_id, reply) do
+    case Map.pop(state.pending_sends, sequence_id) do
+      {nil, _pending} ->
+        :error
+
+      {{callers, metadata, _sent_at}, pending} ->
+        pending = drop_chunks_of(pending, metadata)
+        {:ok, callers, answer(%{state | pending_sends: pending}, callers, reply)}
+    end
+  end
+
+  defp drop_chunks_of(pending, %{uuid: uuid}), do: Map.reject(pending, &chunk_of?(&1, uuid))
+  defp drop_chunks_of(pending, _metadata), do: pending
 
   defp publish_or_batch(payload, opts, from, %{batch_enabled: true} = state) do
     if delayed?(opts) do
@@ -338,7 +353,7 @@ defmodule Pulsar.Producer.Worker do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
-            new_pending = Map.put(acc_state.pending_sends, sequence_id, {from, chunk_metadata, sent_at})
+            new_pending = Map.put(acc_state.pending_sends, sequence_id, {[from], chunk_metadata, sent_at})
             new_state = %{acc_state | sequence_id: sequence_id, pending_sends: new_pending}
             {:cont, {:ok, new_state}}
 
@@ -405,17 +420,12 @@ defmodule Pulsar.Producer.Worker do
   def handle_info({:send_receipt, %Binary.CommandSendReceipt{} = receipt}, state) do
     new_state =
       case Map.pop(state.pending_sends, receipt.sequence_id) do
-        # Batch case
-        {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
+        # A chunk resolves nothing on its own: the message is owed the rest of its receipts.
+        {{callers, %{uuid: _} = chunk_metadata, sent_at}, new_pending} ->
+          handle_chunk_receipt(receipt, callers, chunk_metadata, sent_at, new_pending, state)
+
+        {{callers, _metadata, _sent_at}, new_pending} ->
           answer(%{state | pending_sends: new_pending}, callers, {:ok, receipt.message_id})
-
-        # Chunked message case
-        {{from, %{uuid: _} = chunk_metadata, sent_at}, new_pending} ->
-          handle_chunk_receipt(receipt, from, chunk_metadata, sent_at, new_pending, state)
-
-        # Single message case
-        {{from, _metadata, _sent_at}, new_pending} ->
-          answer(%{state | pending_sends: new_pending}, from, {:ok, receipt.message_id})
 
         # A chunk of a message that was given up on, which a partial send and a discarded chunk
         # both leave behind: the entry is gone, but what reached the broker is still answered.
@@ -431,19 +441,11 @@ defmodule Pulsar.Producer.Worker do
   def handle_info({:send_error, %Binary.CommandSendError{} = error}, state) do
     reply = {:error, {error.error, error.message}}
 
-    case Map.pop(state.pending_sends, error.sequence_id) do
-      {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
-        {:noreply, answer(%{state | pending_sends: new_pending}, callers, reply)}
+    case resolve_send(state, error.sequence_id, reply) do
+      {:ok, _callers, new_state} ->
+        {:noreply, new_state}
 
-      # The rest of the message goes with it: nothing can complete it now.
-      {{from, %{uuid: uuid}, _sent_at}, new_pending} ->
-        new_pending = Map.reject(new_pending, &chunk_of?(&1, uuid))
-        {:noreply, answer(%{state | pending_sends: new_pending}, from, reply)}
-
-      {{from, _metadata, _sent_at}, new_pending} ->
-        {:noreply, answer(%{state | pending_sends: new_pending}, from, reply)}
-
-      {nil, _} ->
+      :error ->
         Logger.warning("Received error for unknown sequence_id #{error.sequence_id}")
         {:noreply, state}
     end
@@ -592,7 +594,7 @@ defmodule Pulsar.Producer.Worker do
 
         # Keyed on the first id, which is the one the receipt comes back on.
         sent_at = System.monotonic_time(:millisecond)
-        new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}, sent_at})
+        new_pending = Map.put(state.pending_sends, sequence_id, {callers, nil, sent_at})
 
         maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_sends: new_pending})
 
@@ -639,58 +641,38 @@ defmodule Pulsar.Producer.Worker do
   end
 
   defp expire_send(sequence_id, state) do
-    case Map.pop(state.pending_sends, sequence_id) do
-      {{callers, %{batch: true}, _sent_at}, pending} when is_list(callers) ->
-        report_send_timeout(callers, sequence_id, state)
-        answer(%{state | pending_sends: pending}, callers, {:error, :send_timeout})
+    case resolve_send(state, sequence_id, {:error, :send_timeout}) do
+      {:ok, callers, new_state} ->
+        report_send_timeout(length(callers), sequence_id, state)
+        new_state
 
-      # The rest of the message goes with it: nothing can complete it now.
-      {{from, %{uuid: uuid}, _sent_at}, pending} ->
-        report_send_timeout([from], sequence_id, state)
-        pending = Map.reject(pending, &chunk_of?(&1, uuid))
-        answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
-
-      {{from, _metadata, _sent_at}, pending} ->
-        report_send_timeout([from], sequence_id, state)
-        answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
-
-      {nil, _pending} ->
+      # Already answered, by the chunk cascade that dropped this one.
+      :error ->
         state
     end
   end
 
-  defp report_send_timeout(callers, sequence_id, state) do
+  defp report_send_timeout(count, sequence_id, state) do
     Logger.warning(
       "Broker did not acknowledge sequence_id #{sequence_id} on #{state.topic} within " <>
-        "#{state.send_timeout}ms, failing #{length(callers)} caller(s)"
+        "#{state.send_timeout}ms, failing #{count} caller(s)"
     )
 
     :telemetry.execute(
       [:pulsar, :producer, :send, :timeout],
-      %{count: length(callers)},
+      %{count: count},
       Map.put(producer_metadata(state), :sequence_id, sequence_id)
     )
   end
 
   defp report_deduplicated(receipt, state) do
-    case Map.pop(state.pending_sends, receipt.sequence_id) do
-      {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
+    case resolve_send(state, receipt.sequence_id, {:ok, :deduplicated}) do
+      {:ok, callers, new_state} ->
         report_discarded(receipt, length(callers), state)
-        answer(%{state | pending_sends: new_pending}, callers, {:ok, :deduplicated})
-
-      # One discarded chunk leaves a message that can never be reassembled, so the rest of it
-      # goes too rather than waiting for receipts that no longer complete anything.
-      {{from, %{uuid: uuid}, _sent_at}, new_pending} ->
-        report_discarded(receipt, 1, state)
-        new_pending = Map.reject(new_pending, &chunk_of?(&1, uuid))
-        answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
-
-      {{from, _metadata, _sent_at}, new_pending} ->
-        report_discarded(receipt, 1, state)
-        answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
+        new_state
 
       # Answered and reported already, by the discarded chunk that dropped this one.
-      {nil, _} ->
+      :error ->
         Logger.debug("Received deduplicated receipt for untracked sequence_id #{receipt.sequence_id}")
         state
     end
@@ -709,33 +691,33 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  defp chunk_of?({_sequence_id, {_from, %{uuid: uuid}, _sent_at}}, uuid), do: true
+  defp chunk_of?({_sequence_id, {_callers, %{uuid: uuid}, _sent_at}}, uuid), do: true
   defp chunk_of?(_pending_send, _uuid), do: false
 
-  defp handle_chunk_receipt(receipt, from, chunk_metadata, sent_at, new_pending, state) do
+  defp handle_chunk_receipt(receipt, callers, chunk_metadata, sent_at, new_pending, state) do
     uuid = chunk_metadata.uuid
     num_chunks = chunk_metadata.num_chunks
 
     updated_chunk_meta = Map.put(chunk_metadata, :message_id, receipt.message_id)
-    updated_pending = Map.put(new_pending, receipt.sequence_id, {from, updated_chunk_meta, sent_at})
+    updated_pending = Map.put(new_pending, receipt.sequence_id, {callers, updated_chunk_meta, sent_at})
 
     chunks_with_receipts =
-      Enum.filter(updated_pending, fn {_seq_id, {_from, meta, _sent_at}} ->
+      Enum.filter(updated_pending, fn {_seq_id, {_callers, meta, _sent_at}} ->
         match?(%{uuid: ^uuid, message_id: _}, meta)
       end)
 
     if length(chunks_with_receipts) == num_chunks do
-      complete_chunked_message(from, uuid, num_chunks, chunks_with_receipts, updated_pending, state)
+      complete_chunked_message(callers, uuid, num_chunks, chunks_with_receipts, updated_pending, state)
     else
       %{state | pending_sends: updated_pending}
     end
   end
 
-  defp complete_chunked_message(from, uuid, num_chunks, chunks_with_receipts, updated_pending, state) do
+  defp complete_chunked_message(callers, uuid, num_chunks, chunks_with_receipts, updated_pending, state) do
     sorted_chunks =
       chunks_with_receipts
-      |> Enum.sort_by(fn {_seq_id, {_from, meta, _sent_at}} -> meta.chunk_id end)
-      |> Enum.map(fn {_seq_id, {_from, meta, _sent_at}} -> meta.message_id end)
+      |> Enum.sort_by(fn {_seq_id, {_callers, meta, _sent_at}} -> meta.chunk_id end)
+      |> Enum.map(fn {_seq_id, {_callers, meta, _sent_at}} -> meta.message_id end)
 
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :complete],
@@ -750,7 +732,7 @@ defmodule Pulsar.Producer.Worker do
       num_chunks: num_chunks
     }
 
-    state = answer(state, from, {:ok, chunked_msg_id})
+    state = answer(state, callers, {:ok, chunked_msg_id})
 
     chunk_seq_ids = Enum.map(chunks_with_receipts, fn {seq_id, _} -> seq_id end)
 

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -47,6 +47,10 @@ defmodule Pulsar.Producer.Worker do
     :broker_monitor,
     {:sequence_id, 0},
     {:pending_sends, %{}},
+    {:pending_messages, 0},
+    :send_timeout,
+    :send_timeout_timer,
+    :max_pending_messages,
     :access_mode,
     :compression,
     {:ready, false},
@@ -75,7 +79,11 @@ defmodule Pulsar.Producer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           sequence_id: integer(),
-          pending_sends: %{integer() => {GenServer.from(), map() | nil}},
+          pending_sends: %{integer() => {GenServer.from() | [GenServer.from()], map()}},
+          pending_messages: non_neg_integer(),
+          send_timeout: pos_integer() | false | nil,
+          send_timeout_timer: reference() | nil,
+          max_pending_messages: pos_integer() | false | nil,
           access_mode: atom(),
           compression: :none | :lz4 | :zlib | :snappy | :zstd,
           ready: boolean(),
@@ -121,13 +129,17 @@ defmodule Pulsar.Producer.Worker do
   Publishes a message and waits for the broker to acknowledge it. Backs
   `Pulsar.Producer.send/3`, which documents the message options.
 
-  Two are not part of that public surface: `:timeout`, the call timeout in milliseconds
-  (default 5000), and `:ordering_key`, which orders within a `:key_shared` subscription
-  without affecting which partition the message lands on.
+  Two are not part of that public surface: `:timeout`, the call timeout in milliseconds, and
+  `:ordering_key`, which orders within a `:key_shared` subscription without affecting which
+  partition the message lands on.
+
+  `:timeout` defaults to `:infinity` because `:send_timeout` is the deadline: a call giving up
+  first would replace `{:error, :send_timeout}` with an exit. Pass one here if `:send_timeout`
+  is off.
   """
   @spec send_message(pid(), binary(), keyword()) :: {:ok, map() | :deduplicated} | {:error, term()}
   def send_message(producer_pid, message, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, 5000)
+    timeout = Keyword.get(opts, :timeout, :infinity)
     GenServer.call(producer_pid, {:send_message, message, opts}, timeout)
   end
 
@@ -237,7 +249,30 @@ defmodule Pulsar.Producer.Worker do
     {:reply, {:error, :producer_waiting}, state}
   end
 
-  def handle_call({:send_message, payload, opts}, from, %{batch_enabled: true} = state) do
+  def handle_call({:send_message, payload, opts}, from, state) do
+    if queue_full?(state) do
+      {:reply, {:error, :producer_queue_full}, state}
+    else
+      publish_or_batch(payload, opts, from, state)
+    end
+  end
+
+  defp queue_full?(%__MODULE__{max_pending_messages: limit}) when limit in [false, nil], do: false
+
+  defp queue_full?(%__MODULE__{} = state), do: state.pending_messages >= state.max_pending_messages
+
+  # Parked, not accepted: a send answered synchronously never waits. A chunked message parks once.
+  defp park_send(%__MODULE__{} = state), do: %{state | pending_messages: state.pending_messages + 1}
+
+  # The only decrement, so the count cannot drift. `terminate/2` is the exception: no state left.
+  defp answer(%__MODULE__{} = state, callers, reply) do
+    callers = List.wrap(callers)
+    Enum.each(callers, fn from -> GenServer.reply(from, reply) end)
+
+    %{state | pending_messages: max(state.pending_messages - length(callers), 0)}
+  end
+
+  defp publish_or_batch(payload, opts, from, %{batch_enabled: true} = state) do
     if delayed?(opts) do
       # A delay names the entry and SingleMessageMetadata has no field for one, so this cannot
       # ride in a batch. What is pending goes first, or it would overtake earlier messages.
@@ -247,9 +282,7 @@ defmodule Pulsar.Producer.Worker do
     end
   end
 
-  def handle_call({:send_message, payload, opts}, from, state) do
-    send_unbatched(payload, opts, from, state)
-  end
+  defp publish_or_batch(payload, opts, from, state), do: send_unbatched(payload, opts, from, state)
 
   defp add_to_batch(payload, opts, from, state) do
     message = %{
@@ -260,6 +293,7 @@ defmodule Pulsar.Producer.Worker do
       event_time: Keyword.get(opts, :event_time)
     }
 
+    state = park_send(state)
     new_batch = [{message, from} | state.batch]
     new_batched = state.batched + 1
 
@@ -301,7 +335,7 @@ defmodule Pulsar.Producer.Worker do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
-            new_pending = Map.put(acc_state.pending_sends, sequence_id, {from, chunk_metadata})
+            new_pending = Map.put(acc_state.pending_sends, sequence_id, {from, sent_now(chunk_metadata)})
             new_state = %{acc_state | sequence_id: sequence_id, pending_sends: new_pending}
             {:cont, {:ok, new_state}}
 
@@ -312,7 +346,7 @@ defmodule Pulsar.Producer.Worker do
 
     case result do
       {:ok, new_state} ->
-        {:noreply, new_state}
+        {:noreply, new_state |> park_send() |> maybe_schedule_send_timeout()}
 
       # Rolling the counter back would reissue sequence ids still in flight, which the
       # broker's deduplication reads as repeats. The pending entries do go: a message missing
@@ -340,6 +374,13 @@ defmodule Pulsar.Producer.Worker do
   end
 
   @impl true
+  def handle_info(:expire_sends, state) do
+    state = %{state | send_timeout_timer: nil}
+
+    {:noreply, state |> expire_due_sends() |> maybe_schedule_send_timeout()}
+  end
+
+  @impl true
   def handle_info(:flush_batch, state) do
     state = do_flush_batch(state)
     timer_ref = Process.send_after(self(), :flush_batch, state.flush_interval)
@@ -363,20 +404,15 @@ defmodule Pulsar.Producer.Worker do
       case Map.pop(state.pending_sends, receipt.sequence_id) do
         # Batch case
         {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
-          Enum.each(callers, fn from ->
-            GenServer.reply(from, {:ok, receipt.message_id})
-          end)
-
-          %{state | pending_sends: new_pending}
+          answer(%{state | pending_sends: new_pending}, callers, {:ok, receipt.message_id})
 
         # Chunked message case
-        {{from, chunk_metadata}, new_pending} when is_map(chunk_metadata) ->
+        {{from, %{uuid: _} = chunk_metadata}, new_pending} ->
           handle_chunk_receipt(receipt, from, chunk_metadata, new_pending, state)
 
         # Single message case
         {{from, _metadata}, new_pending} ->
-          GenServer.reply(from, {:ok, receipt.message_id})
-          %{state | pending_sends: new_pending}
+          answer(%{state | pending_sends: new_pending}, from, {:ok, receipt.message_id})
 
         # A chunk of a message that was given up on, which a partial send and a discarded chunk
         # both leave behind: the entry is gone, but what reached the broker is still answered.
@@ -392,15 +428,12 @@ defmodule Pulsar.Producer.Worker do
   def handle_info({:send_error, %Binary.CommandSendError{} = error}, state) do
     case Map.pop(state.pending_sends, error.sequence_id) do
       {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
-        Enum.each(callers, fn from ->
-          GenServer.reply(from, {:error, {error.error, error.message}})
-        end)
-
-        {:noreply, %{state | pending_sends: new_pending}}
+        reply = {:error, {error.error, error.message}}
+        {:noreply, answer(%{state | pending_sends: new_pending}, callers, reply)}
 
       {{from, _metadata}, new_pending} ->
-        GenServer.reply(from, {:error, {error.error, error.message}})
-        {:noreply, %{state | pending_sends: new_pending}}
+        reply = {:error, {error.error, error.message}}
+        {:noreply, answer(%{state | pending_sends: new_pending}, from, reply)}
 
       {nil, _} ->
         Logger.warning("Received error for unknown sequence_id #{error.sequence_id}")
@@ -550,37 +583,104 @@ defmodule Pulsar.Producer.Worker do
         )
 
         # Keyed on the first id, which is the one the receipt comes back on.
-        new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}})
+        new_pending = Map.put(state.pending_sends, sequence_id, {callers, sent_now(%{batch: true})})
 
-        %{state | sequence_id: highest_sequence_id, pending_sends: new_pending}
+        maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_sends: new_pending})
 
       # Only this entry's callers hear about it; the ones published before it are still owed
       # their receipts.
       {:error, reason} ->
         Logger.error("Failed to send batch: #{inspect(reason)}")
-        Enum.each(callers, fn from -> GenServer.reply(from, {:error, reason}) end)
+        answer(state, callers, {:error, reason})
+    end
+  end
+
+  defp sent_now(metadata), do: Map.put(metadata || %{}, :sent_at, System.monotonic_time(:millisecond))
+
+  # One timer, aimed at the oldest send: every send shares the timeout, so that one expires first.
+  defp maybe_schedule_send_timeout(%__MODULE__{send_timeout: timeout} = state) when timeout in [false, nil], do: state
+
+  defp maybe_schedule_send_timeout(%__MODULE__{send_timeout_timer: timer} = state) when is_reference(timer), do: state
+
+  defp maybe_schedule_send_timeout(%__MODULE__{} = state) do
+    case oldest_send(state) do
+      nil ->
+        state
+
+      sent_at ->
+        due_in = max(sent_at + state.send_timeout - System.monotonic_time(:millisecond), 0)
+        %{state | send_timeout_timer: Process.send_after(self(), :expire_sends, due_in)}
+    end
+  end
+
+  defp oldest_send(%__MODULE__{pending_sends: pending}) when map_size(pending) == 0, do: nil
+
+  defp oldest_send(%__MODULE__{pending_sends: pending}) do
+    pending
+    |> Enum.map(fn {_sequence_id, {_callers, metadata}} -> metadata.sent_at end)
+    |> Enum.min()
+  end
+
+  defp expire_due_sends(%__MODULE__{} = state) do
+    cutoff = System.monotonic_time(:millisecond) - state.send_timeout
+
+    state.pending_sends
+    |> Enum.filter(fn {_sequence_id, {_callers, metadata}} -> metadata.sent_at <= cutoff end)
+    |> Enum.map(fn {sequence_id, _entry} -> sequence_id end)
+    |> Enum.sort()
+    |> Enum.reduce(state, &expire_send/2)
+  end
+
+  defp expire_send(sequence_id, state) do
+    case Map.pop(state.pending_sends, sequence_id) do
+      {{callers, %{batch: true}}, pending} when is_list(callers) ->
+        report_send_timeout(callers, sequence_id, state)
+        answer(%{state | pending_sends: pending}, callers, {:error, :send_timeout})
+
+      # The rest of the message goes with it: nothing can complete it now.
+      {{from, %{uuid: uuid}}, pending} ->
+        report_send_timeout([from], sequence_id, state)
+        pending = Map.reject(pending, &chunk_of?(&1, uuid))
+        answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
+
+      {{from, _metadata}, pending} ->
+        report_send_timeout([from], sequence_id, state)
+        answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
+
+      {nil, _pending} ->
         state
     end
+  end
+
+  defp report_send_timeout(callers, sequence_id, state) do
+    Logger.warning(
+      "Broker did not acknowledge sequence_id #{sequence_id} on #{state.topic} within " <>
+        "#{state.send_timeout}ms, failing #{length(callers)} caller(s)"
+    )
+
+    :telemetry.execute(
+      [:pulsar, :producer, :send, :timeout],
+      %{count: length(callers)},
+      Map.put(producer_metadata(state), :sequence_id, sequence_id)
+    )
   end
 
   defp report_deduplicated(receipt, state) do
     case Map.pop(state.pending_sends, receipt.sequence_id) do
       {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
         report_discarded(receipt, length(callers), state)
-        Enum.each(callers, fn from -> GenServer.reply(from, {:ok, :deduplicated}) end)
-        %{state | pending_sends: new_pending}
+        answer(%{state | pending_sends: new_pending}, callers, {:ok, :deduplicated})
 
       # One discarded chunk leaves a message that can never be reassembled, so the rest of it
       # goes too rather than waiting for receipts that no longer complete anything.
       {{from, %{uuid: uuid}}, new_pending} ->
         report_discarded(receipt, 1, state)
-        GenServer.reply(from, {:ok, :deduplicated})
-        %{state | pending_sends: Map.reject(new_pending, &chunk_of?(&1, uuid))}
+        new_pending = Map.reject(new_pending, &chunk_of?(&1, uuid))
+        answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
 
       {{from, _metadata}, new_pending} ->
         report_discarded(receipt, 1, state)
-        GenServer.reply(from, {:ok, :deduplicated})
-        %{state | pending_sends: new_pending}
+        answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
 
       # Answered and reported already, by the discarded chunk that dropped this one.
       {nil, _} ->
@@ -643,7 +743,7 @@ defmodule Pulsar.Producer.Worker do
       num_chunks: num_chunks
     }
 
-    GenServer.reply(from, {:ok, chunked_msg_id})
+    state = answer(state, from, {:ok, chunked_msg_id})
 
     chunk_seq_ids = Enum.map(chunks_with_receipts, fn {seq_id, _} -> seq_id end)
 

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -79,7 +79,7 @@ defmodule Pulsar.Producer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           sequence_id: integer(),
-          pending_sends: %{integer() => {GenServer.from() | [GenServer.from()], map()}},
+          pending_sends: %{integer() => {GenServer.from() | [GenServer.from()], map() | nil, integer()}},
           pending_messages: non_neg_integer(),
           send_timeout: pos_integer() | false | nil,
           send_timeout_timer: reference() | nil,
@@ -269,7 +269,7 @@ defmodule Pulsar.Producer.Worker do
     callers = List.wrap(callers)
     Enum.each(callers, fn from -> GenServer.reply(from, reply) end)
 
-    %{state | pending_messages: max(state.pending_messages - length(callers), 0)}
+    %{state | pending_messages: state.pending_messages - length(callers)}
   end
 
   defp publish_or_batch(payload, opts, from, %{batch_enabled: true} = state) do
@@ -318,6 +318,9 @@ defmodule Pulsar.Producer.Worker do
   end
 
   defp publish_messages(messages, base_metadata, from, state) do
+    # One send time for the whole message: its chunks share a deadline, as they share a caller.
+    sent_at = System.monotonic_time(:millisecond)
+
     result =
       Enum.reduce_while(messages, {:ok, state}, fn {chunk_payload, chunk_metadata}, {:ok, acc_state} ->
         sequence_id = acc_state.sequence_id + 1
@@ -335,7 +338,7 @@ defmodule Pulsar.Producer.Worker do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
-            new_pending = Map.put(acc_state.pending_sends, sequence_id, {from, sent_now(chunk_metadata)})
+            new_pending = Map.put(acc_state.pending_sends, sequence_id, {from, chunk_metadata, sent_at})
             new_state = %{acc_state | sequence_id: sequence_id, pending_sends: new_pending}
             {:cont, {:ok, new_state}}
 
@@ -403,15 +406,15 @@ defmodule Pulsar.Producer.Worker do
     new_state =
       case Map.pop(state.pending_sends, receipt.sequence_id) do
         # Batch case
-        {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
+        {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
           answer(%{state | pending_sends: new_pending}, callers, {:ok, receipt.message_id})
 
         # Chunked message case
-        {{from, %{uuid: _} = chunk_metadata}, new_pending} ->
-          handle_chunk_receipt(receipt, from, chunk_metadata, new_pending, state)
+        {{from, %{uuid: _} = chunk_metadata, sent_at}, new_pending} ->
+          handle_chunk_receipt(receipt, from, chunk_metadata, sent_at, new_pending, state)
 
         # Single message case
-        {{from, _metadata}, new_pending} ->
+        {{from, _metadata, _sent_at}, new_pending} ->
           answer(%{state | pending_sends: new_pending}, from, {:ok, receipt.message_id})
 
         # A chunk of a message that was given up on, which a partial send and a discarded chunk
@@ -426,13 +429,18 @@ defmodule Pulsar.Producer.Worker do
 
   @impl true
   def handle_info({:send_error, %Binary.CommandSendError{} = error}, state) do
+    reply = {:error, {error.error, error.message}}
+
     case Map.pop(state.pending_sends, error.sequence_id) do
-      {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
-        reply = {:error, {error.error, error.message}}
+      {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
         {:noreply, answer(%{state | pending_sends: new_pending}, callers, reply)}
 
-      {{from, _metadata}, new_pending} ->
-        reply = {:error, {error.error, error.message}}
+      # The rest of the message goes with it: nothing can complete it now.
+      {{from, %{uuid: uuid}, _sent_at}, new_pending} ->
+        new_pending = Map.reject(new_pending, &chunk_of?(&1, uuid))
+        {:noreply, answer(%{state | pending_sends: new_pending}, from, reply)}
+
+      {{from, _metadata, _sent_at}, new_pending} ->
         {:noreply, answer(%{state | pending_sends: new_pending}, from, reply)}
 
       {nil, _} ->
@@ -583,7 +591,8 @@ defmodule Pulsar.Producer.Worker do
         )
 
         # Keyed on the first id, which is the one the receipt comes back on.
-        new_pending = Map.put(state.pending_sends, sequence_id, {callers, sent_now(%{batch: true})})
+        sent_at = System.monotonic_time(:millisecond)
+        new_pending = Map.put(state.pending_sends, sequence_id, {callers, %{batch: true}, sent_at})
 
         maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_sends: new_pending})
 
@@ -594,8 +603,6 @@ defmodule Pulsar.Producer.Worker do
         answer(state, callers, {:error, reason})
     end
   end
-
-  defp sent_now(metadata), do: Map.put(metadata || %{}, :sent_at, System.monotonic_time(:millisecond))
 
   # One timer, aimed at the oldest send: every send shares the timeout, so that one expires first.
   defp maybe_schedule_send_timeout(%__MODULE__{send_timeout: timeout} = state) when timeout in [false, nil], do: state
@@ -617,7 +624,7 @@ defmodule Pulsar.Producer.Worker do
 
   defp oldest_send(%__MODULE__{pending_sends: pending}) do
     pending
-    |> Enum.map(fn {_sequence_id, {_callers, metadata}} -> metadata.sent_at end)
+    |> Enum.map(fn {_sequence_id, {_callers, _metadata, sent_at}} -> sent_at end)
     |> Enum.min()
   end
 
@@ -625,7 +632,7 @@ defmodule Pulsar.Producer.Worker do
     cutoff = System.monotonic_time(:millisecond) - state.send_timeout
 
     state.pending_sends
-    |> Enum.filter(fn {_sequence_id, {_callers, metadata}} -> metadata.sent_at <= cutoff end)
+    |> Enum.filter(fn {_sequence_id, {_callers, _metadata, sent_at}} -> sent_at <= cutoff end)
     |> Enum.map(fn {sequence_id, _entry} -> sequence_id end)
     |> Enum.sort()
     |> Enum.reduce(state, &expire_send/2)
@@ -633,17 +640,17 @@ defmodule Pulsar.Producer.Worker do
 
   defp expire_send(sequence_id, state) do
     case Map.pop(state.pending_sends, sequence_id) do
-      {{callers, %{batch: true}}, pending} when is_list(callers) ->
+      {{callers, %{batch: true}, _sent_at}, pending} when is_list(callers) ->
         report_send_timeout(callers, sequence_id, state)
         answer(%{state | pending_sends: pending}, callers, {:error, :send_timeout})
 
       # The rest of the message goes with it: nothing can complete it now.
-      {{from, %{uuid: uuid}}, pending} ->
+      {{from, %{uuid: uuid}, _sent_at}, pending} ->
         report_send_timeout([from], sequence_id, state)
         pending = Map.reject(pending, &chunk_of?(&1, uuid))
         answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
 
-      {{from, _metadata}, pending} ->
+      {{from, _metadata, _sent_at}, pending} ->
         report_send_timeout([from], sequence_id, state)
         answer(%{state | pending_sends: pending}, from, {:error, :send_timeout})
 
@@ -667,18 +674,18 @@ defmodule Pulsar.Producer.Worker do
 
   defp report_deduplicated(receipt, state) do
     case Map.pop(state.pending_sends, receipt.sequence_id) do
-      {{callers, %{batch: true}}, new_pending} when is_list(callers) ->
+      {{callers, %{batch: true}, _sent_at}, new_pending} when is_list(callers) ->
         report_discarded(receipt, length(callers), state)
         answer(%{state | pending_sends: new_pending}, callers, {:ok, :deduplicated})
 
       # One discarded chunk leaves a message that can never be reassembled, so the rest of it
       # goes too rather than waiting for receipts that no longer complete anything.
-      {{from, %{uuid: uuid}}, new_pending} ->
+      {{from, %{uuid: uuid}, _sent_at}, new_pending} ->
         report_discarded(receipt, 1, state)
         new_pending = Map.reject(new_pending, &chunk_of?(&1, uuid))
         answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
 
-      {{from, _metadata}, new_pending} ->
+      {{from, _metadata, _sent_at}, new_pending} ->
         report_discarded(receipt, 1, state)
         answer(%{state | pending_sends: new_pending}, from, {:ok, :deduplicated})
 
@@ -702,19 +709,19 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  defp chunk_of?({_sequence_id, {_from, %{uuid: uuid}}}, uuid), do: true
+  defp chunk_of?({_sequence_id, {_from, %{uuid: uuid}, _sent_at}}, uuid), do: true
   defp chunk_of?(_pending_send, _uuid), do: false
 
-  defp handle_chunk_receipt(receipt, from, chunk_metadata, new_pending, state) do
+  defp handle_chunk_receipt(receipt, from, chunk_metadata, sent_at, new_pending, state) do
     uuid = chunk_metadata.uuid
     num_chunks = chunk_metadata.num_chunks
 
     updated_chunk_meta = Map.put(chunk_metadata, :message_id, receipt.message_id)
-    updated_pending = Map.put(new_pending, receipt.sequence_id, {from, updated_chunk_meta})
+    updated_pending = Map.put(new_pending, receipt.sequence_id, {from, updated_chunk_meta, sent_at})
 
     chunks_with_receipts =
-      Enum.filter(updated_pending, fn {_seq_id, {_from, meta}} ->
-        is_map(meta) and Map.get(meta, :uuid) == uuid and Map.has_key?(meta, :message_id)
+      Enum.filter(updated_pending, fn {_seq_id, {_from, meta, _sent_at}} ->
+        match?(%{uuid: ^uuid, message_id: _}, meta)
       end)
 
     if length(chunks_with_receipts) == num_chunks do
@@ -727,8 +734,8 @@ defmodule Pulsar.Producer.Worker do
   defp complete_chunked_message(from, uuid, num_chunks, chunks_with_receipts, updated_pending, state) do
     sorted_chunks =
       chunks_with_receipts
-      |> Enum.sort_by(fn {_seq_id, {_from, meta}} -> meta.chunk_id end)
-      |> Enum.map(fn {_seq_id, {_from, meta}} -> meta.message_id end)
+      |> Enum.sort_by(fn {_seq_id, {_from, meta, _sent_at}} -> meta.chunk_id end)
+      |> Enum.map(fn {_seq_id, {_from, meta, _sent_at}} -> meta.message_id end)
 
     :telemetry.execute(
       [:pulsar, :producer, :chunk, :complete],

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -596,9 +596,9 @@ defmodule Pulsar.Producer.Worker do
           Map.put(producer_metadata(state), :sequence_id, sequence_id)
         )
 
-        # Keyed on the first id, which is the one the receipt comes back on.
-        sent_at = System.monotonic_time(:millisecond)
-        new_pending = Map.put(state.pending_sends, sequence_id, {callers, nil, sent_at})
+        # Keyed on the first id, which is the one the receipt comes back on. It keeps the clock
+        # it started in the batch, or flushing would hand every message it carries a fresh one.
+        new_pending = Map.put(state.pending_sends, sequence_id, {callers, nil, state.batch_started_at})
 
         maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_sends: new_pending})
 
@@ -620,21 +620,17 @@ defmodule Pulsar.Producer.Worker do
       nil ->
         state
 
-      due_at ->
-        due_in = max(due_at - System.monotonic_time(:millisecond), 0)
+      sent_at ->
+        due_in = max(sent_at + state.send_timeout - System.monotonic_time(:millisecond), 0)
         %{state | send_timeout_timer: Process.send_after(self(), :expire_sends, due_in)}
     end
   end
 
   # A message waiting to be batched is owed an answer too, counted from when it was taken.
   defp oldest_send(%__MODULE__{} = state) do
-    published = for {_sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends, do: sent_at
-    batched = List.wrap(state.batch_started_at)
+    sent_ats = for {_sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends, do: sent_at
 
-    case Enum.min(published ++ batched, fn -> nil end) do
-      nil -> nil
-      oldest -> oldest + state.send_timeout
-    end
+    Enum.min(sent_ats ++ List.wrap(state.batch_started_at), fn -> nil end)
   end
 
   defp expire_due_sends(%__MODULE__{} = state) do
@@ -648,20 +644,18 @@ defmodule Pulsar.Producer.Worker do
     due
     |> Enum.sort()
     |> Enum.reduce(state, &expire_send/2)
-    |> expire_due_batch()
+    |> expire_due_batch(cutoff)
   end
 
-  defp expire_due_batch(%__MODULE__{batch_started_at: nil} = state), do: state
+  defp expire_due_batch(%__MODULE__{batch_started_at: nil} = state, _cutoff), do: state
 
-  defp expire_due_batch(%__MODULE__{} = state) do
-    if state.batch_started_at + state.send_timeout <= System.monotonic_time(:millisecond) do
-      callers = Enum.map(state.batch, fn {_message, from} -> from end)
-      report_send_timeout(length(callers), :batched, state)
+  defp expire_due_batch(%__MODULE__{batch_started_at: started_at} = state, cutoff) when started_at > cutoff, do: state
 
-      answer(%{state | batch: [], batched: 0, batch_started_at: nil}, callers, {:error, :send_timeout})
-    else
-      state
-    end
+  defp expire_due_batch(%__MODULE__{} = state, _cutoff) do
+    callers = Enum.map(state.batch, fn {_message, from} -> from end)
+    report_batch_timeout(length(callers), state)
+
+    answer(%{state | batch: [], batched: 0, batch_started_at: nil}, callers, {:error, :send_timeout})
   end
 
   defp expire_send(sequence_id, state) do
@@ -686,6 +680,20 @@ defmodule Pulsar.Producer.Worker do
       [:pulsar, :producer, :send, :timeout],
       %{count: count},
       Map.put(producer_metadata(state), :sequence_id, sequence_id)
+    )
+  end
+
+  # These never reached the broker, so there is no sequence id to name them by.
+  defp report_batch_timeout(count, state) do
+    Logger.warning(
+      "#{count} message(s) on #{state.topic} were still waiting to be batched after " <>
+        "#{state.send_timeout}ms, failing their callers"
+    )
+
+    :telemetry.execute(
+      [:pulsar, :producer, :send, :timeout],
+      %{count: count},
+      producer_metadata(state)
     )
   end
 

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -46,7 +46,7 @@ defmodule Pulsar.Producer.Worker do
     :broker_pid,
     :broker_monitor,
     {:sequence_id, 0},
-    {:pending_sends, %{}},
+    {:pending_frames, %{}},
     {:pending_messages, 0},
     :send_timeout,
     :send_timeout_timer,
@@ -80,7 +80,7 @@ defmodule Pulsar.Producer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           sequence_id: integer(),
-          pending_sends: %{integer() => {[GenServer.from()], map() | nil, integer()}},
+          pending_frames: %{integer() => {[GenServer.from()], map() | nil, integer()}},
           pending_messages: non_neg_integer(),
           send_timeout: pos_integer() | false | nil,
           send_timeout_timer: reference() | nil,
@@ -276,13 +276,13 @@ defmodule Pulsar.Producer.Worker do
   # Answers everyone a pending send owes and stops tracking it. A chunk takes the rest of its
   # message with it: nothing can complete it now.
   defp resolve_send(%__MODULE__{} = state, sequence_id, reply) do
-    case Map.pop(state.pending_sends, sequence_id) do
+    case Map.pop(state.pending_frames, sequence_id) do
       {nil, _pending} ->
         :error
 
       {{callers, metadata, _sent_at}, pending} ->
         pending = drop_chunks_of(pending, metadata)
-        {:ok, callers, answer(%{state | pending_sends: pending}, callers, reply)}
+        {:ok, callers, answer(%{state | pending_frames: pending}, callers, reply)}
     end
   end
 
@@ -357,8 +357,8 @@ defmodule Pulsar.Producer.Worker do
           :ok ->
             emit_message_sent(chunk_metadata, chunk_payload, sequence_id, acc_state)
 
-            new_pending = Map.put(acc_state.pending_sends, sequence_id, {[from], chunk_metadata, sent_at})
-            new_state = %{acc_state | sequence_id: sequence_id, pending_sends: new_pending}
+            new_pending = Map.put(acc_state.pending_frames, sequence_id, {[from], chunk_metadata, sent_at})
+            new_state = %{acc_state | sequence_id: sequence_id, pending_frames: new_pending}
             {:cont, {:ok, new_state}}
 
           {:error, reason} ->
@@ -374,7 +374,7 @@ defmodule Pulsar.Producer.Worker do
       # broker's deduplication reads as repeats. The pending entries do go: a message missing
       # chunks can never complete, and its caller already has an error.
       {:error, reason, acc_state} ->
-        {:reply, {:error, reason}, %{acc_state | pending_sends: state.pending_sends}}
+        {:reply, {:error, reason}, %{acc_state | pending_frames: state.pending_frames}}
     end
   end
 
@@ -423,13 +423,13 @@ defmodule Pulsar.Producer.Worker do
   @impl true
   def handle_info({:send_receipt, %Binary.CommandSendReceipt{} = receipt}, state) do
     new_state =
-      case Map.pop(state.pending_sends, receipt.sequence_id) do
+      case Map.pop(state.pending_frames, receipt.sequence_id) do
         # A chunk resolves nothing on its own: the message is owed the rest of its receipts.
         {{callers, %{uuid: _} = chunk_metadata, sent_at}, new_pending} ->
           handle_chunk_receipt(receipt, callers, chunk_metadata, sent_at, new_pending, state)
 
         {{callers, _metadata, _sent_at}, new_pending} ->
-          answer(%{state | pending_sends: new_pending}, callers, {:ok, receipt.message_id})
+          answer(%{state | pending_frames: new_pending}, callers, {:ok, receipt.message_id})
 
         # A chunk of a message that was given up on, which a partial send and a discarded chunk
         # both leave behind: the entry is gone, but what reached the broker is still answered.
@@ -598,9 +598,9 @@ defmodule Pulsar.Producer.Worker do
 
         # Keyed on the first id, which is the one the receipt comes back on. It keeps the clock
         # it started in the batch, or flushing would hand every message it carries a fresh one.
-        new_pending = Map.put(state.pending_sends, sequence_id, {callers, nil, state.batch_started_at})
+        new_pending = Map.put(state.pending_frames, sequence_id, {callers, nil, state.batch_started_at})
 
-        maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_sends: new_pending})
+        maybe_schedule_send_timeout(%{state | sequence_id: highest_sequence_id, pending_frames: new_pending})
 
       # Only this entry's callers hear about it; the ones published before it are still owed
       # their receipts.
@@ -628,7 +628,7 @@ defmodule Pulsar.Producer.Worker do
 
   # A message waiting to be batched is owed an answer too, counted from when it was taken.
   defp oldest_send(%__MODULE__{} = state) do
-    sent_ats = for {_sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends, do: sent_at
+    sent_ats = for {_sequence_id, {_callers, _metadata, sent_at}} <- state.pending_frames, do: sent_at
 
     Enum.min(sent_ats ++ List.wrap(state.batch_started_at), fn -> nil end)
   end
@@ -637,7 +637,7 @@ defmodule Pulsar.Producer.Worker do
     cutoff = System.monotonic_time(:millisecond) - state.send_timeout
 
     due =
-      for {sequence_id, {_callers, _metadata, sent_at}} <- state.pending_sends,
+      for {sequence_id, {_callers, _metadata, sent_at}} <- state.pending_frames,
           sent_at <= cutoff,
           do: sequence_id
 
@@ -683,7 +683,6 @@ defmodule Pulsar.Producer.Worker do
     )
   end
 
-  # These never reached the broker, so there is no sequence id to name them by.
   defp report_batch_timeout(count, state) do
     Logger.warning(
       "#{count} message(s) on #{state.topic} were still waiting to be batched after " <>
@@ -691,7 +690,7 @@ defmodule Pulsar.Producer.Worker do
     )
 
     :telemetry.execute(
-      [:pulsar, :producer, :send, :timeout],
+      [:pulsar, :producer, :batch, :timeout],
       %{count: count},
       producer_metadata(state)
     )
@@ -741,7 +740,7 @@ defmodule Pulsar.Producer.Worker do
     if length(chunks_with_receipts) == num_chunks do
       complete_chunked_message(callers, uuid, num_chunks, chunks_with_receipts, updated_pending, state)
     else
-      %{state | pending_sends: updated_pending}
+      %{state | pending_frames: updated_pending}
     end
   end
 
@@ -773,7 +772,7 @@ defmodule Pulsar.Producer.Worker do
       |> Enum.reject(fn {seq_id, _} -> seq_id in chunk_seq_ids end)
       |> Map.new()
 
-    %{state | pending_sends: final_pending}
+    %{state | pending_frames: final_pending}
   end
 
   defp register_with_broker(state, broker_pid) do

--- a/test/integration/producer/deduplication_test.exs
+++ b/test/integration/producer/deduplication_test.exs
@@ -84,7 +84,7 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
 
       # Four chunks over ids 2..5, the first two of them at or below the mark.
       assert {:ok, %{num_chunks: 4}} = Pulsar.Producer.send(producer, String.duplicate("x", 128))
-      assert worker_state(producer).pending_sends == %{}
+      assert worker_state(producer).pending_frames == %{}
 
       # The same id, unchunked, is discarded -- so it is is_chunk that exempts them.
       :sys.replace_state(worker, &%{&1 | sequence_id: 1})

--- a/test/support/producer_state.ex
+++ b/test/support/producer_state.ex
@@ -1,0 +1,46 @@
+defmodule Pulsar.Test.Support.ProducerState do
+  @moduledoc """
+  A producer worker's state, for tests that drive `Pulsar.Producer.Worker` directly rather than
+  through a supervised producer.
+
+  The defaults describe a ready producer that batches nothing and chunks nothing, so a test only
+  overrides what it is about:
+
+      ProducerState.new(broker, batch_enabled: true, batch_size: 10)
+
+  Its topic and producer name are unique per call, so tests running together cannot be taken for
+  one another in a log line or a telemetry event. A test that asserts on either passes its own.
+  """
+
+  alias Pulsar.Producer.Worker
+
+  @spec new(pid(), keyword() | map()) :: Worker.t()
+  def new(broker, overrides \\ []) do
+    struct(Worker, Map.merge(defaults(broker), Map.new(overrides)))
+  end
+
+  defp defaults(broker) do
+    unique = System.unique_integer([:positive])
+    topic = "persistent://public/default/producer-state-#{unique}"
+
+    %{
+      topic: topic,
+      base_topic: topic,
+      producer_id: unique,
+      producer_name: "producer-#{unique}",
+      broker_pid: broker,
+      ready: true,
+      compression: :none,
+      chunking_enabled: false,
+      max_message_size: 5_242_880,
+      broker_max_message_size: 5_242_880,
+      batch_enabled: false,
+      batch_size: 100,
+      batch_builder: :default,
+      # Long enough that nothing flushes on a timer: these tests flush by filling the batch.
+      flush_interval: 30_000,
+      send_timeout: 30_000,
+      max_pending_messages: 1000
+    }
+  end
+end

--- a/test/unit/producer_batch_test.exs
+++ b/test/unit/producer_batch_test.exs
@@ -7,13 +7,14 @@ defmodule Pulsar.Producer.BatchTest do
   alias Pulsar.Producer.Worker
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
   alias Pulsar.Test.Support.BrokerStub
+  alias Pulsar.Test.Support.ProducerState
 
   @at_time 1_900_000_000_000
 
   setup do
     broker = start_supervised!({BrokerStub, self()})
 
-    %{state: producer_state(broker)}
+    %{state: ProducerState.new(broker, batch_enabled: true, batch_size: 10)}
   end
 
   describe "the entry a batch is published as" do
@@ -267,23 +268,5 @@ defmodule Pulsar.Producer.BatchTest do
     <<payload::bytes-size(^payload_size), tail::binary>> = rest
 
     messages_in_batch(tail, [{single.partition_key, payload} | acc])
-  end
-
-  defp producer_state(broker) do
-    struct(Worker, %{
-      topic: "persistent://public/default/orders",
-      base_topic: "persistent://public/default/orders",
-      producer_id: 1,
-      producer_name: "orders-api",
-      broker_pid: broker,
-      ready: true,
-      compression: :none,
-      chunking_enabled: false,
-      max_message_size: 5_242_880,
-      batch_enabled: true,
-      batch_size: 10,
-      batch_builder: :default,
-      flush_interval: 30_000
-    })
   end
 end

--- a/test/unit/producer_batch_test.exs
+++ b/test/unit/producer_batch_test.exs
@@ -147,7 +147,7 @@ defmodule Pulsar.Producer.BatchTest do
 
       # Ids 1 and 2 went to the entry that landed; the refused one claimed none.
       assert state.sequence_id == 2
-      assert map_size(state.pending_sends) == 1
+      assert map_size(state.pending_frames) == 1
 
       # Only "b" hears about it. The others are still waiting on the receipt for their entry.
       [{_, a_ref}, {_, b_ref}, _] = froms
@@ -165,7 +165,7 @@ defmodule Pulsar.Producer.BatchTest do
       assert [entry] = published()
       assert entry.command.sequence_id == 1
       assert state.sequence_id == 1
-      assert map_size(state.pending_sends) == 1
+      assert map_size(state.pending_frames) == 1
     end
   end
 

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -19,13 +19,13 @@ defmodule Pulsar.Producer.SendTest do
     test "answers its caller and stops tracking it", ctx do
       {from, state} = send_message(ctx.state, "a")
 
-      assert map_size(state.pending_sends) == 1
+      assert map_size(state.pending_frames) == 1
       assert [_frame] = published()
 
       state = expire(state)
 
       assert_replied(from, {:error, :send_timeout})
-      assert state.pending_sends == %{}
+      assert state.pending_frames == %{}
     end
 
     test "answers every caller of a batch it carried", ctx do
@@ -38,7 +38,7 @@ defmodule Pulsar.Producer.SendTest do
 
       assert_replied(first, {:error, :send_timeout})
       assert_replied(second, {:error, :send_timeout})
-      assert state.pending_sends == %{}
+      assert state.pending_frames == %{}
       assert state.pending_messages == 0
     end
 
@@ -46,12 +46,12 @@ defmodule Pulsar.Producer.SendTest do
       state = %{ctx.state | chunking_enabled: true, max_message_size: 8}
 
       {from, state} = send_message(state, String.duplicate("x", 24))
-      assert map_size(state.pending_sends) == 3
+      assert map_size(state.pending_frames) == 3
 
       state = expire(state)
 
       assert_replied(from, {:error, :send_timeout})
-      assert state.pending_sends == %{}
+      assert state.pending_frames == %{}
 
       # Three frames, one caller: the count lands back on nothing owed.
       assert state.pending_messages == 0
@@ -59,7 +59,7 @@ defmodule Pulsar.Producer.SendTest do
 
     test "leaves an already answered send alone", ctx do
       {from, state} = send_message(ctx.state, "a")
-      [sequence_id] = Map.keys(state.pending_sends)
+      [sequence_id] = Map.keys(state.pending_frames)
 
       receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
       {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
@@ -69,7 +69,7 @@ defmodule Pulsar.Producer.SendTest do
       state = expire(state)
 
       refute_received {_ref, {:error, :send_timeout}}
-      assert state.pending_sends == %{}
+      assert state.pending_frames == %{}
     end
 
     test "spares a send that has not been waiting long enough", ctx do
@@ -83,7 +83,7 @@ defmodule Pulsar.Producer.SendTest do
 
       assert_replied(first, {:error, :send_timeout})
       refute_received {_ref, {:error, :send_timeout}}
-      assert map_size(state.pending_sends) == 1
+      assert map_size(state.pending_frames) == 1
       refute is_nil(state.send_timeout_timer), "re-aimed at the send it is still carrying"
     end
 
@@ -95,7 +95,7 @@ defmodule Pulsar.Producer.SendTest do
       {_from, state} = send_message(state, "c")
 
       assert state.send_timeout_timer == armed
-      assert map_size(state.pending_sends) == 3
+      assert map_size(state.pending_frames) == 3
     end
 
     test "answers a caller still waiting to be batched", ctx do
@@ -114,6 +114,31 @@ defmodule Pulsar.Producer.SendTest do
       assert state.pending_messages == 0
     end
 
+    test "spares a batch that has not been waiting long enough", ctx do
+      state = %{ctx.state | batch_enabled: true, batch_size: 100, flush_interval: 30_000}
+
+      {_from, state} = send_message(state, "a")
+      {:noreply, state} = Worker.handle_info(:expire_sends, state)
+
+      refute_received {_ref, {:error, :send_timeout}}
+      assert state.batched == 1
+      assert state.batch_started_at
+    end
+
+    test "hands a flushed batch the clock it started on, not a fresh one", ctx do
+      state = %{ctx.state | batch_enabled: true, batch_size: 2}
+
+      {_first, state} = send_message(state, "a")
+
+      # As if the first message had been sitting in the batch for a second.
+      started_at = state.batch_started_at - 1_000
+      {_second, state} = send_message(%{state | batch_started_at: started_at}, "b")
+
+      assert [{_sequence_id, {_callers, _metadata, sent_at}}] = Map.to_list(state.pending_frames)
+      assert sent_at == started_at
+      assert is_nil(state.batch_started_at)
+    end
+
     test "schedules nothing when the timeout is off", ctx do
       {_from, state} = send_message(%{ctx.state | send_timeout: false}, "a")
 
@@ -127,12 +152,12 @@ defmodule Pulsar.Producer.SendTest do
       state = %{ctx.state | chunking_enabled: true, max_message_size: 8}
 
       {from, state} = send_message(state, String.duplicate("x", 24))
-      assert map_size(state.pending_sends) == 3
+      assert map_size(state.pending_frames) == 3
 
       state = reject_oldest(state)
 
       assert_replied(from, {:error, {:PersistenceError, "storage down"}})
-      assert state.pending_sends == %{}
+      assert state.pending_frames == %{}
 
       # Same again: three frames, one caller.
       assert state.pending_messages == 0
@@ -178,7 +203,7 @@ defmodule Pulsar.Producer.SendTest do
       state = %{ctx.state | max_pending_messages: 1}
 
       {_from, state} = send_message(state, "a")
-      [sequence_id] = Map.keys(state.pending_sends)
+      [sequence_id] = Map.keys(state.pending_frames)
 
       receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
       {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
@@ -192,7 +217,7 @@ defmodule Pulsar.Producer.SendTest do
 
       {_from, state} = send_message(state, String.duplicate("x", 40))
 
-      assert map_size(state.pending_sends) == 5, "five frames"
+      assert map_size(state.pending_frames) == 5, "five frames"
       assert state.pending_messages == 1, "one message"
 
       assert {:noreply, _state} = Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
@@ -202,7 +227,7 @@ defmodule Pulsar.Producer.SendTest do
       {from, state} = send_message(ctx.state, "a")
       assert state.pending_messages == 1
 
-      [sequence_id] = Map.keys(state.pending_sends)
+      [sequence_id] = Map.keys(state.pending_frames)
       receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
       {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
 
@@ -225,7 +250,7 @@ defmodule Pulsar.Producer.SendTest do
 
       state = Enum.reduce(1..20, state, fn i, acc -> elem(send_message(acc, "msg-#{i}"), 1) end)
 
-      assert map_size(state.pending_sends) == 20
+      assert map_size(state.pending_frames) == 20
     end
   end
 
@@ -239,7 +264,7 @@ defmodule Pulsar.Producer.SendTest do
   end
 
   defp reject_oldest(state) do
-    [sequence_id | _] = Enum.sort(Map.keys(state.pending_sends))
+    [sequence_id | _] = Enum.sort(Map.keys(state.pending_frames))
     error = %Binary.CommandSendError{sequence_id: sequence_id, error: :PersistenceError, message: "storage down"}
     {:noreply, new_state} = Worker.handle_info({:send_error, error}, state)
 

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -1,0 +1,210 @@
+defmodule Pulsar.Producer.SendTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  import Pulsar.Test.Support.BrokerStub, only: [published: 0]
+
+  alias Pulsar.Producer.Worker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+  alias Pulsar.Test.Support.BrokerStub
+  alias Pulsar.Test.Support.ProducerState
+
+  setup do
+    broker = start_supervised!({BrokerStub, self()})
+
+    %{state: ProducerState.new(broker, send_timeout: 50)}
+  end
+
+  describe "a send the broker never acknowledges" do
+    test "answers its caller and stops tracking it", ctx do
+      {from, state} = send_message(ctx.state, "a")
+
+      assert map_size(state.pending_sends) == 1
+      assert [_frame] = published()
+
+      state = expire(state)
+
+      assert_replied(from, {:error, :send_timeout})
+      assert state.pending_sends == %{}
+    end
+
+    test "answers every caller of a batch it carried", ctx do
+      state = %{ctx.state | batch_enabled: true, batch_size: 2}
+
+      {first, state} = send_message(state, "a")
+      {second, state} = send_message(state, "b")
+
+      state = expire(state)
+
+      assert_replied(first, {:error, :send_timeout})
+      assert_replied(second, {:error, :send_timeout})
+      assert state.pending_sends == %{}
+      assert state.pending_messages == 0
+    end
+
+    test "drops the rest of a chunked message with it", ctx do
+      state = %{ctx.state | chunking_enabled: true, max_message_size: 8}
+
+      {from, state} = send_message(state, String.duplicate("x", 24))
+      assert map_size(state.pending_sends) == 3
+
+      state = expire(state)
+
+      assert_replied(from, {:error, :send_timeout})
+      assert state.pending_sends == %{}
+
+      # Three frames, one caller: the count lands back on nothing owed.
+      assert state.pending_messages == 0
+    end
+
+    test "leaves an already answered send alone", ctx do
+      {from, state} = send_message(ctx.state, "a")
+      [sequence_id] = Map.keys(state.pending_sends)
+
+      receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
+      {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
+      assert_replied(from, {:ok, message_id()})
+
+      # The timer still comes due; by then it is carrying nothing.
+      state = expire(state)
+
+      refute_received {_ref, {:error, :send_timeout}}
+      assert state.pending_sends == %{}
+    end
+
+    test "spares a send that has not been waiting long enough", ctx do
+      {first, state} = send_message(ctx.state, "a")
+
+      # Only the first is old enough once the timer comes due.
+      Process.sleep(60)
+      {second, state} = send_message(%{state | send_timeout: 5_000}, "b")
+
+      {:noreply, state} = Worker.handle_info(:expire_sends, %{state | send_timeout: 50})
+
+      assert_replied(first, {:error, :send_timeout})
+      refute_received {_ref, {:error, :send_timeout}}
+      assert map_size(state.pending_sends) == 1
+      refute is_nil(state.send_timeout_timer), "re-aimed at the send it is still carrying"
+      assert {_pid, _ref} = second
+    end
+
+    test "arms one timer for the producer, not one per send", ctx do
+      {_from, state} = send_message(ctx.state, "a")
+      armed = state.send_timeout_timer
+
+      {_from, state} = send_message(state, "b")
+      {_from, state} = send_message(state, "c")
+
+      assert state.send_timeout_timer == armed
+      assert map_size(state.pending_sends) == 3
+    end
+
+    test "schedules nothing when the timeout is off", ctx do
+      {_from, state} = send_message(%{ctx.state | send_timeout: false}, "a")
+
+      assert is_nil(state.send_timeout_timer)
+      refute_received :expire_sends
+    end
+  end
+
+  describe "a producer carrying its limit of sends" do
+    test "refuses another rather than queueing it", ctx do
+      state = %{ctx.state | max_pending_messages: 1}
+
+      {_from, state} = send_message(state, "a")
+
+      assert {:reply, {:error, :producer_queue_full}, ^state} =
+               Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+    end
+
+    test "counts messages waiting to be batched", ctx do
+      state = %{ctx.state | batch_enabled: true, batch_size: 10, max_pending_messages: 2}
+
+      {_from, state} = send_message(state, "a")
+      {_from, state} = send_message(state, "b")
+
+      assert state.batched == 2
+      assert [] == published(), "neither has been published yet"
+
+      assert {:reply, {:error, :producer_queue_full}, _state} =
+               Worker.handle_call({:send_message, "c", []}, {self(), make_ref()}, state)
+    end
+
+    test "accepts again once a send is acknowledged", ctx do
+      state = %{ctx.state | max_pending_messages: 1}
+
+      {_from, state} = send_message(state, "a")
+      [sequence_id] = Map.keys(state.pending_sends)
+
+      receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
+      {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
+
+      assert {:noreply, _state} = Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+    end
+
+    # Counting frames took a producer past its limit on one large message.
+    test "counts a chunked message once, however many frames carry it", ctx do
+      state = %{ctx.state | chunking_enabled: true, max_message_size: 8, max_pending_messages: 2}
+
+      {_from, state} = send_message(state, String.duplicate("x", 40))
+
+      assert map_size(state.pending_sends) == 5, "five frames"
+      assert state.pending_messages == 1, "one message"
+
+      assert {:noreply, _state} = Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+    end
+
+    test "lets a send go again once its caller has been answered", ctx do
+      {from, state} = send_message(ctx.state, "a")
+      assert state.pending_messages == 1
+
+      [sequence_id] = Map.keys(state.pending_sends)
+      receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
+      {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
+
+      assert_replied(from, {:ok, message_id()})
+      assert state.pending_messages == 0
+    end
+
+    test "does not count a send it refused outright", ctx do
+      # Nothing is published, so nothing waits: the caller already has its error.
+      state = %{ctx.state | chunking_enabled: true, max_message_size: 0, broker_max_message_size: 0}
+
+      assert {:reply, {:error, :metadata_too_large}, state} =
+               Worker.handle_call({:send_message, "a", []}, {self(), make_ref()}, state)
+
+      assert state.pending_messages == 0
+    end
+
+    test "carries as many as it likes when the limit is off", ctx do
+      state = %{ctx.state | max_pending_messages: false}
+
+      state = Enum.reduce(1..20, state, fn i, acc -> elem(send_message(acc, "msg-#{i}"), 1) end)
+
+      assert map_size(state.pending_sends) == 20
+    end
+  end
+
+  ## Helpers
+
+  defp send_message(state, payload) do
+    from = {self(), make_ref()}
+    {:noreply, new_state} = Worker.handle_call({:send_message, payload, []}, from, state)
+
+    {from, new_state}
+  end
+
+  # Waits for the producer's timer to come due, then hands it back as the producer would get it.
+  defp expire(state) do
+    assert_receive :expire_sends, 500
+    {:noreply, new_state} = Worker.handle_info(:expire_sends, state)
+
+    new_state
+  end
+
+  defp assert_replied({_pid, ref}, reply) do
+    assert_received {^ref, ^reply}
+  end
+
+  defp message_id, do: %Binary.MessageIdData{ledgerId: 7, entryId: 42, partition: -1}
+end

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -107,6 +107,35 @@ defmodule Pulsar.Producer.SendTest do
     end
   end
 
+  describe "a send the broker rejects" do
+    test "drops the rest of a chunked message with it", ctx do
+      state = %{ctx.state | chunking_enabled: true, max_message_size: 8}
+
+      {from, state} = send_message(state, String.duplicate("x", 24))
+      assert map_size(state.pending_sends) == 3
+
+      state = reject_oldest(state)
+
+      assert_replied(from, {:error, {:PersistenceError, "storage down"}})
+      assert state.pending_sends == %{}
+
+      # Three frames, one caller: the count lands back on nothing owed.
+      assert state.pending_messages == 0
+    end
+
+    # Chunks left behind expired later, answering a caller that already had its error.
+    test "answers its caller once, and not again when the timer comes due", ctx do
+      state = %{ctx.state | chunking_enabled: true, max_message_size: 8}
+
+      {from, state} = send_message(state, String.duplicate("x", 24))
+      state = state |> reject_oldest() |> expire()
+
+      assert_replied(from, {:error, {:PersistenceError, "storage down"}})
+      refute_received {_ref, {:error, :send_timeout}}
+      assert state.pending_messages == 0
+    end
+  end
+
   describe "a producer carrying its limit of sends" do
     test "refuses another rather than queueing it", ctx do
       state = %{ctx.state | max_pending_messages: 1}
@@ -192,6 +221,14 @@ defmodule Pulsar.Producer.SendTest do
     {:noreply, new_state} = Worker.handle_call({:send_message, payload, []}, from, state)
 
     {from, new_state}
+  end
+
+  defp reject_oldest(state) do
+    [sequence_id | _] = Enum.sort(Map.keys(state.pending_sends))
+    error = %Binary.CommandSendError{sequence_id: sequence_id, error: :PersistenceError, message: "storage down"}
+    {:noreply, new_state} = Worker.handle_info({:send_error, error}, state)
+
+    new_state
   end
 
   # Waits for the producer's timer to come due, then hands it back as the producer would get it.

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -98,6 +98,22 @@ defmodule Pulsar.Producer.SendTest do
       assert map_size(state.pending_sends) == 3
     end
 
+    test "answers a caller still waiting to be batched", ctx do
+      state = %{ctx.state | batch_enabled: true, batch_size: 100, flush_interval: 30_000}
+
+      {from, state} = send_message(state, "a")
+
+      assert state.batched == 1
+      assert [] == published(), "nothing was published: it is waiting for a flush"
+
+      state = expire(state)
+
+      assert_replied(from, {:error, :send_timeout})
+      assert state.batch == []
+      assert state.batch_started_at == nil
+      assert state.pending_messages == 0
+    end
+
     test "schedules nothing when the timeout is off", ctx do
       {_from, state} = send_message(%{ctx.state | send_timeout: false}, "a")
 
@@ -118,7 +134,7 @@ defmodule Pulsar.Producer.SendTest do
       assert_replied(from, {:error, {:PersistenceError, "storage down"}})
       assert state.pending_sends == %{}
 
-      # Three frames, one caller: the count lands back on nothing owed.
+      # Same again: three frames, one caller.
       assert state.pending_messages == 0
     end
 

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -77,15 +77,14 @@ defmodule Pulsar.Producer.SendTest do
 
       # Only the first is old enough once the timer comes due.
       Process.sleep(60)
-      {second, state} = send_message(%{state | send_timeout: 5_000}, "b")
+      {_second, state} = send_message(state, "b")
 
-      {:noreply, state} = Worker.handle_info(:expire_sends, %{state | send_timeout: 50})
+      {:noreply, state} = Worker.handle_info(:expire_sends, state)
 
       assert_replied(first, {:error, :send_timeout})
       refute_received {_ref, {:error, :send_timeout}}
       assert map_size(state.pending_sends) == 1
       refute is_nil(state.send_timeout_timer), "re-aimed at the send it is still carrying"
-      assert {_pid, _ref} = second
     end
 
     test "arms one timer for the producer, not one per send", ctx do


### PR DESCRIPTION
## Summary

A send the broker never acknowledged was never given up on. Its entry stayed in `pending_frames` for the life of the producer, and nothing bounded how many could accumulate — the caller's own `GenServer.call` timeout was the only deadline anywhere in the system.

`:send_timeout` gives the producer that deadline, and `:max_pending_messages` bounds what it will carry. Both default to what the Java and Go clients use.

## Motivation

`Pulsar.Producer.send/3` parks its caller and answers when the broker's receipt arrives. Nothing else ends that wait. If a receipt never came — the frame lost, the broker slow, the connection quietly wedged — then:

- the caller waited out its `GenServer.call` timeout and **exited**, rather than being answered;
- the entry it left in `pending_frames` was never removed, since only a receipt or a send error removes one;
- nothing capped how many such entries a producer could hold.

The caller-side timeout masked the first of these and did nothing about the other two. It is also the wrong place for the deadline: the producer knows the send is outstanding, the caller only knows it is waiting.

## `:send_timeout`

Default `30_000`, matching Java's `sendTimeoutMs` and Go's `SendTimeout`. `false` disables it, as `0` does in Java and `-1` in Go.

An expired send answers its caller `{:error, :send_timeout}` and stops being tracked. A batch answers every caller it carried. A chunk that never lands takes the rest of its message with it, since nothing can reassemble it — the same cascade a deduplicated chunk already triggered.

**One timer, not one per send.** Every send shares the same timeout, so the oldest is always the next to expire: a single timer is aimed at it and re-aimed once it has fired. A timer per publish would have been simpler to write, but timers outlive the sends they guard, so live timers would scale with throughput × timeout — roughly 300k of them for a healthy producer at 10k msg/s — rather than being one. Java does the same thing for the same reason, rescheduling a single `Timeout` from `pendingMessages.peek()`.

**Counted from when the producer takes a message, not when it reaches the broker.** A message waiting to be batched is owed an answer as much as a published one, so the clock starts in `add_to_batch/4`, and a flushed entry carries the clock it started on rather than a fresh one — otherwise `:flush_interval` would silently extend every caller's deadline by up to its own length. A batch that comes due before it is ever flushed answers its callers and is dropped.

A batch expires as a unit, so a message added moments before the deadline goes with the one that started it, and a flushed entry carries the first message's clock. Both err towards answering early, bounded by `:flush_interval` — which the option now tells you to keep well below `:send_timeout`.

## `:max_pending_messages`

Default `1000`, as in Java and Go. Once that many sends are outstanding, further ones are refused with `{:error, :producer_queue_full}` rather than queued. Java's `blockIfQueueFull` defaults to `false` and behaves the same way; Go blocks by default instead.

It counts **sends**, not frames: a chunked message counts once however many frames carry it, and a batch counts each message it holds. Counting frames would have made a single 100-chunk message take a producer 99 past its limit before anything was checked again.

Keeping that count honest meant funnelling every place that answered a caller — receipts, send errors, deduplication, timeouts, batch failures — through one `answer/3`. That is the only decrement, so the count cannot drift from the truth. `terminate/2` is the deliberate exception, having no state left to keep.

Three of those places turned out to be the same function written out three times: a send error, a deduplicated receipt and a timeout all cascade a chunk's siblings, answer its callers, and stop tracking it. They share one `resolve_send/3`, differing only in the reply. Only a receipt is genuinely different, because a chunk receipt resolves nothing on its own — it accumulates until the last one lands. Collapsing them also removed the `%{batch: true}` marker: with callers always stored as a list, a batch and a single send are the same case.

## Behaviour changes

**`send/3` waits on `:send_timeout` rather than the 5 second `GenServer.call` default.** The call timeout is now `:infinity`, because a call that gave up first would leave the caller with an exit instead of the `{:error, :send_timeout}` the producer was about to answer with — which is exactly what would have happened with the 5s default against a 30s send timeout, making the new error unreachable.

So a failing send now takes up to 30 seconds and reports an error tuple, where it previously exited after 5. Callers that want a shorter bound pass `:timeout` themselves.

**`{:error, :send_timeout}` does not mean the message was not published.** It says nothing came back in time. A receipt arriving just after the deadline finds the send already answered. A retry publishes under a fresh sequence id, which the broker's deduplication does not match against the first attempt, so retrying after a timeout can duplicate the message.

**Disabling `:send_timeout` now removes every bound**, since the call timeout no longer supplies one. An unacknowledged send then holds its caller until the producer restarts, and holds its place in `:max_pending_messages` with it. The option documents this.

**Two telemetry events.** `[:pulsar, :producer, :send, :timeout]` names the send that expired by `:sequence_id`. A batch that came due before it was ever published has no sequence id to name it by, so it emits `[:pulsar, :producer, :batch, :timeout]` rather than the same event with a metadata key missing.

**`pending_sends` is now `pending_frames`**, which is what it holds: one entry per `CommandSend` frame, so a batch is one and a chunked message is several. `pending_messages` counts what callers are owed. The pair now reads on the axis `:max_pending_messages` is actually defined over.

## Verification

**Nineteen tests, and the ones that matter were checked by mutation rather than by assertion.**

- Expiring everything pending instead of only what is due → `spares a send that has not been waiting long enough` fails, nothing else.
- Re-arming on every send → `arms one timer for the producer, not one per send` fails, which is the property the whole design exists for.
- Counting frames instead of sends → `counts a chunked message once, however many frames carry it` fails.
- Parking a send that failed synchronously → 5 tests fail.
- Over-counting by one in `park_send` → **6 tests** fail, so drift in either direction is caught.
- Restarting a batch's clock when it is flushed → `hands a flushed batch the clock it started on, not a fresh one` fails, 5 runs out of 5. This one is why that test sets `batch_started_at` explicitly rather than relying on two sends landing in different milliseconds, which they do not reliably do.
- Expiring a batch that is not yet due → `spares a batch that has not been waiting long enough` fails, nothing else.
- Dropping the chunk cascade from the send-error path → `answers its caller once, and not again when the timer comes due` fails: the orphaned siblings expired later and answered a caller that already had its error, decrementing a second time.

The chunked cascade and batch timeout tests assert `pending_messages` lands back on zero, which is what makes the counter's invariant enforced rather than argued.

**Suite:** 362 unit tests and 488 with integration against the broker in `docker-compose.yml`, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean.

## Tests

`Pulsar.Test.Support.ProducerState` replaces the `producer_state/1` helper both producer unit test files had copies of. It builds a real `Pulsar.Producer.Worker` struct rather than stubbing anything, hence the name. Its topic and producer name are unique per call, so tests running together cannot be taken for one another in a log line or a telemetry event.

## Follow-ups

- `send_async`. The asymmetry that makes disabling `:send_timeout` dangerous here — a blocked caller with no other deadline — does not exist in Java or Go, because both pair their blocking `send` with an async form that hands control back immediately. This is the machinery that would bound one.
- Chunk reassembly rescans all of `pending_frames` on every chunk receipt, so a 100-chunk message against a busy producer does 100 full scans. Pre-existing, and this PR is the first thing to put a ceiling on how large that map gets. Fixing it properly means a second structure keyed by `uuid`, which then needs its own expiry and cascade — its own PR.
- `:send_timeout` covers a send the producer has taken. One still sitting in the mailbox — a worker blocked in `Backoff.run/1` during registration, or in `:startup_delay_ms` — is bounded only by `:timeout`, which `send/3` now documents.

