### PR TITLE
refactor!: remove producer_count option

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,20 +123,18 @@ one group per partition:
 stable topology root (:orders)
 ├── topology discovery
 ├── group for partition 0
-│   ├── worker 1
-│   └── worker 2
+│   └── worker
 ├── group for partition 1
-│   ├── worker 1
-│   └── worker 2
+│   └── worker
 └── group for partition 2
-    ├── worker 1
-    └── worker 2
+    └── worker
 ```
 
-The number of workers in each group comes from `:consumer_count` or `:producer_count`.
-Adding partitions changes the children below the root, but not the root itself. This is why
-names, stop operations, client listings, and publishing target the logical resource instead
-of a particular worker.
+Producer groups contain one worker, preserving one ordered send lane and one sequence-id and
+batching domain per partition. Consumer groups may contain several workers, configured with
+`:consumer_count`. Adding partitions changes the children below the root, but not the root
+itself. This is why names, stop operations, client listings, and publishing target the logical
+resource instead of a particular worker.
 
 The stable root represents that logical resource even when none of its groups currently has
 a live worker. It remains registered and appears in client listings while operations report

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,17 +117,24 @@ That is the pid returned to the caller, registered under its public name, and re
 `Pulsar.Client.consumers/1` or `Pulsar.Client.producers/1`.
 
 A non-partitioned topic has one internal <code>Pulsar.Topology.Group</code>. A partitioned topic has
-one group per partition:
+one group per partition. What lives inside each group depends on the resource:
 
 ```text
-stable topology root (:orders)
+producer topology root (:orders-producer)
 ├── topology discovery
 ├── group for partition 0
-│   └── worker
-├── group for partition 1
-│   └── worker
-└── group for partition 2
-    └── worker
+│   └── producer worker
+└── group for partition 1
+    └── producer worker
+
+consumer topology root (:orders-billing, consumer_count: 2)
+├── topology discovery
+├── group for partition 0
+│   ├── consumer worker 1
+│   └── consumer worker 2
+└── group for partition 1
+    ├── consumer worker 1
+    └── consumer worker 2
 ```
 
 Producer groups contain one worker, preserving one ordered send lane and one sequence-id and
@@ -142,8 +149,8 @@ that no workers are available. This lets reconciliation recover the resource wit
 the pid applications use to address it.
 
 Producer publishing resolves the logical root, selects a partition group, and sends through
-one of that group's workers. Consumer workers receive broker messages and invoke the
-configured `Pulsar.Consumer.Callback` in the worker process.
+that group's worker. Consumer workers receive broker messages and invoke the configured
+`Pulsar.Consumer.Callback` in the worker process.
 
 ## Startup Is Asynchronous
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ MyApp.Supervisor
             │   └── stable producer root(s)
             │       ├── topology discovery
             │       └── partition group(s)
-            │           └── producer worker(s)
+            │           └── producer worker (one per group)
             └── Bootstrap
 ```
 

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -48,7 +48,7 @@ defmodule Pulsar.Consumer do
       end)
       |> Keyword.put(:companions, &DeadLetter.attach/2)
 
-    Topology.start_link(Worker, Client.registry(:consumers, client), :consumer_count, opts)
+    Topology.start_link(Worker, Client.registry(:consumers, client), :consumers, opts)
   end
 
   @doc """

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -71,7 +71,7 @@ defmodule Pulsar.Producer do
     topic = Keyword.fetch!(opts, :topic)
     opts = Keyword.put_new_lazy(opts, :name, fn -> default_name(topic) end)
 
-    Topology.start_link(Worker, registry, :producer_count, opts)
+    Topology.start_link(Worker, registry, :producers, opts)
   end
 
   @doc """

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -18,11 +18,6 @@ defmodule Pulsar.Producer.Options do
       type: {:or, [:string, :atom]},
       doc: "Name the producer is registered under. Defaults to `\"<topic>-producer\"`."
     ],
-    producer_count: [
-      type: :pos_integer,
-      default: 1,
-      doc: "Number of producer processes to start for the topic, or for each partition."
-    ],
     access_mode: [
       type: {:in, [:shared, :exclusive, :wait_for_exclusive, :exclusive_with_fencing]},
       default: :shared,

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -1,8 +1,8 @@
 defmodule Pulsar.Producer.Worker do
   @moduledoc false
 
-  # The GenServer behind a single producer. Pulsar.Producer starts these through
-  # Pulsar.Topology.Group, one per partition and per :producer_count.
+  # The GenServer behind a single producer. Pulsar.Producer starts one through
+  # Pulsar.Topology.Group for the topic or for each partition.
 
   use GenServer
 

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -43,18 +43,18 @@ defmodule Pulsar.Topology do
     }
   end
 
-  @spec start_link(module(), atom() | nil, :consumers | :producers | :unknown, keyword()) ::
+  @spec start_link(module(), atom() | nil, :consumers | :producers, keyword()) ::
           Supervisor.on_start()
-  def start_link(worker, registry, kind, opts) do
+  def start_link(worker, registry, kind, opts) when kind in [:consumers, :producers] do
     start_link(worker, registry, kind, opts, [])
   end
 
   # The fifth argument is an internal seam for exercising asynchronous discovery without a
   # broker. Consumer and Producer deliberately keep it out of the API they document.
   @doc false
-  @spec start_link(module(), atom() | nil, :consumers | :producers | :unknown, keyword(), keyword()) ::
+  @spec start_link(module(), atom() | nil, :consumers | :producers, keyword(), keyword()) ::
           Supervisor.on_start()
-  def start_link(worker, registry, kind, opts, controller_opts) do
+  def start_link(worker, registry, kind, opts, controller_opts) when kind in [:consumers, :producers] do
     name = Keyword.fetch!(opts, :name)
     config = %{worker: worker, kind: kind, opts: opts}
 
@@ -407,7 +407,7 @@ defmodule Pulsar.Topology do
     discovery =
       {self(), config, controller_opts}
       |> Discovery.child_spec()
-      |> Map.put(:id, {Discovery, resource_kind_for_config(config), topic, hashing_scheme_for_config(config)})
+      |> Map.put(:id, {Discovery, config.kind, topic, hashing_scheme_for_config(config)})
 
     # Companions start before discovery so a worker never observes the tree without them. They
     # resolve their own brokers asynchronously, so none of them delays this root coming up.
@@ -428,9 +428,6 @@ defmodule Pulsar.Topology do
         {%{config | opts: opts}, specs}
     end
   end
-
-  defp resource_kind_for_config(%{kind: kind}) when kind in [:consumers, :producers], do: kind
-  defp resource_kind_for_config(_config), do: :unknown
 
   # Carried on the child id so routing reads it from the same which_children the groups come
   # from, keeping a send to one call. The registry value would be the usual place for this, but
@@ -603,7 +600,6 @@ defmodule Pulsar.Topology do
 
   defp worker_count(%{kind: :consumers, opts: opts}), do: Keyword.fetch!(opts, :consumer_count)
   defp worker_count(%{kind: :producers}), do: 1
-  defp worker_count(%{opts: opts}), do: Keyword.fetch!(opts, :worker_count)
 
   defp group_child_spec(id, worker, worker_count, opts) do
     %{

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -56,7 +56,7 @@ defmodule Pulsar.Topology do
           Supervisor.on_start()
   def start_link(worker, registry, kind, opts, controller_opts) when kind in [:consumers, :producers] do
     name = Keyword.fetch!(opts, :name)
-    config = %{worker: worker, kind: kind, opts: opts}
+    config = %{worker: worker, kind: kind, worker_count: worker_count(kind, opts), opts: opts}
 
     Supervisor.start_link(__MODULE__, {config, controller_opts}, start_options(registry, name))
   end
@@ -578,13 +578,13 @@ defmodule Pulsar.Topology do
   # :topic is the topic a worker subscribes to and :base_topic the one the resource was
   # configured with; they differ only for a partition. Workers carry both so a callback can
   # tell which partition it handles without inspecting the tree it lives in.
-  defp topic_child_spec(%{worker: worker, opts: opts} = config) do
+  defp topic_child_spec(%{worker: worker, worker_count: worker_count, opts: opts}) do
     topic_opts = Keyword.merge(opts, base_topic: Keyword.fetch!(opts, :topic), partition: nil)
 
-    group_child_spec({:topic, :non_partitioned}, worker, worker_count(config), topic_opts)
+    group_child_spec({:topic, :non_partitioned}, worker, worker_count, topic_opts)
   end
 
-  defp partition_child_spec(partition_index, %{worker: worker, opts: opts} = config) do
+  defp partition_child_spec(partition_index, %{worker: worker, worker_count: worker_count, opts: opts}) do
     base_topic = Keyword.fetch!(opts, :topic)
 
     partition_opts =
@@ -595,11 +595,11 @@ defmodule Pulsar.Topology do
         name: Topic.partition(Keyword.fetch!(opts, :name), partition_index)
       )
 
-    group_child_spec({:partition, partition_index}, worker, worker_count(config), partition_opts)
+    group_child_spec({:partition, partition_index}, worker, worker_count, partition_opts)
   end
 
-  defp worker_count(%{kind: :consumers, opts: opts}), do: Keyword.fetch!(opts, :consumer_count)
-  defp worker_count(%{kind: :producers}), do: 1
+  defp worker_count(:consumers, opts), do: Keyword.fetch!(opts, :consumer_count)
+  defp worker_count(:producers, _opts), do: 1
 
   defp group_child_spec(id, worker, worker_count, opts) do
     %{

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -43,18 +43,20 @@ defmodule Pulsar.Topology do
     }
   end
 
-  @spec start_link(module(), atom() | nil, atom(), keyword()) :: Supervisor.on_start()
-  def start_link(worker, registry, count_key, opts) do
-    start_link(worker, registry, count_key, opts, [])
+  @spec start_link(module(), atom() | nil, :consumers | :producers | :unknown, keyword()) ::
+          Supervisor.on_start()
+  def start_link(worker, registry, kind, opts) do
+    start_link(worker, registry, kind, opts, [])
   end
 
   # The fifth argument is an internal seam for exercising asynchronous discovery without a
   # broker. Consumer and Producer deliberately keep it out of the API they document.
   @doc false
-  @spec start_link(module(), atom() | nil, atom(), keyword(), keyword()) :: Supervisor.on_start()
-  def start_link(worker, registry, count_key, opts, controller_opts) do
+  @spec start_link(module(), atom() | nil, :consumers | :producers | :unknown, keyword(), keyword()) ::
+          Supervisor.on_start()
+  def start_link(worker, registry, kind, opts, controller_opts) do
     name = Keyword.fetch!(opts, :name)
-    config = %{worker: worker, count_key: count_key, opts: opts}
+    config = %{worker: worker, kind: kind, opts: opts}
 
     Supervisor.start_link(__MODULE__, {config, controller_opts}, start_options(registry, name))
   end
@@ -427,8 +429,7 @@ defmodule Pulsar.Topology do
     end
   end
 
-  defp resource_kind_for_config(%{count_key: :consumer_count}), do: :consumers
-  defp resource_kind_for_config(%{count_key: :producer_count}), do: :producers
+  defp resource_kind_for_config(%{kind: kind}) when kind in [:consumers, :producers], do: kind
   defp resource_kind_for_config(_config), do: :unknown
 
   # Carried on the child id so routing reads it from the same which_children the groups come
@@ -438,7 +439,7 @@ defmodule Pulsar.Topology do
   #
   # nil where a resource does not route on a key, and for a producer whose options have not been
   # through Producer.Options; Hash.partition/3 resolves it to the default.
-  defp hashing_scheme_for_config(%{count_key: :producer_count, opts: opts}) do
+  defp hashing_scheme_for_config(%{kind: :producers, opts: opts}) do
     Keyword.get(opts, :hashing_scheme)
   end
 
@@ -580,13 +581,13 @@ defmodule Pulsar.Topology do
   # :topic is the topic a worker subscribes to and :base_topic the one the resource was
   # configured with; they differ only for a partition. Workers carry both so a callback can
   # tell which partition it handles without inspecting the tree it lives in.
-  defp topic_child_spec(%{worker: worker, count_key: count_key, opts: opts}) do
+  defp topic_child_spec(%{worker: worker, opts: opts} = config) do
     topic_opts = Keyword.merge(opts, base_topic: Keyword.fetch!(opts, :topic), partition: nil)
 
-    group_child_spec({:topic, :non_partitioned}, worker, count_key, topic_opts)
+    group_child_spec({:topic, :non_partitioned}, worker, worker_count(config), topic_opts)
   end
 
-  defp partition_child_spec(partition_index, %{worker: worker, count_key: count_key, opts: opts}) do
+  defp partition_child_spec(partition_index, %{worker: worker, opts: opts} = config) do
     base_topic = Keyword.fetch!(opts, :topic)
 
     partition_opts =
@@ -597,13 +598,17 @@ defmodule Pulsar.Topology do
         name: Topic.partition(Keyword.fetch!(opts, :name), partition_index)
       )
 
-    group_child_spec({:partition, partition_index}, worker, count_key, partition_opts)
+    group_child_spec({:partition, partition_index}, worker, worker_count(config), partition_opts)
   end
 
-  defp group_child_spec(id, worker, count_key, opts) do
+  defp worker_count(%{kind: :consumers, opts: opts}), do: Keyword.fetch!(opts, :consumer_count)
+  defp worker_count(%{kind: :producers}), do: 1
+  defp worker_count(%{opts: opts}), do: Keyword.fetch!(opts, :worker_count)
+
+  defp group_child_spec(id, worker, worker_count, opts) do
     %{
       id: id,
-      start: {Group, :start_link, [worker, count_key, opts]},
+      start: {Group, :start_link, [worker, worker_count, opts]},
       restart: :transient,
       type: :supervisor
     }

--- a/lib/pulsar/topology/group.ex
+++ b/lib/pulsar/topology/group.ex
@@ -8,7 +8,9 @@ defmodule Pulsar.Topology.Group do
   require Logger
 
   @spec start_link(module(), pos_integer(), keyword()) :: Supervisor.on_start()
-  def start_link(worker, count, opts), do: Supervisor.start_link(__MODULE__, {worker, count, opts})
+  def start_link(worker, count, opts) when count > 0 do
+    Supervisor.start_link(__MODULE__, {worker, count, opts})
+  end
 
   @impl true
   def init({worker, count, opts}) do

--- a/lib/pulsar/topology/group.ex
+++ b/lib/pulsar/topology/group.ex
@@ -7,13 +7,12 @@ defmodule Pulsar.Topology.Group do
 
   require Logger
 
-  @spec start_link(module(), atom(), keyword()) :: Supervisor.on_start()
-  def start_link(worker, count_key, opts), do: Supervisor.start_link(__MODULE__, {worker, count_key, opts})
+  @spec start_link(module(), pos_integer(), keyword()) :: Supervisor.on_start()
+  def start_link(worker, count, opts), do: Supervisor.start_link(__MODULE__, {worker, count, opts})
 
   @impl true
-  def init({worker, count_key, opts}) do
+  def init({worker, count, opts}) do
     name = Keyword.fetch!(opts, :name)
-    count = Keyword.fetch!(opts, count_key)
 
     Logger.debug(
       "Starting #{inspect(worker)} group #{name} for topic #{Keyword.fetch!(opts, :topic)} with #{count} workers"
@@ -21,7 +20,7 @@ defmodule Pulsar.Topology.Group do
 
     children =
       for i <- 1..count do
-        # Producer epochs are keyed by broker name, so every worker needs its own identity.
+        # Workers need distinct names within a group; producer epochs are keyed by this identity.
         worker_name = "#{name}-#{i}"
 
         %{

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -96,12 +96,12 @@ defmodule Pulsar.ClientTest do
       end
     end
 
-    test "rejects a producer option the producer schema does not accept" do
-      assert_raise NimbleOptions.ValidationError, ~r/invalid value for :producer_count/, fn ->
+    test "rejects the removed producer count option" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options.*:producer_count/, fn ->
         Client.start_link(
           name: :bad_producer,
           host: "pulsar://127.0.0.1:1",
-          producers: [[topic: "t", producer_count: :many]]
+          producers: [[topic: "t", producer_count: 2]]
         )
       end
     end

--- a/test/unit/client_test.exs
+++ b/test/unit/client_test.exs
@@ -96,10 +96,20 @@ defmodule Pulsar.ClientTest do
       end
     end
 
-    test "rejects the removed producer count option" do
-      assert_raise NimbleOptions.ValidationError, ~r/unknown options.*:producer_count/, fn ->
+    test "rejects a producer option the producer schema does not accept" do
+      assert_raise NimbleOptions.ValidationError, ~r/invalid value for :access_mode/, fn ->
         Client.start_link(
           name: :bad_producer,
+          host: "pulsar://127.0.0.1:1",
+          producers: [[topic: "t", access_mode: :Nonsense]]
+        )
+      end
+    end
+
+    test "rejects the removed producer count option in a client declaration" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options.*:producer_count/, fn ->
+        Client.start_link(
+          name: :producer_count,
           host: "pulsar://127.0.0.1:1",
           producers: [[topic: "t", producer_count: 2]]
         )

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -198,7 +198,7 @@ defmodule Pulsar.Consumer.DeadLetterTest do
            [
              ConsumerWorker,
              registry,
-             :consumer_count,
+             :consumers,
              Keyword.put(opts(overrides), :companions, &DeadLetter.attach/2),
              [resolver: fn _topic, _opts -> Process.sleep(:infinity) end]
            ]}

--- a/test/unit/producer_options_test.exs
+++ b/test/unit/producer_options_test.exs
@@ -12,7 +12,6 @@ defmodule Pulsar.Producer.OptionsTest do
       opts = validate!([])
 
       assert opts[:client] == :default
-      assert opts[:producer_count] == 1
       assert opts[:access_mode] == :shared
       assert opts[:compression] == :none
       assert opts[:batch_enabled] == false
@@ -50,9 +49,9 @@ defmodule Pulsar.Producer.OptionsTest do
       end
     end
 
-    test "rejects a non-integer producer count" do
-      assert_raise NimbleOptions.ValidationError, ~r/:producer_count/, fn ->
-        validate!(producer_count: "two")
+    test "rejects the removed producer count option" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options.*:producer_count/, fn ->
+        validate!(producer_count: 2)
       end
     end
 

--- a/test/unit/producer_test.exs
+++ b/test/unit/producer_test.exs
@@ -174,7 +174,6 @@ defmodule Pulsar.ProducerTest do
           topic: "persistent://public/default/routing",
           name: "routing-producer",
           client: :test,
-          producer_count: 1,
           partition_discovery_interval_ms: false
         ],
         extra_opts
@@ -183,7 +182,7 @@ defmodule Pulsar.ProducerTest do
     root =
       start_supervised!(%{
         id: {:routing_topology, System.unique_integer([:positive])},
-        start: {Topology, :start_link, [RoutingWorker, registry, :producer_count, opts, [resolver: resolver]]},
+        start: {Topology, :start_link, [RoutingWorker, registry, :producers, opts, [resolver: resolver]]},
         type: :supervisor
       })
 

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -244,9 +244,9 @@ defmodule Pulsar.TopologyTest do
       assert is_pid(group)
     end
 
-    test "a producer topology starts one worker per partition" do
+    test "a producer topology starts one worker per partition regardless of stale count options" do
       {root, _registry} =
-        start_async_topology(fn _topic, _opts -> {:ok, 3} end, [],
+        start_async_topology(fn _topic, _opts -> {:ok, 3} end, [producer_count: 3],
           worker: OptsWorker,
           kind: :producers
         )
@@ -373,11 +373,10 @@ defmodule Pulsar.TopologyTest do
         topic: @topic,
         name: @name,
         client: :test,
-        consumer_count: 1,
         partition_discovery_interval_ms: false
       ]
 
-      config = %{worker: PartitionFourFails, kind: :consumers, opts: opts}
+      config = %{worker: PartitionFourFails, kind: :consumers, worker_count: 1, opts: opts}
 
       assert {:error, {:partition_start_failed, 4, _reason}} =
                Topology.reconcile(root, 6, config)

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -124,6 +124,7 @@ defmodule Pulsar.TopologyTest do
 
   defp start_async_topology(resolver, opts \\ [], controller_opts \\ []) do
     {worker, controller_opts} = Keyword.pop(controller_opts, :worker, StubWorker)
+    {kind, controller_opts} = Keyword.pop(controller_opts, :kind, :unknown)
     registry = :"registry-#{System.unique_integer([:positive])}"
     start_supervised!({Registry, keys: :unique, name: registry})
 
@@ -133,18 +134,22 @@ defmodule Pulsar.TopologyTest do
           topic: @topic,
           name: @name,
           client: :test,
-          count_key: 1,
           partition_discovery_interval_ms: false
         ],
         opts
       )
+
+    topology_opts =
+      if kind == :unknown,
+        do: Keyword.put_new(topology_opts, :worker_count, 1),
+        else: topology_opts
 
     root =
       start_supervised!(%{
         id: {:root, System.unique_integer([:positive])},
         start:
           {Topology, :start_link,
-           [worker, registry, :count_key, topology_opts, Keyword.put(controller_opts, :resolver, resolver)]},
+           [worker, registry, kind, topology_opts, Keyword.put(controller_opts, :resolver, resolver)]},
         type: :supervisor
       })
 
@@ -215,7 +220,7 @@ defmodule Pulsar.TopologyTest do
         if attempt == 0, do: {:error, :no_broker_available}, else: {:ok, 3}
       end
 
-      {root, _registry} = start_async_topology(resolver, count_key: 2)
+      {root, _registry} = start_async_topology(resolver, worker_count: 2)
 
       :ok = Topology.await_ready(root, 1_000)
       assert Agent.get(attempts, & &1) >= 2
@@ -237,6 +242,20 @@ defmodule Pulsar.TopologyTest do
       refute_receive :resolved, 150
       assert [{0, group}] = Topology.groups(root)
       assert is_pid(group)
+    end
+
+    test "a producer topology starts one worker per partition" do
+      {root, _registry} =
+        start_async_topology(fn _topic, _opts -> {:ok, 3} end, [],
+          worker: OptsWorker,
+          kind: :producers
+        )
+
+      :ok = Topology.await_ready(root, 1_000)
+
+      assert Enum.all?(Topology.groups(root), fn {_index, group} ->
+               match?([{_id, _worker, :worker, _modules}], Supervisor.which_children(group))
+             end)
     end
 
     @tag telemetry_listen: [
@@ -351,11 +370,11 @@ defmodule Pulsar.TopologyTest do
         topic: @topic,
         name: @name,
         client: :test,
-        count_key: 1,
+        worker_count: 1,
         partition_discovery_interval_ms: false
       ]
 
-      config = %{worker: PartitionFourFails, count_key: :count_key, opts: opts}
+      config = %{worker: PartitionFourFails, kind: :unknown, opts: opts}
 
       assert {:error, {:partition_start_failed, 4, _reason}} =
                Topology.reconcile(root, 6, config)

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -124,7 +124,7 @@ defmodule Pulsar.TopologyTest do
 
   defp start_async_topology(resolver, opts \\ [], controller_opts \\ []) do
     {worker, controller_opts} = Keyword.pop(controller_opts, :worker, StubWorker)
-    {kind, controller_opts} = Keyword.pop(controller_opts, :kind, :unknown)
+    {kind, controller_opts} = Keyword.pop(controller_opts, :kind, :consumers)
     registry = :"registry-#{System.unique_integer([:positive])}"
     start_supervised!({Registry, keys: :unique, name: registry})
 
@@ -140,8 +140,8 @@ defmodule Pulsar.TopologyTest do
       )
 
     topology_opts =
-      if kind == :unknown,
-        do: Keyword.put_new(topology_opts, :worker_count, 1),
+      if kind == :consumers,
+        do: Keyword.put_new(topology_opts, :consumer_count, 1),
         else: topology_opts
 
     root =
@@ -220,7 +220,7 @@ defmodule Pulsar.TopologyTest do
         if attempt == 0, do: {:error, :no_broker_available}, else: {:ok, 3}
       end
 
-      {root, _registry} = start_async_topology(resolver, worker_count: 2)
+      {root, _registry} = start_async_topology(resolver, consumer_count: 2)
 
       :ok = Topology.await_ready(root, 1_000)
       assert Agent.get(attempts, & &1) >= 2
@@ -253,7 +253,10 @@ defmodule Pulsar.TopologyTest do
 
       :ok = Topology.await_ready(root, 1_000)
 
-      assert Enum.all?(Topology.groups(root), fn {_index, group} ->
+      groups = Topology.groups(root)
+      assert length(groups) == 3
+
+      assert Enum.all?(groups, fn {_index, group} ->
                match?([{_id, _worker, :worker, _modules}], Supervisor.which_children(group))
              end)
     end
@@ -370,11 +373,11 @@ defmodule Pulsar.TopologyTest do
         topic: @topic,
         name: @name,
         client: :test,
-        worker_count: 1,
+        consumer_count: 1,
         partition_discovery_interval_ms: false
       ]
 
-      config = %{worker: PartitionFourFails, kind: :unknown, opts: opts}
+      config = %{worker: PartitionFourFails, kind: :consumers, opts: opts}
 
       assert {:error, {:partition_start_failed, 4, _reason}} =
                Topology.reconcile(root, 6, config)

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -244,9 +244,9 @@ defmodule Pulsar.TopologyTest do
       assert is_pid(group)
     end
 
-    test "a producer topology starts one worker per partition regardless of stale count options" do
+    test "a producer topology starts one worker per partition" do
       {root, _registry} =
-        start_async_topology(fn _topic, _opts -> {:ok, 3} end, [producer_count: 3],
+        start_async_topology(fn _topic, _opts -> {:ok, 3} end, [],
           worker: OptsWorker,
           kind: :producers
         )
@@ -257,7 +257,7 @@ defmodule Pulsar.TopologyTest do
       assert length(groups) == 3
 
       assert Enum.all?(groups, fn {_index, group} ->
-               match?([{_id, _worker, :worker, _modules}], Supervisor.which_children(group))
+               match?([{_id, pid, :worker, _modules}] when is_pid(pid), Supervisor.which_children(group))
              end)
     end
 


### PR DESCRIPTION
## Summary

Removes the `:producer_count` option and makes a producer topology run exactly one producer worker for a non-partitioned topic, or one worker per partition for a partitioned topic.

This is a breaking API change intended for 3.0. `:consumer_count` is unchanged.

## Motivation

`:producer_count` looked like a throughput control, but it did not distribute sends across the configured workers. Producer routing always selected the first live worker in a partition group, so values above `1` registered extra producers with the broker that normally remained idle.

Those extra workers were not harmless redundancy:

- Each had its own broker producer name, epoch, sequence-id state, pending sends, and batch.
- A failure or restart could move traffic between those independent ordering and deduplication domains.
- Multiple workers for one partition were at odds with exclusive producer access modes.
- Readiness waited for every configured worker even though only one was used for publishing.

The throughput argument no longer applies now that `send_async/3` allows one producer worker to carry many sends in flight. Batching amortizes broker writes, while topic partitions provide independent parallel send lanes without splitting one partition across producer identities.

## Implementation

- Removes `:producer_count` from `Pulsar.Producer.Options`; supplying it now fails validation instead of being silently ignored.
- Makes topology construction explicit about whether a resource contains consumers or producers.
- Resolves the group worker count centrally: consumers still use `:consumer_count`, while producers always use `1`.
- Passes the resolved count into `Pulsar.Topology.Group` instead of passing an option key.
- Updates the architecture guide and adds regression coverage for one producer worker per partition.

## Breaking change and migration

Remove `:producer_count` from producer declarations:

```elixir
# Before
{Pulsar.Producer,
 topic: "orders",
 producer_count: 4}

# 3.0
{Pulsar.Producer,
 topic: "orders"}
```

Use `Pulsar.Producer.send_async/3` with `await/2` when one calling process needs several sends in flight:

```elixir
refs =
  for payload <- payloads do
    {:ok, ref} = Pulsar.Producer.send_async(:orders, payload)
    ref
  end

Enum.map(refs, &Pulsar.Producer.await/1)
```

Use a partitioned topic when the workload needs multiple parallel send lanes. Messages routed to the same partition continue through one producer worker.

## Verification

- `mix test test/unit` — 378 passing (28 doctests, 350 tests)
- `mix compile --warnings-as-errors`
- `mix docs`
