### PR TITLE
feat(producer): async send

### DIFF
--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -225,9 +225,10 @@ defmodule Pulsar.Producer do
 
   A producer that goes down before answering is reported as `{:error, {:producer_died, reason}}`.
 
-  The default is `:infinity`; when the producer's `:send_timeout` is disabled, this can wait
-  indefinitely. A finite timeout abandons the wait without cancelling the send: the message may
-  still be published, and its answer remains unread in the caller's mailbox.
+  Each reference can be awaited once. The default timeout is `:infinity`; when the producer's
+  `:send_timeout` is disabled, this can wait indefinitely. A finite timeout abandons the wait
+  without cancelling the send, so the message may still be published. It also consumes the
+  reference: a late answer is dropped and cannot be recovered by calling `await/2` again.
   """
   @spec await(reference(), timeout()) :: {:ok, send_result()} | {:error, term()}
   def await(ref, timeout \\ :infinity) when is_reference(ref) do

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -198,8 +198,9 @@ defmodule Pulsar.Producer do
   Errors that `send/3` returns are delivered to `await/2` instead, so nothing is lost by not
   waiting — but a reference that is never awaited leaves its answer unread in the mailbox.
 
-  Whether a producer will take the message at all is answered here: a full one refuses with
-  `{:error, :producer_queue_full}` rather than handing back a reference.
+  It answers `{:error, reason}` here only when there is no worker to hand the message to, such as
+  a producer still discovering its topology. What the producer itself decides, a full queue
+  included, reaches `await/2`.
   """
   @spec send_async(pid() | String.t() | atom(), binary(), keyword()) ::
           {:ok, reference()} | {:error, term()}
@@ -219,8 +220,7 @@ defmodule Pulsar.Producer do
   @doc """
   Waits for a send started by `send_async/3`, answering as `send/3` would have.
 
-  A producer that goes down before answering is reported as `{:error, {:producer_died, reason}}`,
-  the same shape `send/3` reports it under.
+  A producer that goes down before answering is reported as `{:error, {:producer_died, reason}}`.
 
   `:send_timeout` already bounds how long a producer holds a send, so the default here is to wait
   for it. A timeout given instead abandons the wait without cancelling the send: the message may

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -160,10 +160,10 @@ defmodule Pulsar.Producer do
   - `:event_time` - the message's event time, in milliseconds
   - `:deliver_at_time` / `:deliver_after` - delayed delivery. The broker delays whole entries, so
     a delayed message is published on its own rather than joining a batch
-  - `:timeout` - how long to wait for the call itself, in milliseconds. Defaults to `:infinity`,
-    leaving `:send_timeout` as the deadline. `:send_timeout` is counted from when the producer
-    takes the message, so a producer that has not finished registering has not started it: this
-    is what bounds that wait
+  - `:timeout` - how long to wait, in milliseconds, answering `{:error, :timeout}` if it passes.
+    Defaults to `:infinity`, leaving `:send_timeout` as the deadline. `:send_timeout` is counted
+    from when the producer takes the message, so a producer that has not finished registering has
+    not started it: this is what bounds that wait. Giving up here does not cancel the send
   - `:client` - the client to resolve a producer name against
 
   ## Examples
@@ -175,12 +175,10 @@ defmodule Pulsar.Producer do
           {:ok, send_result()} | {:error, term()}
   def send(producer, message, opts \\ [])
 
-  def send(producer, message, opts) when is_pid(producer) and is_binary(message), do: publish(producer, message, opts)
-
-  def send(name, message, opts) when (is_binary(name) or is_atom(name)) and is_binary(message) do
-    case Client.lookup(:producers, name, Keyword.get(opts, :client, :default)) do
-      {:ok, pid} -> publish(pid, message, opts)
-      {:error, :not_found} = error -> error
+  def send(producer, message, opts) when is_binary(message) do
+    case send_async(producer, message, opts) do
+      {:ok, ref} -> await(ref, Keyword.get(opts, :timeout, :infinity))
+      {:error, _reason} = error -> error
     end
   end
 
@@ -274,16 +272,6 @@ defmodule Pulsar.Producer do
 
   # Resolving the partition here keeps topology knowledge in one module: the partition
   # supervisors below only build child specs.
-  defp publish(producer, message, opts) do
-    case resolve_worker(producer, opts) do
-      {:ok, worker} -> Worker.send_message(worker, message, opts)
-      {:error, _reason} = error -> error
-    end
-  catch
-    # A stale root and a worker that dies mid-send have the same public result.
-    :exit, reason -> {:error, {:producer_died, reason}}
-  end
-
   # The monitor's reference doubles as the tag the reply carries, the way `GenServer.call/3`
   # does it, so `await/2` selects on either the reply or the producer going down.
   defp publish_async(producer, message, opts) do

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -137,8 +137,7 @@ defmodule Pulsar.Producer do
   A producer already carrying `:max_pending_messages` refuses with
   `{:error, :producer_queue_full}` rather than taking on more.
 
-  Publishing to a producer from inside its own worker — a synchronous telemetry handler, say —
-  answers `{:error, :calling_self}` rather than waiting on a reply the worker cannot get to.
+  Calling `send/3` from the selected producer worker returns `{:error, :calling_self}`.
 
   `{:error, :send_timeout}` is the other shape: the broker did not acknowledge the message
   within `:send_timeout`. **It does not say the message was not published**, only that nothing
@@ -164,9 +163,10 @@ defmodule Pulsar.Producer do
   - `:deliver_at_time` / `:deliver_after` - delayed delivery. The broker delays whole entries, so
     a delayed message is published on its own rather than joining a batch
   - `:timeout` - how long to wait, in milliseconds, answering `{:error, :timeout}` if it passes.
-    Defaults to `:infinity`, leaving `:send_timeout` as the deadline. `:send_timeout` is counted
-    from when the producer takes the message, so a producer that has not finished registering has
-    not started it: this is what bounds that wait. Giving up here does not cancel the send
+    Defaults to `:infinity`. With the default producer settings, `:send_timeout` remains the
+    deadline; if `:send_timeout` is disabled, the wait can be unbounded. `:send_timeout` is counted
+    from when the producer takes the message, so it does not bound the wait for a producer that has
+    not finished registering. Giving up here does not cancel the send
   - `:client` - the client to resolve a producer name against
 
   ## Examples
@@ -187,11 +187,10 @@ defmodule Pulsar.Producer do
   end
 
   @doc """
-  Publishes without waiting for the broker, answering with a reference to await on.
+  Starts publishing without waiting for the broker and returns a reference for `await/2`.
 
-  Takes the same options as `send/3`, other than `:timeout`, which belongs to the wait rather
-  than the send. The message is published in the order it was handed over, so two sends from one
-  process to one partition keep theirs.
+  Takes the same options as `send/3`, except `:timeout`, which belongs to `await/2`. Calls from
+  one process that route to the same partition are handed to the producer in order.
 
       {:ok, first} = Pulsar.Producer.send_async(:audit, "one")
       {:ok, second} = Pulsar.Producer.send_async(:audit, "two")
@@ -199,16 +198,12 @@ defmodule Pulsar.Producer do
       {:ok, _message_id} = Pulsar.Producer.await(first)
       {:ok, _message_id} = Pulsar.Producer.await(second)
 
-  Errors that `send/3` returns are delivered to `await/2` instead, so nothing is lost by not
-  waiting — but a reference that is never awaited leaves its answer unread in the mailbox.
+  The process that calls `send_async/3` must also call `await/2`, because the reply and the
+  producer's `:DOWN` message arrive in its mailbox. If the reference is never awaited, the reply
+  remains unread there.
 
-  The reference belongs to the process that made it: the reply and the producer's `:DOWN` both
-  arrive in that mailbox, so `await/2` has to run there. Handing one to another process gives it
-  nothing to receive.
-
-  It answers `{:error, reason}` here only when there is no worker to hand the message to, such as
-  a producer still discovering its topology. What the producer itself decides, a full queue
-  included, reaches `await/2`.
+  Routing failures, such as a producer still discovering its topology, are returned immediately.
+  Once a worker accepts the send, producer errors such as a full queue are returned by `await/2`.
   """
   @spec send_async(pid() | String.t() | atom(), binary(), keyword()) ::
           {:ok, reference()} | {:error, term()}
@@ -230,9 +225,9 @@ defmodule Pulsar.Producer do
 
   A producer that goes down before answering is reported as `{:error, {:producer_died, reason}}`.
 
-  `:send_timeout` already bounds how long a producer holds a send, so the default here is to wait
-  for it. A timeout given instead abandons the wait without cancelling the send: the message may
-  still be published, and its answer stays in the mailbox unread.
+  The default is `:infinity`; when the producer's `:send_timeout` is disabled, this can wait
+  indefinitely. A finite timeout abandons the wait without cancelling the send: the message may
+  still be published, and its answer remains unread in the caller's mailbox.
   """
   @spec await(reference(), timeout()) :: {:ok, send_result()} | {:error, term()}
   def await(ref, timeout \\ :infinity) when is_reference(ref) do
@@ -280,14 +275,11 @@ defmodule Pulsar.Producer do
 
   # Resolving the partition here keeps topology knowledge in one module: the partition
   # supervisors below only build child specs.
-  # The monitor's reference doubles as the tag the reply carries, the way `GenServer.call/3`
-  # does it, so `await/2` selects on either the reply or the producer going down. It is an alias
-  # for the same reason: demonitoring deactivates it, so an answer to a wait already given up on
-  # is dropped by the runtime rather than left in the caller's mailbox.
+  # Use the monitor alias as the reply tag so `await/2` receives either the reply or `:DOWN`.
+  # Demonitoring deactivates the alias, which drops replies that arrive after a timeout.
   defp publish_async(producer, message, opts) do
     case resolve_worker(producer, opts) do
-      # A worker cannot take its own cast while it is waiting for the answer, and it is holding
-      # up its whole mailbox while it waits. `GenServer.call/3` refuses this for the same reason.
+      # Prevent `send/3` from awaiting a cast that only this worker can process.
       {:ok, worker} when worker == self() ->
         {:error, :calling_self}
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -275,8 +275,9 @@ defmodule Pulsar.Producer do
   # Resolving the partition here keeps topology knowledge in one module: the partition
   # supervisors below only build child specs.
   defp publish(producer, message, opts) do
-    with {:ok, worker} <- resolve_worker(producer, opts) do
-      Worker.send_message(worker, message, opts)
+    case resolve_worker(producer, opts) do
+      {:ok, worker} -> Worker.send_message(worker, message, opts)
+      {:error, _reason} = error -> error
     end
   catch
     # A stale root and a worker that dies mid-send have the same public result.
@@ -286,11 +287,15 @@ defmodule Pulsar.Producer do
   # The monitor's reference doubles as the tag the reply carries, the way `GenServer.call/3`
   # does it, so `await/2` selects on either the reply or the producer going down.
   defp publish_async(producer, message, opts) do
-    with {:ok, worker} <- resolve_worker(producer, opts) do
-      ref = Process.monitor(worker)
-      GenServer.cast(worker, {:send_message, message, opts, {self(), ref}})
+    case resolve_worker(producer, opts) do
+      {:ok, worker} ->
+        ref = Process.monitor(worker)
+        GenServer.cast(worker, {:send_message, message, opts, {self(), ref}})
 
-      {:ok, ref}
+        {:ok, ref}
+
+      {:error, _reason} = error ->
+        error
     end
   catch
     :exit, reason -> {:error, {:producer_died, reason}}

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -278,12 +278,14 @@ defmodule Pulsar.Producer do
   # Resolving the partition here keeps topology knowledge in one module: the partition
   # supervisors below only build child specs.
   # The monitor's reference doubles as the tag the reply carries, the way `GenServer.call/3`
-  # does it, so `await/2` selects on either the reply or the producer going down.
+  # does it, so `await/2` selects on either the reply or the producer going down. It is an alias
+  # for the same reason: demonitoring deactivates it, so an answer to a wait already given up on
+  # is dropped by the runtime rather than left in the caller's mailbox.
   defp publish_async(producer, message, opts) do
     case resolve_worker(producer, opts) do
       {:ok, worker} ->
-        ref = Process.monitor(worker)
-        GenServer.cast(worker, {:send_message, message, opts, {self(), ref}})
+        ref = Process.monitor(worker, alias: :demonitor)
+        GenServer.cast(worker, {:send_message, message, opts, {ref, ref}})
 
         {:ok, ref}
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -137,6 +137,9 @@ defmodule Pulsar.Producer do
   A producer already carrying `:max_pending_messages` refuses with
   `{:error, :producer_queue_full}` rather than taking on more.
 
+  Publishing to a producer from inside its own worker — a synchronous telemetry handler, say —
+  answers `{:error, :calling_self}` rather than waiting on a reply the worker cannot get to.
+
   `{:error, :send_timeout}` is the other shape: the broker did not acknowledge the message
   within `:send_timeout`. **It does not say the message was not published**, only that nothing
   came back in time. A retry publishes under a fresh sequence id, which the broker's
@@ -283,6 +286,11 @@ defmodule Pulsar.Producer do
   # is dropped by the runtime rather than left in the caller's mailbox.
   defp publish_async(producer, message, opts) do
     case resolve_worker(producer, opts) do
+      # A worker cannot take its own cast while it is waiting for the answer, and it is holding
+      # up its whole mailbox while it waits. `GenServer.call/3` refuses this for the same reason.
+      {:ok, worker} when worker == self() ->
+        {:error, :calling_self}
+
       {:ok, worker} ->
         ref = Process.monitor(worker, alias: :demonitor)
         GenServer.cast(worker, {:send_message, message, opts, {ref, ref}})

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -175,7 +175,8 @@ defmodule Pulsar.Producer do
           {:ok, send_result()} | {:error, term()}
   def send(producer, message, opts \\ [])
 
-  def send(producer, message, opts) when is_binary(message) do
+  def send(producer, message, opts)
+      when (is_pid(producer) or is_binary(producer) or is_atom(producer)) and is_binary(message) do
     case send_async(producer, message, opts) do
       {:ok, ref} -> await(ref, Keyword.get(opts, :timeout, :infinity))
       {:error, _reason} = error -> error
@@ -197,6 +198,10 @@ defmodule Pulsar.Producer do
 
   Errors that `send/3` returns are delivered to `await/2` instead, so nothing is lost by not
   waiting — but a reference that is never awaited leaves its answer unread in the mailbox.
+
+  The reference belongs to the process that made it: the reply and the producer's `:DOWN` both
+  arrive in that mailbox, so `await/2` has to run there. Handing one to another process gives it
+  nothing to receive.
 
   It answers `{:error, reason}` here only when there is no worker to hand the message to, such as
   a producer still discovering its topology. What the producer itself decides, a full queue

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -185,6 +185,66 @@ defmodule Pulsar.Producer do
   end
 
   @doc """
+  Publishes without waiting for the broker, answering with a reference to await on.
+
+  Takes the same options as `send/3`, other than `:timeout`, which belongs to the wait rather
+  than the send. The message is published in the order it was handed over, so two sends from one
+  process to one partition keep theirs.
+
+      {:ok, first} = Pulsar.Producer.send_async(:audit, "one")
+      {:ok, second} = Pulsar.Producer.send_async(:audit, "two")
+
+      {:ok, _message_id} = Pulsar.Producer.await(first)
+      {:ok, _message_id} = Pulsar.Producer.await(second)
+
+  Errors that `send/3` returns are delivered to `await/2` instead, so nothing is lost by not
+  waiting — but a reference that is never awaited leaves its answer unread in the mailbox.
+
+  Whether a producer will take the message at all is answered here: a full one refuses with
+  `{:error, :producer_queue_full}` rather than handing back a reference.
+  """
+  @spec send_async(pid() | String.t() | atom(), binary(), keyword()) ::
+          {:ok, reference()} | {:error, term()}
+  def send_async(producer, message, opts \\ [])
+
+  def send_async(producer, message, opts) when is_pid(producer) and is_binary(message) do
+    publish_async(producer, message, opts)
+  end
+
+  def send_async(name, message, opts) when (is_binary(name) or is_atom(name)) and is_binary(message) do
+    case Client.lookup(:producers, name, Keyword.get(opts, :client, :default)) do
+      {:ok, pid} -> publish_async(pid, message, opts)
+      {:error, :not_found} = error -> error
+    end
+  end
+
+  @doc """
+  Waits for a send started by `send_async/3`, answering as `send/3` would have.
+
+  A producer that goes down before answering is reported as `{:error, {:producer_died, reason}}`,
+  the same shape `send/3` reports it under.
+
+  `:send_timeout` already bounds how long a producer holds a send, so the default here is to wait
+  for it. A timeout given instead abandons the wait without cancelling the send: the message may
+  still be published, and its answer stays in the mailbox unread.
+  """
+  @spec await(reference(), timeout()) :: {:ok, send_result()} | {:error, term()}
+  def await(ref, timeout \\ :infinity) when is_reference(ref) do
+    receive do
+      {^ref, reply} ->
+        Process.demonitor(ref, [:flush])
+        reply
+
+      {:DOWN, ^ref, :process, _pid, reason} ->
+        {:error, {:producer_died, reason}}
+    after
+      timeout ->
+        Process.demonitor(ref, [:flush])
+        {:error, :timeout}
+    end
+  end
+
+  @doc """
   Stops a producer, given its pid or its name.
 
   A pid must be the stable root returned by `start/1` or `start_link/1`. Group and worker pids
@@ -215,25 +275,44 @@ defmodule Pulsar.Producer do
   # Resolving the partition here keeps topology knowledge in one module: the partition
   # supervisors below only build child specs.
   defp publish(producer, message, opts) do
-    case Topology.kind(producer) do
-      :worker ->
-        Worker.send_message(producer, message, opts)
-
-      :group ->
-        {:error, :not_found}
-
-      :topology ->
-        {groups, hashing_scheme} = Topology.routing(producer)
-        route(groups, hashing_scheme, message, opts)
+    with {:ok, worker} <- resolve_worker(producer, opts) do
+      Worker.send_message(worker, message, opts)
     end
   catch
     # A stale root and a worker that dies mid-send have the same public result.
     :exit, reason -> {:error, {:producer_died, reason}}
   end
 
-  defp route([], _hashing_scheme, _message, _opts), do: {:error, :not_ready}
+  # The monitor's reference doubles as the tag the reply carries, the way `GenServer.call/3`
+  # does it, so `await/2` selects on either the reply or the producer going down.
+  defp publish_async(producer, message, opts) do
+    with {:ok, worker} <- resolve_worker(producer, opts) do
+      ref = Process.monitor(worker)
+      GenServer.cast(worker, {:send_message, message, opts, {self(), ref}})
 
-  defp route(groups, hashing_scheme, message, opts) do
+      {:ok, ref}
+    end
+  catch
+    :exit, reason -> {:error, {:producer_died, reason}}
+  end
+
+  defp resolve_worker(producer, opts) do
+    case Topology.kind(producer) do
+      :worker ->
+        {:ok, producer}
+
+      :group ->
+        {:error, :not_found}
+
+      :topology ->
+        {groups, hashing_scheme} = Topology.routing(producer)
+        route(groups, hashing_scheme, opts)
+    end
+  end
+
+  defp route([], _hashing_scheme, _opts), do: {:error, :not_ready}
+
+  defp route(groups, hashing_scheme, opts) do
     # Missing partitions are added highest-first, so the contiguous width stays at the old
     # modulus until every new slot exists. Restarting groups remain present and retain their
     # slot, avoiding a temporary key remap during either growth or recovery.
@@ -245,7 +324,7 @@ defmodule Pulsar.Producer do
         index = select_partition(opts, hashing_scheme, partitions)
 
         case List.keyfind(groups, index, 0) do
-          {_index, group} when is_pid(group) -> send_to_worker(Topology.workers(group), message, opts)
+          {_index, group} when is_pid(group) -> pick_worker(Topology.workers(group))
           {_index, _restarting} -> {:error, :no_producers_available}
           nil -> {:error, {:partition_not_found, index}}
         end
@@ -268,11 +347,8 @@ defmodule Pulsar.Producer do
     end
   end
 
-  defp send_to_worker([], _message, _opts), do: {:error, :no_producers_available}
-
-  defp send_to_worker([worker | _rest], message, opts) do
-    Worker.send_message(worker, message, opts)
-  end
+  defp pick_worker([]), do: {:error, :no_producers_available}
+  defp pick_worker([worker | _rest]), do: {:ok, worker}
 
   # Two producers in one static supervision tree need distinct ids, so the id follows
   # the same default as the producer's name.

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -246,12 +246,29 @@ defmodule Pulsar.Producer.Worker do
   @impl true
   def handle_call(:ready?, _from, state), do: {:reply, state.ready, state}
 
-  def handle_call({:send_message, _, _}, _from, %{ready: false} = state) do
+  def handle_call({:send_message, payload, opts}, from, state) do
+    take_send(payload, opts, from, state)
+  end
+
+  @impl true
+  def handle_cast({:send_message, payload, opts, from}, state) do
+    case take_send(payload, opts, from, state) do
+      # A caster has nothing to receive a synchronous answer, so it is delivered like any other.
+      {:reply, reply, new_state} ->
+        GenServer.reply(from, reply)
+        {:noreply, new_state}
+
+      {:noreply, _new_state} = noreply ->
+        noreply
+    end
+  end
+
+  defp take_send(_payload, _opts, _from, %__MODULE__{ready: false} = state) do
     Logger.warning("Producer #{state.producer_name} is waiting, cannot send message")
     {:reply, {:error, :producer_waiting}, state}
   end
 
-  def handle_call({:send_message, payload, opts}, from, state) do
+  defp take_send(payload, opts, from, state) do
     if queue_full?(state) do
       {:reply, {:error, :producer_queue_full}, state}
     else

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -247,7 +247,6 @@ defmodule Pulsar.Producer.Worker do
     end
   end
 
-  # Answered without `answer/3`: a refused send was never parked, so there is nothing to count off.
   defp refuse(state, from, reason) do
     GenServer.reply(from, {:error, reason})
 

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -247,12 +247,12 @@ defmodule Pulsar.Producer.Worker do
   def handle_call(:ready?, _from, state), do: {:reply, state.ready, state}
 
   def handle_call({:send_message, payload, opts}, from, state) do
-    take_send(payload, opts, from, state)
+    do_send(payload, opts, from, state)
   end
 
   @impl true
   def handle_cast({:send_message, payload, opts, from}, state) do
-    case take_send(payload, opts, from, state) do
+    case do_send(payload, opts, from, state) do
       # A caster has nothing to receive a synchronous answer, so it is delivered like any other.
       {:reply, reply, new_state} ->
         GenServer.reply(from, reply)
@@ -263,12 +263,12 @@ defmodule Pulsar.Producer.Worker do
     end
   end
 
-  defp take_send(_payload, _opts, _from, %__MODULE__{ready: false} = state) do
+  defp do_send(_payload, _opts, _from, %__MODULE__{ready: false} = state) do
     Logger.warning("Producer #{state.producer_name} is waiting, cannot send message")
     {:reply, {:error, :producer_waiting}, state}
   end
 
-  defp take_send(payload, opts, from, state) do
+  defp do_send(payload, opts, from, state) do
     if queue_full?(state) do
       {:reply, {:error, :producer_queue_full}, state}
     else

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -127,24 +127,6 @@ defmodule Pulsar.Producer.Worker do
   @spec ready?(pid(), timeout()) :: boolean()
   def ready?(producer, timeout), do: GenServer.call(producer, :ready?, timeout)
 
-  @doc """
-  Publishes a message and waits for the broker to acknowledge it. Backs
-  `Pulsar.Producer.send/3`, which documents the message options.
-
-  Two are not part of that public surface: `:timeout`, the call timeout in milliseconds, and
-  `:ordering_key`, which orders within a `:key_shared` subscription without affecting which
-  partition the message lands on.
-
-  `:timeout` defaults to `:infinity` because `:send_timeout` is the deadline: a call giving up
-  first would replace `{:error, :send_timeout}` with an exit. Pass one here if `:send_timeout`
-  is off.
-  """
-  @spec send_message(pid(), binary(), keyword()) :: {:ok, map() | :deduplicated} | {:error, term()}
-  def send_message(producer_pid, message, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, :infinity)
-    GenServer.call(producer_pid, {:send_message, message, opts}, timeout)
-  end
-
   ## GenServer Callbacks
 
   @impl true
@@ -246,34 +228,30 @@ defmodule Pulsar.Producer.Worker do
   @impl true
   def handle_call(:ready?, _from, state), do: {:reply, state.ready, state}
 
-  def handle_call({:send_message, payload, opts}, from, state) do
-    do_send(payload, opts, from, state)
-  end
-
   @impl true
   def handle_cast({:send_message, payload, opts, from}, state) do
-    case do_send(payload, opts, from, state) do
-      # A caster has nothing to receive a synchronous answer, so it is delivered like any other.
-      {:reply, reply, new_state} ->
-        GenServer.reply(from, reply)
-        {:noreply, new_state}
-
-      {:noreply, _new_state} = noreply ->
-        noreply
-    end
+    {:noreply, do_send(payload, opts, from, state)}
   end
 
-  defp do_send(_payload, _opts, _from, %__MODULE__{ready: false} = state) do
+  defp do_send(_payload, _opts, from, %__MODULE__{ready: false} = state) do
     Logger.warning("Producer #{state.producer_name} is waiting, cannot send message")
-    {:reply, {:error, :producer_waiting}, state}
+
+    refuse(state, from, :producer_waiting)
   end
 
   defp do_send(payload, opts, from, state) do
     if queue_full?(state) do
-      {:reply, {:error, :producer_queue_full}, state}
+      refuse(state, from, :producer_queue_full)
     else
       publish_or_batch(payload, opts, from, state)
     end
+  end
+
+  # Answered without `answer/3`: a refused send was never parked, so there is nothing to count off.
+  defp refuse(state, from, reason) do
+    GenServer.reply(from, {:error, reason})
+
+    state
   end
 
   defp queue_full?(%__MODULE__{max_pending_messages: limit}) when limit in [false, nil], do: false
@@ -335,9 +313,9 @@ defmodule Pulsar.Producer.Worker do
     state = %{state | batch: new_batch, batched: new_batched, batch_started_at: started_at}
 
     if new_batched >= state.batch_size do
-      {:noreply, do_flush_batch(state)}
+      do_flush_batch(state)
     else
-      {:noreply, maybe_schedule_send_timeout(state)}
+      maybe_schedule_send_timeout(state)
     end
   end
 
@@ -349,7 +327,7 @@ defmodule Pulsar.Producer.Worker do
 
     case maybe_chunk(compressed_payload, base_metadata, state) do
       {:ok, messages} -> publish_messages(messages, base_metadata, from, state)
-      {:error, reason} -> {:reply, {:error, reason}, state}
+      {:error, reason} -> refuse(state, from, reason)
     end
   end
 
@@ -385,13 +363,13 @@ defmodule Pulsar.Producer.Worker do
 
     case result do
       {:ok, new_state} ->
-        {:noreply, new_state |> park_send() |> maybe_schedule_send_timeout()}
+        new_state |> park_send() |> maybe_schedule_send_timeout()
 
       # Rolling the counter back would reissue sequence ids still in flight, which the
       # broker's deduplication reads as repeats. The pending entries do go: a message missing
       # chunks can never complete, and its caller already has an error.
       {:error, reason, acc_state} ->
-        {:reply, {:error, reason}, %{acc_state | pending_frames: state.pending_frames}}
+        refuse(%{acc_state | pending_frames: state.pending_frames}, from, reason)
     end
   end
 

--- a/test/integration/producer/common_test.exs
+++ b/test/integration/producer/common_test.exs
@@ -89,4 +89,28 @@ defmodule Pulsar.Integration.Producer.CommonTest do
     close_stats = Utils.collect_producer_closed_stats(producer_names: [producer_group_name])
     assert %{success_count: 1, failure_count: 0, total_count: 1} = close_stats
   end
+
+  test "send multiple messages asynchronously" do
+    {:ok, producer} =
+      Pulsar.Producer.start(@topic,
+        client: @client,
+        name: "async-producer"
+      )
+
+    assert :ok = Pulsar.Producer.await_ready(producer)
+
+    refs =
+      Enum.map(["one", "two", "three"], fn payload ->
+        assert {:ok, ref} = Pulsar.Producer.send_async(producer, payload)
+        ref
+      end)
+
+    for ref <- Enum.reverse(refs) do
+      assert {:ok, message_id} = Pulsar.Producer.await(ref)
+      assert message_id.ledgerId
+      assert message_id.entryId
+    end
+
+    assert :ok = Pulsar.Producer.stop(producer, client: @client)
+  end
 end

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -37,13 +37,15 @@ defmodule Pulsar.Consumer.BatchAckTest do
     def init(state), do: {:ok, state}
 
     @impl true
-    def handle_call({:send_message, payload, _opts}, _from, {refuse, notify_pid} = state) do
+    def handle_cast({:send_message, payload, _opts, from}, {refuse, notify_pid} = state) do
       if payload in refuse do
-        {:reply, {:error, :message_too_large}, state}
+        GenServer.reply(from, {:error, :message_too_large})
       else
         send(notify_pid, {:diverted, payload})
-        {:reply, {:ok, %Binary.MessageIdData{ledgerId: 9, entryId: 1, partition: -1}}, state}
+        GenServer.reply(from, {:ok, %Binary.MessageIdData{ledgerId: 9, entryId: 1, partition: -1}})
       end
+
+      {:noreply, state}
     end
   end
 

--- a/test/unit/producer_batch_test.exs
+++ b/test/unit/producer_batch_test.exs
@@ -138,7 +138,7 @@ defmodule Pulsar.Producer.BatchTest do
         [froms, ["a", "b", "a"], 0..2]
         |> Enum.zip()
         |> Enum.reduce(state, fn {from, key, index}, acc ->
-          {:noreply, next} = Worker.handle_call({:send_message, "msg-#{index}", [partition_key: key]}, from, acc)
+          {:noreply, next} = Worker.handle_cast({:send_message, "msg-#{index}", [partition_key: key], from}, acc)
           next
         end)
 
@@ -239,7 +239,7 @@ defmodule Pulsar.Producer.BatchTest do
   ## Helpers
 
   defp send_message(state, payload, opts) do
-    Worker.handle_call({:send_message, payload, opts}, {self(), make_ref()}, state)
+    Worker.handle_cast({:send_message, payload, opts, {self(), make_ref()}}, state)
   end
 
   defp key_based(state), do: %{state | batch_builder: :key_based}

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -27,6 +27,18 @@ defmodule Pulsar.Producer.SendAsyncTest do
     end
 
     def handle_cast({:send_message, _payload, _opts, _from}, :silent = state), do: {:noreply, state}
+
+    # Answers late, so a caller that has already given up would be the one to receive it.
+    def handle_cast({:send_message, payload, _opts, from}, {:echo_after, delay} = state) do
+      Process.send_after(self(), {:answer, from, payload}, delay)
+      {:noreply, state}
+    end
+
+    @impl true
+    def handle_info({:answer, from, payload}, state) do
+      GenServer.reply(from, {:ok, payload})
+      {:noreply, state}
+    end
   end
 
   setup do
@@ -138,6 +150,17 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
     end
 
+    # `send/3` never hands back the reference, so an answer arriving after it gave up would be
+    # one its caller could not reach. Demonitoring the alias has the runtime drop it instead.
+    test "leaves no answer behind when it gives up" do
+      worker = start_supervised!({StubWorker, {:echo_after, 60}})
+
+      assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
+
+      Process.sleep(100)
+      assert {:messages, []} = Process.info(self(), :messages)
+    end
+
     test "reports a producer that goes down" do
       worker = start_supervised!({StubWorker, :silent})
       task = Task.async(fn -> Producer.send(worker, "a") end)
@@ -153,8 +176,8 @@ defmodule Pulsar.Producer.SendAsyncTest do
 
   # What `Pulsar.Producer.send_async/3` does once it has resolved a worker.
   defp send_async_to(worker, payload) do
-    ref = Process.monitor(worker)
-    GenServer.cast(worker, {:send_message, payload, [], {self(), ref}})
+    ref = Process.monitor(worker, alias: :demonitor)
+    GenServer.cast(worker, {:send_message, payload, [], {ref, ref}})
 
     ref
   end

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -28,13 +28,11 @@ defmodule Pulsar.Producer.SendAsyncTest do
 
     def handle_cast({:send_message, _payload, _opts, _from}, :silent = state), do: {:noreply, state}
 
-    # Answers late, so a caller that has already given up would be the one to receive it.
     def handle_cast({:send_message, payload, _opts, from}, {:echo_after, delay} = state) do
       Process.send_after(self(), {:answer, from, payload}, delay)
       {:noreply, state}
     end
 
-    # Runs `send/3` in the worker's own process, as a synchronous telemetry handler would.
     @impl true
     def handle_call({:publish_to_self, payload}, _from, state) do
       {:reply, Producer.send(self(), payload, timeout: 100), state}
@@ -156,8 +154,6 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
     end
 
-    # `send/3` never hands back the reference, so an answer arriving after it gave up would be
-    # one its caller could not reach. Demonitoring the alias has the runtime drop it instead.
     test "leaves no answer behind when it gives up" do
       worker = start_supervised!({StubWorker, {:echo_after, 60}})
 
@@ -167,8 +163,6 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert {:messages, []} = Process.info(self(), :messages)
     end
 
-    # A worker awaiting its own cast would wedge mid-callback and stop draining its mailbox, so
-    # neither the reply nor its own `:send_timeout` could ever reach it.
     test "refuses to publish to the producer it is already running in" do
       worker = start_supervised!({StubWorker, :echo})
 
@@ -189,7 +183,6 @@ defmodule Pulsar.Producer.SendAsyncTest do
 
   ## Helpers
 
-  # What `Pulsar.Producer.send_async/3` does once it has resolved a worker.
   defp send_async_to(worker, payload) do
     ref = Process.monitor(worker, alias: :demonitor)
     GenServer.cast(worker, {:send_message, payload, [], {ref, ref}})

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -28,20 +28,14 @@ defmodule Pulsar.Producer.SendAsyncTest do
 
     def handle_cast({:send_message, _payload, _opts, _from}, :silent = state), do: {:noreply, state}
 
-    def handle_cast({:send_message, payload, _opts, from}, {:echo_after, delay} = state) do
-      Process.send_after(self(), {:answer, from, payload}, delay)
+    def handle_cast({:send_message, payload, _opts, from}, {:hold, owner} = state) do
+      send(owner, {:held_send, from, payload})
       {:noreply, state}
     end
 
     @impl true
     def handle_call({:publish_to_self, payload}, _from, state) do
       {:reply, Producer.send(self(), payload, timeout: 100), state}
-    end
-
-    @impl true
-    def handle_info({:answer, from, payload}, state) do
-      GenServer.reply(from, {:ok, payload})
-      {:noreply, state}
     end
   end
 
@@ -117,6 +111,19 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert Process.alive?(worker), "the send is still the producer's to answer"
     end
 
+    test "cannot recover an answer after timing out" do
+      worker = start_supervised!({StubWorker, {:hold, self()}})
+      ref = send_async_to(worker, "a")
+
+      assert_receive {:held_send, from, "a"}
+      assert {:error, :timeout} = Producer.await(ref, 0)
+
+      GenServer.reply(from, {:ok, "a"})
+
+      refute_receive {^ref, _reply}
+      assert {:error, :timeout} = Producer.await(ref, 0)
+    end
+
     test "belongs to the process that started the send" do
       worker = start_supervised!({StubWorker, :echo})
       ref = send_async_to(worker, "a")
@@ -152,15 +159,6 @@ defmodule Pulsar.Producer.SendAsyncTest do
       worker = start_supervised!({StubWorker, :silent})
 
       assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
-    end
-
-    test "leaves no answer behind when it gives up" do
-      worker = start_supervised!({StubWorker, {:echo_after, 60}})
-
-      assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
-
-      Process.sleep(100)
-      assert {:messages, []} = Process.info(self(), :messages)
     end
 
     test "refuses to publish to the producer it is already running in" do

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -9,8 +9,8 @@ defmodule Pulsar.Producer.SendAsyncTest do
   alias Pulsar.Test.Support.BrokerStub
   alias Pulsar.Test.Support.ProducerState
 
-  # Stands in for a producer worker: it answers the cast the way one eventually would, or holds
-  # onto it when asked to, so `await/2` can be driven without a broker behind it.
+  # Stands in for a producer worker: it answers the cast, or sits on it, so `await/2` can be
+  # driven without a broker behind it.
   defmodule StubWorker do
     @moduledoc false
     use GenServer
@@ -44,7 +44,6 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert state.pending_messages == 1
     end
 
-    # A caster has no reply to return, so what `send/3` answers synchronously is delivered.
     test "delivers a refusal to its caller rather than returning it", ctx do
       state = %{ctx.state | max_pending_messages: 1}
       {:noreply, state} = cast(state, "a")

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -34,6 +34,12 @@ defmodule Pulsar.Producer.SendAsyncTest do
       {:noreply, state}
     end
 
+    # Runs `send/3` in the worker's own process, as a synchronous telemetry handler would.
+    @impl true
+    def handle_call({:publish_to_self, payload}, _from, state) do
+      {:reply, Producer.send(self(), payload, timeout: 100), state}
+    end
+
     @impl true
     def handle_info({:answer, from, payload}, state) do
       GenServer.reply(from, {:ok, payload})
@@ -159,6 +165,15 @@ defmodule Pulsar.Producer.SendAsyncTest do
 
       Process.sleep(100)
       assert {:messages, []} = Process.info(self(), :messages)
+    end
+
+    # A worker awaiting its own cast would wedge mid-callback and stop draining its mailbox, so
+    # neither the reply nor its own `:send_timeout` could ever reach it.
+    test "refuses to publish to the producer it is already running in" do
+      worker = start_supervised!({StubWorker, :echo})
+
+      assert {:error, :calling_self} = GenServer.call(worker, {:publish_to_self, "a"})
+      assert Process.alive?(worker)
     end
 
     test "reports a producer that goes down" do

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -101,6 +101,16 @@ defmodule Pulsar.Producer.SendAsyncTest do
       assert Process.alive?(worker), "the send is still the producer's to answer"
     end
 
+    test "belongs to the process that started the send" do
+      worker = start_supervised!({StubWorker, :echo})
+      ref = send_async_to(worker, "a")
+
+      elsewhere = Task.async(fn -> Producer.await(ref, 20) end)
+
+      assert {:error, :timeout} = Task.await(elsewhere)
+      assert {:ok, "a"} = Producer.await(ref), "the answer was here all along"
+    end
+
     test "leaves nothing behind for a send it already answered" do
       worker = start_supervised!({StubWorker, :echo})
 
@@ -110,6 +120,32 @@ defmodule Pulsar.Producer.SendAsyncTest do
       GenServer.stop(worker, :shutdown)
 
       refute_receive {:DOWN, ^ref, :process, _pid, _reason}, 50
+    end
+  end
+
+  # `Topology.kind/1` reads anything that is not a topology or group supervisor as a worker, so a
+  # stub answers `send/3` as a producer would.
+  describe "send/3 over send_async/3" do
+    test "answers with what the producer replied" do
+      worker = start_supervised!({StubWorker, :echo})
+
+      assert {:ok, "a"} = Producer.send(worker, "a")
+    end
+
+    test "gives up with a timeout of its own" do
+      worker = start_supervised!({StubWorker, :silent})
+
+      assert {:error, :timeout} = Producer.send(worker, "a", timeout: 20)
+    end
+
+    test "reports a producer that goes down" do
+      worker = start_supervised!({StubWorker, :silent})
+      task = Task.async(fn -> Producer.send(worker, "a") end)
+
+      Process.sleep(20)
+      GenServer.stop(worker, :shutdown)
+
+      assert {:error, {:producer_died, :shutdown}} = Task.await(task)
     end
   end
 

--- a/test/unit/producer_send_async_test.exs
+++ b/test/unit/producer_send_async_test.exs
@@ -1,0 +1,138 @@
+defmodule Pulsar.Producer.SendAsyncTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  import Pulsar.Test.Support.BrokerStub, only: [published: 0]
+
+  alias Pulsar.Producer
+  alias Pulsar.Producer.Worker
+  alias Pulsar.Test.Support.BrokerStub
+  alias Pulsar.Test.Support.ProducerState
+
+  # Stands in for a producer worker: it answers the cast the way one eventually would, or holds
+  # onto it when asked to, so `await/2` can be driven without a broker behind it.
+  defmodule StubWorker do
+    @moduledoc false
+    use GenServer
+
+    def start_link(answer), do: GenServer.start_link(__MODULE__, answer)
+
+    @impl true
+    def init(answer), do: {:ok, answer}
+
+    @impl true
+    def handle_cast({:send_message, payload, _opts, from}, :echo = state) do
+      GenServer.reply(from, {:ok, payload})
+      {:noreply, state}
+    end
+
+    def handle_cast({:send_message, _payload, _opts, _from}, :silent = state), do: {:noreply, state}
+  end
+
+  setup do
+    broker = start_supervised!({BrokerStub, self()})
+
+    %{state: ProducerState.new(broker)}
+  end
+
+  describe "taking a send by cast" do
+    test "publishes it and parks its caller", ctx do
+      {:noreply, state} = cast(ctx.state, "a")
+
+      assert [_sent] = published()
+      assert map_size(state.pending_frames) == 1
+      assert state.pending_messages == 1
+    end
+
+    # A caster has no reply to return, so what `send/3` answers synchronously is delivered.
+    test "delivers a refusal to its caller rather than returning it", ctx do
+      state = %{ctx.state | max_pending_messages: 1}
+      {:noreply, state} = cast(state, "a")
+
+      {ref, {:noreply, state}} = cast_with_ref(state, "b")
+
+      assert_received {^ref, {:error, :producer_queue_full}}
+      assert map_size(state.pending_frames) == 1
+    end
+
+    test "refuses while the producer is still registering", ctx do
+      {ref, {:noreply, state}} = cast_with_ref(%{ctx.state | ready: false}, "a")
+
+      assert_received {^ref, {:error, :producer_waiting}}
+      assert [] == published()
+      assert state.pending_messages == 0
+    end
+
+    test "publishes in the order it was handed the messages", ctx do
+      state =
+        Enum.reduce(["a", "b", "c"], ctx.state, fn payload, acc ->
+          {:noreply, next} = cast(acc, payload)
+          next
+        end)
+
+      assert map_size(state.pending_frames) == 3
+      assert ["a", "b", "c"] == Enum.map(published(), & &1.payload)
+    end
+  end
+
+  describe "await/2" do
+    test "answers with what the producer replied" do
+      worker = start_supervised!({StubWorker, :echo})
+
+      ref = send_async_to(worker, "a")
+
+      assert {:ok, "a"} = Producer.await(ref)
+    end
+
+    test "reports a producer that goes down before answering" do
+      worker = start_supervised!({StubWorker, :silent})
+
+      ref = send_async_to(worker, "a")
+      GenServer.stop(worker, :shutdown)
+
+      assert {:error, {:producer_died, :shutdown}} = Producer.await(ref)
+    end
+
+    test "gives up on its own without cancelling the send" do
+      worker = start_supervised!({StubWorker, :silent})
+
+      ref = send_async_to(worker, "a")
+
+      assert {:error, :timeout} = Producer.await(ref, 20)
+      assert Process.alive?(worker), "the send is still the producer's to answer"
+    end
+
+    test "leaves nothing behind for a send it already answered" do
+      worker = start_supervised!({StubWorker, :echo})
+
+      ref = send_async_to(worker, "a")
+      assert {:ok, "a"} = Producer.await(ref)
+
+      GenServer.stop(worker, :shutdown)
+
+      refute_receive {:DOWN, ^ref, :process, _pid, _reason}, 50
+    end
+  end
+
+  ## Helpers
+
+  # What `Pulsar.Producer.send_async/3` does once it has resolved a worker.
+  defp send_async_to(worker, payload) do
+    ref = Process.monitor(worker)
+    GenServer.cast(worker, {:send_message, payload, [], {self(), ref}})
+
+    ref
+  end
+
+  defp cast(state, payload) do
+    {_ref, result} = cast_with_ref(state, payload)
+
+    result
+  end
+
+  defp cast_with_ref(state, payload) do
+    ref = make_ref()
+
+    {ref, Worker.handle_cast({:send_message, payload, [], {self(), ref}}, state)}
+  end
+end

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -182,8 +182,9 @@ defmodule Pulsar.Producer.SendTest do
 
       {_from, state} = send_message(state, "a")
 
-      assert {:reply, {:error, :producer_queue_full}, ^state} =
-               Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+      {refused, {:noreply, ^state}} = cast(state, "b")
+
+      assert_replied(refused, {:error, :producer_queue_full})
     end
 
     test "counts messages waiting to be batched", ctx do
@@ -195,8 +196,9 @@ defmodule Pulsar.Producer.SendTest do
       assert state.batched == 2
       assert [] == published(), "neither has been published yet"
 
-      assert {:reply, {:error, :producer_queue_full}, _state} =
-               Worker.handle_call({:send_message, "c", []}, {self(), make_ref()}, state)
+      {refused, {:noreply, _state}} = cast(state, "c")
+
+      assert_replied(refused, {:error, :producer_queue_full})
     end
 
     test "accepts again once a send is acknowledged", ctx do
@@ -208,7 +210,7 @@ defmodule Pulsar.Producer.SendTest do
       receipt = %Binary.CommandSendReceipt{sequence_id: sequence_id, message_id: message_id()}
       {:noreply, state} = Worker.handle_info({:send_receipt, receipt}, state)
 
-      assert {:noreply, _state} = Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+      assert {:noreply, _state} = Worker.handle_cast({:send_message, "b", [], {self(), make_ref()}}, state)
     end
 
     # Counting frames took a producer past its limit on one large message.
@@ -220,7 +222,7 @@ defmodule Pulsar.Producer.SendTest do
       assert map_size(state.pending_frames) == 5, "five frames"
       assert state.pending_messages == 1, "one message"
 
-      assert {:noreply, _state} = Worker.handle_call({:send_message, "b", []}, {self(), make_ref()}, state)
+      assert {:noreply, _state} = Worker.handle_cast({:send_message, "b", [], {self(), make_ref()}}, state)
     end
 
     test "lets a send go again once its caller has been answered", ctx do
@@ -239,9 +241,9 @@ defmodule Pulsar.Producer.SendTest do
       # Nothing is published, so nothing waits: the caller already has its error.
       state = %{ctx.state | chunking_enabled: true, max_message_size: 0, broker_max_message_size: 0}
 
-      assert {:reply, {:error, :metadata_too_large}, state} =
-               Worker.handle_call({:send_message, "a", []}, {self(), make_ref()}, state)
+      {refused, {:noreply, state}} = cast(state, "a")
 
+      assert_replied(refused, {:error, :metadata_too_large})
       assert state.pending_messages == 0
     end
 
@@ -256,9 +258,16 @@ defmodule Pulsar.Producer.SendTest do
 
   ## Helpers
 
+  # A send arrives as a cast, so a refusal is delivered to its caller rather than returned.
+  defp cast(state, payload) do
+    from = {self(), make_ref()}
+
+    {from, Worker.handle_cast({:send_message, payload, [], from}, state)}
+  end
+
   defp send_message(state, payload) do
     from = {self(), make_ref()}
-    {:noreply, new_state} = Worker.handle_call({:send_message, payload, []}, from, state)
+    {:noreply, new_state} = Worker.handle_cast({:send_message, payload, [], from}, state)
 
     {from, new_state}
   end

--- a/test/unit/producer_send_test.exs
+++ b/test/unit/producer_send_test.exs
@@ -258,7 +258,6 @@ defmodule Pulsar.Producer.SendTest do
 
   ## Helpers
 
-  # A send arrives as a cast, so a refusal is delivered to its caller rather than returned.
   defp cast(state, payload) do
     from = {self(), make_ref()}
 

--- a/test/unit/producer_test.exs
+++ b/test/unit/producer_test.exs
@@ -16,8 +16,9 @@ defmodule Pulsar.ProducerTest do
     def init(partition), do: {:ok, partition}
 
     @impl true
-    def handle_call({:send_message, _message, _opts}, _from, partition) do
-      {:reply, {:ok, partition}, partition}
+    def handle_cast({:send_message, _message, _opts, from}, partition) do
+      GenServer.reply(from, {:ok, partition})
+      {:noreply, partition}
     end
   end
 


### PR DESCRIPTION
## Summary

`send_async/3` publishes without waiting and answers with a reference; `await/2` collects the result `send/3` would have returned.

```elixir
{:ok, first} = Pulsar.Producer.send_async(:audit, "one")
{:ok, second} = Pulsar.Producer.send_async(:audit, "two")

{:ok, _message_id} = Pulsar.Producer.await(first)
{:ok, _message_id} = Pulsar.Producer.await(second)
```

## Motivation

`send/3` blocks until the broker acknowledges, so **one process can have exactly one send in flight**. Reaching `:max_pending_messages` — 1000 by default — takes a thousand concurrent callers. The backpressure limit added in #185 was, for a single-process client, effectively `1`.

It also made two other things awkward:

- A long `:flush_interval` blocks every caller for its duration, so batching cost latency at the call site.
- Disabling `:send_timeout` left a caller with no deadline at all, since #185 moved the call timeout to `:infinity`. Java and Go can offer that safely because their blocking `send` is paired with an async form; ours was not.

## What it does

The worker already parked every caller and answered through one place, so nothing about the send path changed. `send_async/3` resolves a worker exactly as `send/3` does, then casts instead of calling.

**The monitor's reference is the reply tag**, the way `GenServer.call/3` does it. One reference identifies the send and detects the producer dying, so `await/2` selects on either:

```elixir
receive do
  {^ref, reply} -> Process.demonitor(ref, [:flush]); reply
  {:DOWN, ^ref, :process, _pid, reason} -> {:error, {:producer_died, reason}}
after
  timeout -> Process.demonitor(ref, [:flush]); {:error, :timeout}
end
```

That keeps async failures the same shape as synchronous ones: `send/3` already reports a dead producer as `{:error, {:producer_died, reason}}`.

**The reference is a process alias**, minted with `Process.monitor(worker, alias: :demonitor)` and used as both halves of the `from`. That is not decoration: it is how `GenServer.call/3` avoids leaving an answer behind when it gives up. Demonitoring deactivates the alias, so a reply the caller has stopped waiting for is dropped by the runtime rather than left unread in its mailbox — which matters here because `send/3` never hands the reference back, so its caller could not drain one. Aliases arrived in [Erlang/OTP 24](https://www.erlang.org/blog/otp-24-highlights/) via [EEP 53](https://www.erlang.org/eeps/eep-0053).

The `from` is `{ref, ref}` rather than OTP's `[:alias | ref]` tag: `:gen.reply/2` falls through to `To ! {Tag, Reply}`, so putting the alias in the `to` position gets the same routing, and dialyzer does not have to accept an improper list being built by hand.

**The reference belongs to the process that made it.** Both the reply and the `:DOWN` arrive in that mailbox, so `await/2` has to run there — handing a reference to another process gives it nothing to receive. Java's `CompletableFuture` and Go's callback both cross that boundary; this does not, and the docs say so.

**Publishing to a producer from inside its own worker answers `{:error, :calling_self}`.** A worker cannot dequeue its own cast while blocked awaiting the reply, so it would wedge mid-callback and stop draining its mailbox entirely — taking every other pending send with it, and its own `:send_timeout` timer along with them. It is reachable from a synchronous telemetry handler, since the worker emits telemetry from inside `handle_cast/2` and `handle_info/2`. `GenServer.call/3` refuses the same thing for the same reason.

Everything else is reused. `:send_timeout` bounds an async send exactly as it bounds a blocking one, and `:max_pending_messages` counts it the same way.

## `send/3` is now built on it

```elixir
def send(producer, message, opts) do
  case send_async(producer, message, opts) do
    {:ok, ref} -> await(ref, Keyword.get(opts, :timeout, :infinity))
    {:error, _reason} = error -> error
  end
end
```

Rather than leave two parallel paths through the worker, every send is now a cast. `Worker.send_message/3`, `handle_call({:send_message, …})` and `Pulsar.Producer.publish/3` are gone, and the worker has one send entry point.

That let the internals drop a shape they only had because two callbacks needed different things from them: `do_send/4`, `add_to_batch/4`, `send_unbatched/4` and `publish_messages/4` all returned `{:reply, …}` or `{:noreply, …}` tuples and now return plain state. A refusal is delivered through a dedicated `refuse/3` rather than `answer/3`, because a refused send was never parked and there is nothing to count off — the same trap that produced a leak during #185, with a test asserting the counter stays at zero.

**One behaviour change.** `:timeout` used to reach `GenServer.call`, so exceeding it exited and surfaced as `{:error, {:producer_died, {:timeout, {GenServer, :call, …}}}}`. It now answers `{:error, :timeout}`. Cleaner, and it stops a timeout being reported as the producer having died — but it is a public error shape changing.

## Ordering

**Two sends from one process to one partition are published in the order they were handed over.** Casts between a pair of processes are ordered by the BEAM, so the guarantee comes for free.

This is why the implementation is a cast rather than `Task.async(fn -> send(...) end)`, which is otherwise a one-line version of the same idea. Spawning a task per send puts an intermediate process between caller and worker, and which of two tasks reaches the mailbox first is down to the scheduler — so a key's messages could be published out of order within their partition, which is the one thing partitioning is meant to prevent. The task version also links, so a dying producer would take the caller with it rather than returning an error, and it costs a process per message in flight.

## Structure

The routing that `send/3` performed inline is now `resolve_worker/2`, so both paths share it rather than duplicating partition selection.

The monitor and the cast live in `Pulsar.Producer` rather than in the worker's client API. `send_async/3` mints a reference that only `await/2` knows how to interpret — the two are halves of one protocol, and keeping them in one module means a reader does not have to hold both files at once to follow the reference's lifetime.

## Verification

Fourteen tests, covering the cast path headless and the reference protocol against a stub producer:

- A cast publishes and parks its caller; `pending_messages` counts it.
- A refusal (`:producer_queue_full`, `:producer_waiting`, `:metadata_too_large`) is **delivered** to the caller rather than returned, and leaves `pending_messages` at zero.
- Three casts publish in the order they were handed over.
- `await/2` returns what the producer replied, reports `{:error, {:producer_died, reason}}` when it goes down first, and gives up on its own without cancelling the send.
- A reference that was already answered leaves no `:DOWN` behind, so the `demonitor(:flush)` is doing its job.
- A reference awaited from another process times out there while its answer waits, unread, for the process that made it.
- `send/3` itself answers, times out with `{:error, :timeout}`, and reports a producer that goes down — driven against a stub, since `Topology.kind/1` reads anything that is not a topology or group supervisor as a worker.
- A timed-out `send/3` leaves the caller's mailbox **empty** once the late answer arrives, which is the alias doing its job.
- A stub calling `send/3` on itself gets `{:error, :calling_self}` and stays alive.

Three mutations, each failing exactly its own test and nothing else: reverting `send/3` to `await(ref)` without the caller's `:timeout`; swapping the alias back for a plain monitor ref; and dropping the `calling_self` guard.

Eleven existing call sites moved to `handle_cast`, and two stubs that impersonate a producer — the routing worker and the dead letter producer — had to learn to answer a cast, which is a reasonable sign the change is coherent.

**Suite:** 376 unit tests and 502 with integration against the broker in `docker-compose.yml`, plus `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and a `--warnings-as-errors` compile, all clean.

## Follow-ups

- `async_stream/3`, in the shape of `Task.async_stream/3` but with a reference per message rather than a process. `{:error, :producer_queue_full}` is the one send error that is unambiguously safe to retry — it is refused before the message is parked or published — so a stream can absorb it as backpressure rather than surfacing it, which makes `:max_concurrency` a hint instead of a footgun.
- `producer_count` deserves a look. Only the first worker of a group ever publishes, so values above 1 start workers that register with the broker and never send. Splitting one partition's writes across several producer names would break per-key ordering anyway, and this PR removes the throughput argument for it: one worker can now carry `:max_pending_messages` at once.



