### PR TITLE
fix(consumer): manual flow control stalled on uncounted permits

### DIFF
--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -15,6 +15,38 @@ defmodule Pulsar.Consumer do
   delivered the message. `send_flow/3` grants permits to a worker or every worker behind
   the consumer root.
 
+  ## Flow Control
+
+  A consumer grants `:flow_initial` permits when it subscribes, and `:flow_policy` decides
+  what happens from there. `:auto` refills `:flow_refill` whenever outstanding permits reach
+  `:flow_threshold`. `:manual` never refills on its own. A `{module, function, args}` policy
+  is asked after every delivery:
+
+      defmodule MyApp.Flow do
+        def decide(%{outstanding: outstanding}, refill) when outstanding <= 20, do: {:grant, refill}
+        def decide(_flow, _refill), do: :ok
+      end
+
+      Pulsar.Consumer.start(topic, subscription, MyApp.Callback,
+        flow_policy: {MyApp.Flow, :decide, [100]}
+      )
+
+  It receives `%{consumed: permits, outstanding: permits}` and answers `:ok` or
+  `{:grant, permits}`. `:consumed` is what the delivery cost and `:outstanding` what is left
+  after it, before any grant the policy makes.
+
+  `:consumed` counts every message the broker charged for, not the ones a callback saw. The
+  broker also charges for batch members excluded by an `ack_set` on a partially acknowledged
+  entry, members compacted away, and deliveries diverted to a dead letter topic — none of
+  which reach `c:Pulsar.Consumer.Callback.handle_message/2` or
+  `c:Pulsar.Consumer.Callback.handle_invalid_message/2`. A policy that counts callbacks
+  instead eventually believes the broker holds permits it has already spent.
+
+  A policy runs in the consumer process, so it must not call `send_flow/3` on that consumer:
+  that is a call to itself and deadlocks. Handing the decision to another process, which then
+  calls `send_flow/3`, is fine as long as that process is not waiting on this one. Granting
+  does not ask the policy again, and neither does `send_flow/3`.
+
   ## Options
 
   #{Pulsar.Consumer.Options.docs()}

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -184,7 +184,8 @@ defmodule Pulsar.Consumer do
   @doc """
   Grants a consumer more flow permits.
 
-  Only needed when `:flow_initial` is `0`, which turns off automatic flow control.
+  Only needed under `flow_policy: :manual`, and only for refills a callback module's
+  `handle_permits/2` does not make itself.
 
   Takes the stable consumer root, one of its worker pids, or its name. Every live worker behind
   a root is granted the permits, and the first refusal is returned — retrying by name is safe,
@@ -194,9 +195,9 @@ defmodule Pulsar.Consumer do
   returned.
 
   A consumer with no workers is an error rather than a silent success: nothing was granted,
-  so nothing will be delivered. Permits belong to individual worker instances; a replacement
-  starts with the configured `:flow_initial` and therefore needs another grant when that value
-  is `0`.
+  so nothing will be delivered. Permits belong to individual worker instances, and each grants
+  `:flow_initial` for itself on subscribe, so a replacement needs another grant only for
+  whatever it had been given on top of that.
   """
   @spec send_flow(pid() | String.t() | atom(), pos_integer(), keyword()) :: :ok | {:error, term()}
   def send_flow(consumer, permits, opts \\ [])

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -17,10 +17,9 @@ defmodule Pulsar.Consumer do
 
   ## Flow Control
 
-  A consumer grants `:flow_initial` permits when it subscribes, and `:flow_policy` decides
-  what happens from there. `:auto` refills `:flow_refill` whenever outstanding permits reach
-  `:flow_threshold`. `:manual` never refills on its own. A `{module, function, args}` policy
-  is asked after every delivery:
+  A consumer grants `:flow_initial` permits when it subscribes, and `:flow_policy` refills
+  them from there. `:auto` grants `:flow_refill` whenever outstanding permits reach
+  `:flow_threshold`. Name a `{module, function, args}` to decide for yourself:
 
       defmodule MyApp.Flow do
         def decide(%{outstanding: outstanding}, refill) when outstanding <= 20, do: {:grant, refill}
@@ -31,21 +30,26 @@ defmodule Pulsar.Consumer do
         flow_policy: {MyApp.Flow, :decide, [100]}
       )
 
-  It receives `%{consumed: permits, outstanding: permits}` and answers `:ok` or
-  `{:grant, permits}`. `:consumed` is what the delivery cost and `:outstanding` what is left
-  after it, before any grant the policy makes.
+  It is asked after every delivery with `%{consumed: permits, outstanding: permits}`, and
+  answers `:ok` or `{:grant, permits}`. `:consumed` is what the delivery cost and
+  `:outstanding` what is left after it, before any grant the policy makes.
 
   `:consumed` counts every message the broker charged for, not the ones a callback saw. The
   broker also charges for batch members excluded by an `ack_set` on a partially acknowledged
   entry, members compacted away, and deliveries diverted to a dead letter topic — none of
   which reach `c:Pulsar.Consumer.Callback.handle_message/2` or
-  `c:Pulsar.Consumer.Callback.handle_invalid_message/2`. A policy that counts callbacks
-  instead eventually believes the broker holds permits it has already spent.
+  `c:Pulsar.Consumer.Callback.handle_invalid_message/2`. A policy counting callbacks instead
+  eventually believes the broker holds permits it has already spent.
 
-  A policy runs in the consumer process, so it must not call `send_flow/3` on that consumer:
-  that is a call to itself and deadlocks. Handing the decision to another process, which then
-  calls `send_flow/3`, is fine as long as that process is not waiting on this one. Granting
-  does not ask the policy again, and neither does `send_flow/3`.
+  Two things follow from a policy only being asked after a delivery. It cannot grant the
+  first permits, since without them nothing is delivered: those come from `:flow_initial`, or
+  from `send_flow/3` in another process. And it runs in the consumer process, so it must not
+  call `send_flow/3` on that consumer — that is a call to itself and deadlocks. Handing the
+  decision to another process, which then calls `send_flow/3`, is fine as long as that process
+  is not waiting on this one.
+
+  A policy that always answers `:ok` grants nothing, leaving every refill to `send_flow/3`.
+  Granting does not ask the policy again, and neither does `send_flow/3`.
 
   ## Options
 
@@ -216,8 +220,8 @@ defmodule Pulsar.Consumer do
   @doc """
   Grants a consumer more flow permits.
 
-  Only needed under `flow_policy: :manual`, and only for refills a callback module's
-  `handle_permits/2` does not make itself.
+  Needed when the consumer's `:flow_policy` leaves refills to you, and to grant the first
+  permits when `:flow_initial` is `0`, which no policy can do itself.
 
   Takes the stable consumer root, one of its worker pids, or its name. Every live worker behind
   a root is granted the permits, and the first refusal is returned — retrying by name is safe,

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -45,6 +45,15 @@ defmodule Pulsar.Consumer.Callback do
     redelivered). Override it to record or divert such messages; see `Pulsar.Message.valid?/1`
     for what they contain. Because they are routed here, `handle_message/2` only ever
     receives messages that arrived intact.
+  - `handle_permits/2` - Called after every delivery with the permits it consumed and the
+    consumer's flow window before any refill. Its default implementation applies the configured
+    automatic refill policy; overriding it replaces that policy. See `## Flow Control`.
+
+  These defaults come from `use Pulsar.Consumer.Callback`. A module taking the behaviour without
+  it has to write them itself, since the consumer calls each one directly. `handle_permits/2` is
+  the one it cannot skip — every delivery goes through it, so it is left out of
+  `@optional_callbacks` and the compiler says so rather than letting the consumer fail on its
+  first message.
 
   ## Message Format
 
@@ -136,6 +145,15 @@ defmodule Pulsar.Consumer.Callback do
   - `{:noreply, new_state}` - Message processed, but don't automatically ACK/NACK. Use `Pulsar.Consumer.ack/2` or `Pulsar.Consumer.nack/2` for manual acknowledgment
   - `{:stop, new_state}` - Message processed successfully, acknowledge, then stop consumer
 
+  ### `handle_permits/2` (Optional)
+
+  Takes a `t:flow_context/0` and the current state. The default implementation grants
+  `:refill` when an automatic consumer's `:outstanding` permits reach `:threshold`; call
+  `super(flow, state)` to observe flow without replacing it. See `## Flow Control`.
+
+  - `{:ok, new_state}` - Grant nothing
+  - `{:grant, permits, new_state}` - Grant `permits` more to the broker
+
   ### `terminate/2` (Optional)
 
   If not implemented, defaults to `:ok`.
@@ -218,6 +236,44 @@ defmodule Pulsar.Consumer.Callback do
 
         {:noreply, state}
       end
+
+  ## Flow Control
+
+  After every broker delivery the consumer calls `handle_permits/2` once, with the total
+  permits that delivery consumed, however many message callbacks it triggered — including none.
+  `:outstanding` is the window after that consumption and before any grant returned here.
+
+  This matters for batches and dead-letter policies. The broker also charges for batch members
+  excluded by an `ack_set`, messages compacted away, and deliveries diverted to a dead letter
+  topic. Counting only callback-visible messages eventually overestimates the broker's window.
+
+  The default implementation provides automatic flow control. Override it to replace the
+  configured threshold/refill policy:
+
+      defmodule MyApp.PacedConsumer do
+        use Pulsar.Consumer.Callback
+
+        def handle_permits(%{outstanding: outstanding}, state) when outstanding <= 20 do
+          {:grant, 50, state}
+        end
+
+        def handle_permits(_flow, state), do: {:ok, state}
+
+        def handle_message(_message, state), do: {:ok, state}
+      end
+
+  A consumer configured with `flow_initial: 0` is in manual mode, so the default grants nothing
+  and the decision is yours. An override can answer here with `{:grant, permits, state}`, or
+  forward `flow.consumed` to its owning process, return `{:ok, state}`, and have that process
+  grant later with `Pulsar.Consumer.send_flow/2`.
+
+  Grant through the return value rather than `Pulsar.Consumer.send_flow/2`. This callback runs
+  in the consumer process, so calling `send_flow/2` on that consumer from here deadlocks.
+  Handing the decision to another process, which then calls `send_flow/2`, is fine as long as
+  that process is not itself waiting on this one.
+
+  Neither granting from this callback nor `Pulsar.Consumer.send_flow/2` calls it again: it
+  reports broker consumption, not grants.
   """
 
   @type message_args :: Pulsar.Message.t()
@@ -225,6 +281,24 @@ defmodule Pulsar.Consumer.Callback do
   @type init_arg :: term()
   @type state :: term()
   @type reason :: term()
+
+  @typedoc """
+  Flow accounting for one broker delivery, passed to `c:handle_permits/2`.
+
+  - `:consumed` - total broker permits consumed by the delivery, including messages no message
+    callback received
+  - `:outstanding` - permits left after that consumption and before a callback-requested grant
+  - `:threshold` - configured automatic refill threshold
+  - `:refill` - configured automatic refill amount
+  - `:mode` - `:automatic` when `:flow_initial` is positive, otherwise `:manual`
+  """
+  @type flow_context :: %{
+          consumed: non_neg_integer(),
+          outstanding: non_neg_integer(),
+          threshold: non_neg_integer(),
+          refill: non_neg_integer(),
+          mode: :automatic | :manual
+        }
 
   @typedoc """
   The consumer's resolved identity, passed to `c:init/2`.
@@ -291,6 +365,9 @@ defmodule Pulsar.Consumer.Callback do
               {:ok, state}
               | {:error, reason, state}
               | {:noreply, state}
+  @callback handle_permits(flow_context, state) ::
+              {:ok, state}
+              | {:grant, pos_integer(), state}
 
   defmacro __using__(_opts) do
     quote do
@@ -330,6 +407,15 @@ defmodule Pulsar.Consumer.Callback do
         {:ok, state}
       end
 
+      def handle_permits(%{mode: :automatic, outstanding: outstanding, threshold: threshold, refill: refill}, state)
+          when outstanding <= threshold and refill > 0 do
+        {:grant, refill, state}
+      end
+
+      def handle_permits(_flow, state) do
+        {:ok, state}
+      end
+
       defoverridable init: 2,
                      terminate: 2,
                      handle_call: 3,
@@ -337,7 +423,8 @@ defmodule Pulsar.Consumer.Callback do
                      handle_info: 2,
                      became_active: 1,
                      became_passive: 1,
-                     handle_invalid_message: 2
+                     handle_invalid_message: 2,
+                     handle_permits: 2
     end
   end
 

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -45,15 +45,6 @@ defmodule Pulsar.Consumer.Callback do
     redelivered). Override it to record or divert such messages; see `Pulsar.Message.valid?/1`
     for what they contain. Because they are routed here, `handle_message/2` only ever
     receives messages that arrived intact.
-  - `handle_permits/2` - Called after every delivery with the permits it consumed and the
-    consumer's flow window before any refill. Its default implementation applies the configured
-    automatic refill policy; overriding it replaces that policy. See `## Flow Control`.
-
-  These defaults come from `use Pulsar.Consumer.Callback`. A module taking the behaviour without
-  it has to write them itself, since the consumer calls each one directly. `handle_permits/2` is
-  the one it cannot skip — every delivery goes through it, so it is left out of
-  `@optional_callbacks` and the compiler says so rather than letting the consumer fail on its
-  first message.
 
   ## Message Format
 
@@ -145,15 +136,6 @@ defmodule Pulsar.Consumer.Callback do
   - `{:noreply, new_state}` - Message processed, but don't automatically ACK/NACK. Use `Pulsar.Consumer.ack/2` or `Pulsar.Consumer.nack/2` for manual acknowledgment
   - `{:stop, new_state}` - Message processed successfully, acknowledge, then stop consumer
 
-  ### `handle_permits/2` (Optional)
-
-  Takes a `t:flow_context/0` and the current state. The default implementation grants
-  `:refill` when an `:auto` consumer's `:outstanding` permits reach `:threshold`; call
-  `super(flow, state)` to observe flow without replacing it. See `## Flow Control`.
-
-  - `{:ok, new_state}` - Grant nothing
-  - `{:grant, permits, new_state}` - Grant `permits` more to the broker
-
   ### `terminate/2` (Optional)
 
   If not implemented, defaults to `:ok`.
@@ -236,45 +218,6 @@ defmodule Pulsar.Consumer.Callback do
 
         {:noreply, state}
       end
-
-  ## Flow Control
-
-  After every broker delivery the consumer calls `handle_permits/2` once, with the total
-  permits that delivery consumed, however many message callbacks it triggered — including none.
-  `:outstanding` is the window after that consumption and before any grant returned here.
-
-  This matters for batches and dead-letter policies. The broker also charges for batch members
-  excluded by an `ack_set`, messages compacted away, and deliveries diverted to a dead letter
-  topic. Counting only callback-visible messages eventually overestimates the broker's window.
-
-  The default implementation is the `flow_policy: :auto` policy. Override it to replace the
-  configured threshold/refill rule:
-
-      defmodule MyApp.PacedConsumer do
-        use Pulsar.Consumer.Callback
-
-        def handle_permits(%{outstanding: outstanding}, state) when outstanding <= 20 do
-          {:grant, 50, state}
-        end
-
-        def handle_permits(_flow, state), do: {:ok, state}
-
-        def handle_message(_message, state), do: {:ok, state}
-      end
-
-  Under `flow_policy: :manual` the default grants nothing and every refill is yours. `:flow_initial`
-  is still granted on subscribe under either policy, so a manual consumer can start with a window
-  and manage it from there, and a replacement worker comes back with the same one. An override can
-  answer here with `{:grant, permits, state}`, or forward `flow.consumed` to its owning process,
-  return `{:ok, state}`, and have that process grant later with `Pulsar.Consumer.send_flow/2`.
-
-  Grant through the return value rather than `Pulsar.Consumer.send_flow/2`. This callback runs
-  in the consumer process, so calling `send_flow/2` on that consumer from here deadlocks.
-  Handing the decision to another process, which then calls `send_flow/2`, is fine as long as
-  that process is not itself waiting on this one.
-
-  Neither granting from this callback nor `Pulsar.Consumer.send_flow/2` calls it again: it
-  reports broker consumption, not grants.
   """
 
   @type message_args :: Pulsar.Message.t()
@@ -282,24 +225,6 @@ defmodule Pulsar.Consumer.Callback do
   @type init_arg :: term()
   @type state :: term()
   @type reason :: term()
-
-  @typedoc """
-  Flow accounting for one broker delivery, passed to `c:handle_permits/2`.
-
-  - `:consumed` - total broker permits consumed by the delivery, including messages no message
-    callback received
-  - `:outstanding` - permits left after that consumption and before a callback-requested grant
-  - `:threshold` - configured automatic refill threshold
-  - `:refill` - configured automatic refill amount
-  - `:mode` - the consumer's `:flow_policy`, `:auto` or `:manual`
-  """
-  @type flow_context :: %{
-          consumed: non_neg_integer(),
-          outstanding: non_neg_integer(),
-          threshold: non_neg_integer(),
-          refill: non_neg_integer(),
-          mode: :auto | :manual
-        }
 
   @typedoc """
   The consumer's resolved identity, passed to `c:init/2`.
@@ -366,9 +291,6 @@ defmodule Pulsar.Consumer.Callback do
               {:ok, state}
               | {:error, reason, state}
               | {:noreply, state}
-  @callback handle_permits(flow_context, state) ::
-              {:ok, state}
-              | {:grant, pos_integer(), state}
 
   defmacro __using__(_opts) do
     quote do
@@ -408,15 +330,6 @@ defmodule Pulsar.Consumer.Callback do
         {:ok, state}
       end
 
-      def handle_permits(%{mode: :auto, outstanding: outstanding, threshold: threshold, refill: refill}, state)
-          when outstanding <= threshold and refill > 0 do
-        {:grant, refill, state}
-      end
-
-      def handle_permits(_flow, state) do
-        {:ok, state}
-      end
-
       defoverridable init: 2,
                      terminate: 2,
                      handle_call: 3,
@@ -424,8 +337,7 @@ defmodule Pulsar.Consumer.Callback do
                      handle_info: 2,
                      became_active: 1,
                      became_passive: 1,
-                     handle_invalid_message: 2,
-                     handle_permits: 2
+                     handle_invalid_message: 2
     end
   end
 

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -148,7 +148,7 @@ defmodule Pulsar.Consumer.Callback do
   ### `handle_permits/2` (Optional)
 
   Takes a `t:flow_context/0` and the current state. The default implementation grants
-  `:refill` when an automatic consumer's `:outstanding` permits reach `:threshold`; call
+  `:refill` when an `:auto` consumer's `:outstanding` permits reach `:threshold`; call
   `super(flow, state)` to observe flow without replacing it. See `## Flow Control`.
 
   - `{:ok, new_state}` - Grant nothing
@@ -247,8 +247,8 @@ defmodule Pulsar.Consumer.Callback do
   excluded by an `ack_set`, messages compacted away, and deliveries diverted to a dead letter
   topic. Counting only callback-visible messages eventually overestimates the broker's window.
 
-  The default implementation provides automatic flow control. Override it to replace the
-  configured threshold/refill policy:
+  The default implementation is the `flow_policy: :auto` policy. Override it to replace the
+  configured threshold/refill rule:
 
       defmodule MyApp.PacedConsumer do
         use Pulsar.Consumer.Callback
@@ -262,10 +262,11 @@ defmodule Pulsar.Consumer.Callback do
         def handle_message(_message, state), do: {:ok, state}
       end
 
-  A consumer configured with `flow_initial: 0` is in manual mode, so the default grants nothing
-  and the decision is yours. An override can answer here with `{:grant, permits, state}`, or
-  forward `flow.consumed` to its owning process, return `{:ok, state}`, and have that process
-  grant later with `Pulsar.Consumer.send_flow/2`.
+  Under `flow_policy: :manual` the default grants nothing and every refill is yours. `:flow_initial`
+  is still granted on subscribe under either policy, so a manual consumer can start with a window
+  and manage it from there, and a replacement worker comes back with the same one. An override can
+  answer here with `{:grant, permits, state}`, or forward `flow.consumed` to its owning process,
+  return `{:ok, state}`, and have that process grant later with `Pulsar.Consumer.send_flow/2`.
 
   Grant through the return value rather than `Pulsar.Consumer.send_flow/2`. This callback runs
   in the consumer process, so calling `send_flow/2` on that consumer from here deadlocks.
@@ -290,14 +291,14 @@ defmodule Pulsar.Consumer.Callback do
   - `:outstanding` - permits left after that consumption and before a callback-requested grant
   - `:threshold` - configured automatic refill threshold
   - `:refill` - configured automatic refill amount
-  - `:mode` - `:automatic` when `:flow_initial` is positive, otherwise `:manual`
+  - `:mode` - the consumer's `:flow_policy`, `:auto` or `:manual`
   """
   @type flow_context :: %{
           consumed: non_neg_integer(),
           outstanding: non_neg_integer(),
           threshold: non_neg_integer(),
           refill: non_neg_integer(),
-          mode: :automatic | :manual
+          mode: :auto | :manual
         }
 
   @typedoc """
@@ -407,7 +408,7 @@ defmodule Pulsar.Consumer.Callback do
         {:ok, state}
       end
 
-      def handle_permits(%{mode: :automatic, outstanding: outstanding, threshold: threshold, refill: refill}, state)
+      def handle_permits(%{mode: :auto, outstanding: outstanding, threshold: threshold, refill: refill}, state)
           when outstanding <= threshold and refill > 0 do
         {:grant, refill, state}
       end

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -46,12 +46,16 @@ defmodule Pulsar.Consumer.Options do
       doc: "Passed to the callback module's `init/1`."
     ],
     flow_policy: [
-      type: {:in, [:auto, :manual]},
+      type: {:custom, __MODULE__, :validate_flow_policy, []},
       default: :auto,
       doc: """
       Who decides refills once the consumer is running. `:auto` applies `:flow_threshold` and
-      `:flow_refill` through the callback module's default `handle_permits/2`. `:manual` leaves
-      every refill to you, through that callback or `Pulsar.Consumer.send_flow/2`.
+      `:flow_refill`. `:manual` never refills, leaving it to `Pulsar.Consumer.send_flow/2`. A
+      `{module, function, args}` is called after every delivery as
+      `apply(module, function, [flow | args])`, where `flow` is
+      `%{consumed: permits, outstanding: permits}`, and answers `:ok` or `{:grant, permits}`.
+      It runs in the consumer process, so it must not call `Pulsar.Consumer.send_flow/2` on
+      that consumer. See `Pulsar.Consumer` for what `:consumed` counts.
       """
     ],
     flow_initial: [
@@ -234,9 +238,28 @@ defmodule Pulsar.Consumer.Options do
       raise ArgumentError,
             "flow_policy: :auto with flow_initial: 0 never receives a message: the broker is " <>
               "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
-              ":flow_initial, or flow_policy: :manual to grant permits yourself."
+              ":flow_initial, or a policy that grants permits itself."
     end
 
     opts
+  end
+
+  @doc false
+  @spec validate_flow_policy(term()) :: {:ok, term()} | {:error, String.t()}
+  def validate_flow_policy(policy) when policy in [:auto, :manual], do: {:ok, policy}
+
+  # Checked here rather than at the first delivery, where an unloadable policy would take the
+  # consumer down once per redelivery.
+  def validate_flow_policy({module, function, args} = policy)
+      when is_atom(module) and is_atom(function) and is_list(args) do
+    if Code.ensure_loaded?(module) and function_exported?(module, function, length(args) + 1) do
+      {:ok, policy}
+    else
+      {:error, "expected #{inspect(module)} to export #{function}/#{length(args) + 1}"}
+    end
+  end
+
+  def validate_flow_policy(other) do
+    {:error, "expected :auto, :manual, or a {module, function, args} tuple, got: #{inspect(other)}"}
   end
 end

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -1,6 +1,8 @@
 defmodule Pulsar.Consumer.Options do
   @moduledoc false
 
+  require Logger
+
   @schema [
     topic: [
       type: :string,
@@ -45,26 +47,33 @@ defmodule Pulsar.Consumer.Options do
       default: [],
       doc: "Passed to the callback module's `init/1`."
     ],
+    flow_policy: [
+      type: {:in, [:auto, :manual]},
+      doc: """
+      Who decides refills once the consumer is running. `:auto` applies `:flow_threshold` and
+      `:flow_refill` through the callback module's default `handle_permits/2`. `:manual` leaves
+      every refill to you, through that callback or `Pulsar.Consumer.send_flow/2`. Defaults to
+      `:auto`, or to `:manual` when `:flow_initial` is `0`.
+      """
+    ],
     flow_initial: [
       type: :non_neg_integer,
       default: 100,
       doc: """
-      Permits granted to the broker on subscribe. A positive value selects automatic mode,
-      whose default `handle_permits/2` implementation applies `:flow_threshold` and
-      `:flow_refill`. `0` selects manual mode, whose default grants nothing; override the
-      callback or use `Pulsar.Consumer.send_flow/2`. Permits belong to a worker instance, so
-      replacement workers also start with `0` and must be granted permits again.
+      Permits granted to the broker when a consumer subscribes, under either policy. Every
+      worker instance grants them, so a replacement comes back with its window rather than
+      waiting to be given one.
       """
     ],
     flow_threshold: [
       type: :non_neg_integer,
       default: 50,
-      doc: "Outstanding permits at which the default automatic flow policy requests more."
+      doc: "Outstanding permits at which the default `:auto` policy requests more."
     ],
     flow_refill: [
       type: :non_neg_integer,
       default: 50,
-      doc: "Permits requested by each default automatic refill."
+      doc: "Permits requested by each refill the default `:auto` policy makes."
     ],
     initial_position: [
       type: {:in, [:earliest, :latest]},
@@ -220,5 +229,30 @@ defmodule Pulsar.Consumer.Options do
   Validates consumer options.
   """
   @spec validate!(keyword()) :: keyword()
-  def validate!(opts), do: NimbleOptions.validate!(opts, @schema)
+  def validate!(opts), do: opts |> NimbleOptions.validate!(@schema) |> resolve_flow_policy!()
+
+  # :flow_policy carries no default, so an absent one can still be told apart from a stated one
+  # and read the way 3.0 read :flow_initial.
+  defp resolve_flow_policy!(opts) do
+    case {Keyword.get(opts, :flow_policy), Keyword.fetch!(opts, :flow_initial)} do
+      {nil, 0} ->
+        Logger.warning(
+          "flow_initial: 0 to select manual flow control is deprecated, set flow_policy: :manual instead"
+        )
+
+        Keyword.put(opts, :flow_policy, :manual)
+
+      {nil, _initial} ->
+        Keyword.put(opts, :flow_policy, :auto)
+
+      {:auto, 0} ->
+        raise ArgumentError,
+              "flow_policy: :auto with flow_initial: 0 never receives a message: the broker is " <>
+                "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
+                ":flow_initial, or flow_policy: :manual to grant permits yourself."
+
+      {_policy, _initial} ->
+        opts
+    end
+  end
 end

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -1,8 +1,6 @@
 defmodule Pulsar.Consumer.Options do
   @moduledoc false
 
-  require Logger
-
   @schema [
     topic: [
       type: :string,
@@ -49,11 +47,11 @@ defmodule Pulsar.Consumer.Options do
     ],
     flow_policy: [
       type: {:in, [:auto, :manual]},
+      default: :auto,
       doc: """
       Who decides refills once the consumer is running. `:auto` applies `:flow_threshold` and
       `:flow_refill` through the callback module's default `handle_permits/2`. `:manual` leaves
-      every refill to you, through that callback or `Pulsar.Consumer.send_flow/2`. Defaults to
-      `:auto`, or to `:manual` when `:flow_initial` is `0`.
+      every refill to you, through that callback or `Pulsar.Consumer.send_flow/2`.
       """
     ],
     flow_initial: [
@@ -229,30 +227,16 @@ defmodule Pulsar.Consumer.Options do
   Validates consumer options.
   """
   @spec validate!(keyword()) :: keyword()
-  def validate!(opts), do: opts |> NimbleOptions.validate!(@schema) |> resolve_flow_policy!()
+  def validate!(opts), do: opts |> NimbleOptions.validate!(@schema) |> validate_flow!()
 
-  # :flow_policy carries no default, so an absent one can still be told apart from a stated one
-  # and read the way 3.0 read :flow_initial.
-  defp resolve_flow_policy!(opts) do
-    case {Keyword.get(opts, :flow_policy), Keyword.fetch!(opts, :flow_initial)} do
-      {nil, 0} ->
-        Logger.warning(
-          "flow_initial: 0 to select manual flow control is deprecated, set flow_policy: :manual instead"
-        )
-
-        Keyword.put(opts, :flow_policy, :manual)
-
-      {nil, _initial} ->
-        Keyword.put(opts, :flow_policy, :auto)
-
-      {:auto, 0} ->
-        raise ArgumentError,
-              "flow_policy: :auto with flow_initial: 0 never receives a message: the broker is " <>
-                "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
-                ":flow_initial, or flow_policy: :manual to grant permits yourself."
-
-      {_policy, _initial} ->
-        opts
+  defp validate_flow!(opts) do
+    if Keyword.fetch!(opts, :flow_policy) == :auto and Keyword.fetch!(opts, :flow_initial) == 0 do
+      raise ArgumentError,
+            "flow_policy: :auto with flow_initial: 0 never receives a message: the broker is " <>
+              "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
+              ":flow_initial, or flow_policy: :manual to grant permits yourself."
     end
+
+    opts
   end
 end

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -49,13 +49,10 @@ defmodule Pulsar.Consumer.Options do
       type: {:custom, __MODULE__, :validate_flow_policy, []},
       default: :auto,
       doc: """
-      Who decides refills once the consumer is running. `:auto` applies `:flow_threshold` and
-      `:flow_refill`. `:manual` never refills, leaving it to `Pulsar.Consumer.send_flow/2`. A
-      `{module, function, args}` is called after every delivery as
-      `apply(module, function, [flow | args])`, where `flow` is
-      `%{consumed: permits, outstanding: permits}`, and answers `:ok` or `{:grant, permits}`.
-      It runs in the consumer process, so it must not call `Pulsar.Consumer.send_flow/2` on
-      that consumer. See `Pulsar.Consumer` for what `:consumed` counts.
+      What refills permits once the consumer is running. `:auto` grants `:flow_refill` whenever
+      outstanding permits reach `:flow_threshold`. A `{module, function, args}` decides for
+      itself; see `Pulsar.Consumer` for what it is passed, what it may answer, and what it
+      cannot do.
       """
     ],
     flow_initial: [
@@ -238,7 +235,8 @@ defmodule Pulsar.Consumer.Options do
       raise ArgumentError,
             "flow_policy: :auto with flow_initial: 0 never receives a message: the broker is " <>
               "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
-              ":flow_initial, or a policy that grants permits itself."
+              ":flow_initial, or a {module, function, args} policy if permits will come from " <>
+              "Pulsar.Consumer.send_flow/3."
     end
 
     opts
@@ -246,7 +244,7 @@ defmodule Pulsar.Consumer.Options do
 
   @doc false
   @spec validate_flow_policy(term()) :: {:ok, term()} | {:error, String.t()}
-  def validate_flow_policy(policy) when policy in [:auto, :manual], do: {:ok, policy}
+  def validate_flow_policy(:auto), do: {:ok, :auto}
 
   # Checked here rather than at the first delivery, where an unloadable policy would take the
   # consumer down once per redelivery.
@@ -260,6 +258,6 @@ defmodule Pulsar.Consumer.Options do
   end
 
   def validate_flow_policy(other) do
-    {:error, "expected :auto, :manual, or a {module, function, args} tuple, got: #{inspect(other)}"}
+    {:error, "expected :auto or a {module, function, args} tuple, got: #{inspect(other)}"}
   end
 end

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -49,20 +49,22 @@ defmodule Pulsar.Consumer.Options do
       type: :non_neg_integer,
       default: 100,
       doc: """
-      Permits granted to the broker on subscribe. `0` disables automatic flow control,
-      leaving it to `Pulsar.Consumer.send_flow/2`. Permits belong to a worker instance, so
+      Permits granted to the broker on subscribe. A positive value selects automatic mode,
+      whose default `handle_permits/2` implementation applies `:flow_threshold` and
+      `:flow_refill`. `0` selects manual mode, whose default grants nothing; override the
+      callback or use `Pulsar.Consumer.send_flow/2`. Permits belong to a worker instance, so
       replacement workers also start with `0` and must be granted permits again.
       """
     ],
     flow_threshold: [
       type: :non_neg_integer,
       default: 50,
-      doc: "Outstanding permits at which more are requested. Ignored when `:flow_initial` is 0."
+      doc: "Outstanding permits at which the default automatic flow policy requests more."
     ],
     flow_refill: [
       type: :non_neg_integer,
       default: 50,
-      doc: "Permits requested on each refill. Ignored when `:flow_initial` is 0."
+      doc: "Permits requested by each default automatic refill."
     ],
     initial_position: [
       type: {:in, [:earliest, :latest]},

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -66,6 +66,8 @@ defmodule Pulsar.Consumer.Worker do
     :schema_version
   ]
 
+  @type flow_mfa :: {module(), atom(), [term()]}
+
   @type t :: %__MODULE__{
           topic: String.t(),
           base_topic: String.t(),
@@ -79,7 +81,7 @@ defmodule Pulsar.Consumer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           ready: boolean(),
-          flow_policy: :auto | :manual,
+          flow_policy: :auto | :manual | flow_mfa(),
           flow_initial: non_neg_integer(),
           flow_threshold: non_neg_integer(),
           flow_refill: non_neg_integer(),
@@ -407,7 +409,7 @@ defmodule Pulsar.Consumer.Worker do
         :deliver -> process_messages_normally(new_state, messages)
       end
 
-    {:noreply, notify_permits(new_state, permits_consumed)}
+    {:noreply, apply_flow_policy(new_state, permits_consumed)}
   end
 
   @impl true
@@ -804,26 +806,34 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   # One policy hook sees the exact cost of every broker delivery.
-  defp notify_permits(state, consumed) do
-    flow = %{
-      consumed: consumed,
-      outstanding: state.flow_outstanding_permits,
-      threshold: state.flow_threshold,
-      refill: state.flow_refill,
-      mode: state.flow_policy
-    }
+  defp apply_flow_policy(state, consumed) do
+    case decide_flow(state, consumed) do
+      :ok ->
+        state
 
-    case state.callback_module.handle_permits(flow, state.callback_state) do
-      {:ok, callback_state} ->
-        %{state | callback_state: callback_state}
-
-      {:grant, permits, callback_state} when is_integer(permits) and permits > 0 ->
-        grant_permits(%{state | callback_state: callback_state}, permits)
+      {:grant, permits} when is_integer(permits) and permits > 0 ->
+        grant_permits(state, permits)
 
       unexpected_result ->
-        Logger.warning("Unexpected callback result: #{inspect(unexpected_result)}, granting no permits")
+        Logger.warning("Unexpected flow policy result: #{inspect(unexpected_result)}, granting no permits")
         state
     end
+  end
+
+  defp decide_flow(%__MODULE__{flow_policy: :manual}, _consumed), do: :ok
+
+  defp decide_flow(%__MODULE__{flow_policy: :auto} = state, _consumed) do
+    if state.flow_outstanding_permits <= state.flow_threshold and state.flow_refill > 0 do
+      {:grant, state.flow_refill}
+    else
+      :ok
+    end
+  end
+
+  defp decide_flow(%__MODULE__{flow_policy: {module, function, args}} = state, consumed) do
+    flow = %{consumed: consumed, outstanding: state.flow_outstanding_permits}
+
+    apply(module, function, [flow | args])
   end
 
   defp grant_permits(state, permits) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -42,6 +42,7 @@ defmodule Pulsar.Consumer.Worker do
     :broker_pid,
     :broker_monitor,
     {:ready, false},
+    :flow_policy,
     :flow_initial,
     :flow_threshold,
     :flow_refill,
@@ -78,6 +79,7 @@ defmodule Pulsar.Consumer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           ready: boolean(),
+          flow_policy: :auto | :manual,
           flow_initial: non_neg_integer(),
           flow_threshold: non_neg_integer(),
           flow_refill: non_neg_integer(),
@@ -808,7 +810,7 @@ defmodule Pulsar.Consumer.Worker do
       outstanding: state.flow_outstanding_permits,
       threshold: state.flow_threshold,
       refill: state.flow_refill,
-      mode: if(state.flow_initial > 0, do: :automatic, else: :manual)
+      mode: state.flow_policy
     }
 
     case state.callback_module.handle_permits(flow, state.callback_state) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -81,7 +81,7 @@ defmodule Pulsar.Consumer.Worker do
           broker_pid: pid(),
           broker_monitor: reference(),
           ready: boolean(),
-          flow_policy: :auto | :manual | flow_mfa(),
+          flow_policy: :auto | flow_mfa(),
           flow_initial: non_neg_integer(),
           flow_threshold: non_neg_integer(),
           flow_refill: non_neg_integer(),
@@ -805,7 +805,6 @@ defmodule Pulsar.Consumer.Worker do
     %{state | flow_outstanding_permits: new_permits}
   end
 
-  # One policy hook sees the exact cost of every broker delivery.
   defp apply_flow_policy(state, consumed) do
     case decide_flow(state, consumed) do
       :ok ->
@@ -819,8 +818,6 @@ defmodule Pulsar.Consumer.Worker do
         state
     end
   end
-
-  defp decide_flow(%__MODULE__{flow_policy: :manual}, _consumed), do: :ok
 
   defp decide_flow(%__MODULE__{flow_policy: :auto} = state, _consumed) do
     if state.flow_outstanding_permits <= state.flow_threshold and state.flow_refill > 0 do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -405,7 +405,7 @@ defmodule Pulsar.Consumer.Worker do
         :deliver -> process_messages_normally(new_state, messages)
       end
 
-    {:noreply, check_and_refill_permits(new_state)}
+    {:noreply, notify_permits(new_state, permits_consumed)}
   end
 
   @impl true
@@ -801,30 +801,36 @@ defmodule Pulsar.Consumer.Worker do
     %{state | flow_outstanding_permits: new_permits}
   end
 
-  defp check_and_refill_permits(%{flow_initial: 0} = state) do
-    state
-  end
+  # One policy hook sees the exact cost of every broker delivery.
+  defp notify_permits(state, consumed) do
+    flow = %{
+      consumed: consumed,
+      outstanding: state.flow_outstanding_permits,
+      threshold: state.flow_threshold,
+      refill: state.flow_refill,
+      mode: if(state.flow_initial > 0, do: :automatic, else: :manual)
+    }
 
-  defp check_and_refill_permits(state) do
-    refill_threshold = state.flow_threshold
-    refill_amount = state.flow_refill
-    current_permits = state.flow_outstanding_permits
+    case state.callback_module.handle_permits(flow, state.callback_state) do
+      {:ok, callback_state} ->
+        %{state | callback_state: callback_state}
 
-    if current_permits <= refill_threshold do
-      do_refill_permits(state, refill_amount, current_permits)
-    else
-      state
+      {:grant, permits, callback_state} when is_integer(permits) and permits > 0 ->
+        grant_permits(%{state | callback_state: callback_state}, permits)
+
+      unexpected_result ->
+        Logger.warning("Unexpected callback result: #{inspect(unexpected_result)}, granting no permits")
+        state
     end
   end
 
-  defp do_refill_permits(state, refill_amount, current_permits) do
-    case send_flow_command(state, refill_amount) do
+  defp grant_permits(state, permits) do
+    case send_flow_command(state, permits) do
       :ok ->
-        %{state | flow_outstanding_permits: current_permits + refill_amount}
+        %{state | flow_outstanding_permits: state.flow_outstanding_permits + permits}
 
-      error ->
-        Logger.error("Failed to send flow command: #{inspect(error)}")
-        state
+      {:error, reason} ->
+        exit({:send_flow_failed, reason})
     end
   end
 

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -193,7 +193,7 @@ defmodule Pulsar.Reader do
       consumer_count: 1,
       initial_position: start_position,
       read_compacted: read_compacted,
-      flow_policy: :manual,
+      flow_policy: {Pulsar.Reader.Callback, :report_permits, [self(), reader_ref]},
       flow_initial: flow_permits,
       startup_delay_ms: startup_delay_ms,
       startup_jitter_ms: startup_jitter_ms,

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -69,6 +69,7 @@ defmodule Pulsar.Reader do
   """
 
   alias Pulsar.Consumer
+  alias Pulsar.Reader.Callback
   alias Pulsar.Topology
 
   @default_startup_timeout 5_000
@@ -193,7 +194,7 @@ defmodule Pulsar.Reader do
       consumer_count: 1,
       initial_position: start_position,
       read_compacted: read_compacted,
-      flow_policy: {Pulsar.Reader.Callback, :report_permits, [self(), reader_ref]},
+      flow_policy: {Callback, :report_permits, [self(), reader_ref]},
       flow_initial: flow_permits,
       startup_delay_ms: startup_delay_ms,
       startup_jitter_ms: startup_jitter_ms,
@@ -206,7 +207,7 @@ defmodule Pulsar.Reader do
       |> maybe_put(:start_message_id, start_message_id)
       |> maybe_put(:start_timestamp, start_timestamp)
 
-    case Consumer.start(topic, subscription_name, Pulsar.Reader.Callback, consumer_opts) do
+    case Consumer.start(topic, subscription_name, Callback, consumer_opts) do
       {:ok, consumer} ->
         case build_reader_state(consumer, client_name, reader_ref, flow_permits, timeout, startup_timeout) do
           {:ok, state} ->

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -313,12 +313,19 @@ defmodule Pulsar.Reader do
   # A worker not seen before granted itself :flow_initial when it subscribed, so its window
   # starts there rather than at zero. Counting it from zero would refill a worker that is
   # already full, leaving it holding twice what the reader means to have outstanding.
+  #
+  # The count is left signed: one entry can carry more messages than the window has permits,
+  # and the broker charges every one of them. Clamping at zero would forget the excess and
+  # under-grant by exactly that much on the next refill.
   defp decrement_permits(state, consumer_pid, consumed) do
     current = Map.get(state.permits_by_consumer, consumer_pid, state.flow_permits)
-    new_permits = Map.put(state.permits_by_consumer, consumer_pid, max(current - consumed, 0))
+    new_permits = Map.put(state.permits_by_consumer, consumer_pid, current - consumed)
     %{state | permits_by_consumer: new_permits}
   end
 
+  # Refills one window at a time until the worker is back above the threshold, so a delivery
+  # that overdrew several windows is answered by as many grants. :flow_permits is a positive
+  # integer, so this always terminates.
   defp maybe_refill_flow(state, consumer_pid) do
     current_permits = Map.get(state.permits_by_consumer, consumer_pid, state.flow_permits)
     threshold = div(state.flow_permits, 2)
@@ -326,7 +333,8 @@ defmodule Pulsar.Reader do
     if current_permits <= threshold do
       :ok = Consumer.send_flow(consumer_pid, state.flow_permits)
       new_permits = Map.put(state.permits_by_consumer, consumer_pid, current_permits + state.flow_permits)
-      %{state | permits_by_consumer: new_permits}
+
+      maybe_refill_flow(%{state | permits_by_consumer: new_permits}, consumer_pid)
     else
       state
     end

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -251,21 +251,28 @@ defmodule Pulsar.Reader do
     {:halt, :halted}
   end
 
+  # A delivery's permits arrive after its messages and are charged once the stream has read past
+  # them, so the window tracks what has been consumed rather than what the broker has sent.
   defp next_message(state) do
     case :queue.out(state.buffer) do
-      {{:value, {consumer_pid, message}}, new_buffer} ->
-        new_state = %{state | buffer: new_buffer}
-        new_state = decrement_permits(new_state, consumer_pid)
-        new_state = maybe_refill_flow(new_state, consumer_pid)
-        {[message], new_state}
+      {{:value, {:message, message}}, new_buffer} ->
+        {[message], %{state | buffer: new_buffer}}
+
+      {{:value, {:permits, consumer_pid, consumed}}, new_buffer} ->
+        %{state | buffer: new_buffer}
+        |> decrement_permits(consumer_pid, consumed)
+        |> maybe_refill_flow(consumer_pid)
+        |> next_message()
 
       {:empty, _buffer} ->
         reader_ref = state.reader_ref
 
         receive do
-          {:pulsar_message, ^reader_ref, consumer_pid, message} ->
-            new_buffer = :queue.in({consumer_pid, message}, state.buffer)
-            next_message(%{state | buffer: new_buffer})
+          {:pulsar_message, ^reader_ref, _consumer_pid, message} ->
+            next_message(%{state | buffer: :queue.in({:message, message}, state.buffer)})
+
+          {:pulsar_permits, ^reader_ref, consumer_pid, consumed} ->
+            next_message(%{state | buffer: :queue.in({:permits, consumer_pid, consumed}, state.buffer)})
         after
           state.timeout ->
             {:halt, state}
@@ -291,9 +298,9 @@ defmodule Pulsar.Reader do
   defp maybe_put(keyword, _key, nil), do: keyword
   defp maybe_put(keyword, key, value), do: Keyword.put(keyword, key, value)
 
-  defp decrement_permits(state, consumer_pid) do
+  defp decrement_permits(state, consumer_pid, consumed) do
     current = Map.get(state.permits_by_consumer, consumer_pid, 0)
-    new_permits = Map.put(state.permits_by_consumer, consumer_pid, max(current - 1, 0))
+    new_permits = Map.put(state.permits_by_consumer, consumer_pid, max(current - consumed, 0))
     %{state | permits_by_consumer: new_permits}
   end
 

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -253,9 +253,13 @@ defmodule Pulsar.Reader do
     {:halt, :halted}
   end
 
+  defp next_message(state), do: next_message(state, deadline(state.timeout))
+
   # A delivery's permits arrive after its messages and are charged once the stream has read past
-  # them, so the window tracks what has been consumed rather than what the broker has sent.
-  defp next_message(state) do
+  # them, so the window tracks what has been consumed rather than what the broker has sent. They
+  # keep their own deadline: :timeout measures time without a message, and a delivery that
+  # yielded none must not extend it.
+  defp next_message(state, deadline) do
     case :queue.out(state.buffer) do
       {{:value, {:message, message}}, new_buffer} ->
         {[message], %{state | buffer: new_buffer}}
@@ -264,23 +268,29 @@ defmodule Pulsar.Reader do
         %{state | buffer: new_buffer}
         |> decrement_permits(consumer_pid, consumed)
         |> maybe_refill_flow(consumer_pid)
-        |> next_message()
+        |> next_message(deadline)
 
       {:empty, _buffer} ->
         reader_ref = state.reader_ref
 
         receive do
           {:pulsar_message, ^reader_ref, _consumer_pid, message} ->
-            next_message(%{state | buffer: :queue.in({:message, message}, state.buffer)})
+            next_message(%{state | buffer: :queue.in({:message, message}, state.buffer)}, deadline)
 
           {:pulsar_permits, ^reader_ref, consumer_pid, consumed} ->
-            next_message(%{state | buffer: :queue.in({:permits, consumer_pid, consumed}, state.buffer)})
+            next_message(%{state | buffer: :queue.in({:permits, consumer_pid, consumed}, state.buffer)}, deadline)
         after
-          state.timeout ->
+          time_left(deadline) ->
             {:halt, state}
         end
     end
   end
+
+  defp deadline(:infinity), do: :infinity
+  defp deadline(timeout), do: System.monotonic_time(:millisecond) + timeout
+
+  defp time_left(:infinity), do: :infinity
+  defp time_left(deadline), do: max(deadline - System.monotonic_time(:millisecond), 0)
 
   defp stop_reader(:halted), do: :ok
 
@@ -300,14 +310,17 @@ defmodule Pulsar.Reader do
   defp maybe_put(keyword, _key, nil), do: keyword
   defp maybe_put(keyword, key, value), do: Keyword.put(keyword, key, value)
 
+  # A worker not seen before granted itself :flow_initial when it subscribed, so its window
+  # starts there rather than at zero. Counting it from zero would refill a worker that is
+  # already full, leaving it holding twice what the reader means to have outstanding.
   defp decrement_permits(state, consumer_pid, consumed) do
-    current = Map.get(state.permits_by_consumer, consumer_pid, 0)
+    current = Map.get(state.permits_by_consumer, consumer_pid, state.flow_permits)
     new_permits = Map.put(state.permits_by_consumer, consumer_pid, max(current - consumed, 0))
     %{state | permits_by_consumer: new_permits}
   end
 
   defp maybe_refill_flow(state, consumer_pid) do
-    current_permits = Map.get(state.permits_by_consumer, consumer_pid, 0)
+    current_permits = Map.get(state.permits_by_consumer, consumer_pid, state.flow_permits)
     threshold = div(state.flow_permits, 2)
 
     if current_permits <= threshold do

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -193,7 +193,8 @@ defmodule Pulsar.Reader do
       consumer_count: 1,
       initial_position: start_position,
       read_compacted: read_compacted,
-      flow_initial: 0,
+      flow_policy: :manual,
+      flow_initial: flow_permits,
       startup_delay_ms: startup_delay_ms,
       startup_jitter_ms: startup_jitter_ms,
       init_args: [self(), reader_ref]
@@ -222,7 +223,7 @@ defmodule Pulsar.Reader do
   end
 
   defp build_reader_state(consumer, client_name, reader_ref, flow_permits, timeout, startup_timeout) do
-    case wait_for_consumers_ready(consumer, flow_permits, startup_timeout) do
+    case wait_for_consumers_ready(consumer, startup_timeout) do
       {:ok, consumer_pids} ->
         permits_by_consumer = Map.new(consumer_pids, fn pid -> {pid, flow_permits} end)
 
@@ -317,9 +318,10 @@ defmodule Pulsar.Reader do
     end
   end
 
-  defp wait_for_consumers_ready(consumer, flow_permits, startup_timeout) do
+  # Each worker grants :flow_initial for itself when it subscribes, so a partition discovered
+  # later, or a worker that restarts, starts with a window instead of waiting to be given one.
+  defp wait_for_consumers_ready(consumer, startup_timeout) do
     with :ok <- Consumer.await_ready(consumer, timeout: startup_timeout),
-         :ok <- Consumer.send_flow(consumer, flow_permits),
          [_ | _] = consumer_pids <- Topology.workers(consumer) do
       {:ok, consumer_pids}
     else

--- a/lib/pulsar/reader/callback.ex
+++ b/lib/pulsar/reader/callback.ex
@@ -20,13 +20,18 @@ defmodule Pulsar.Reader.Callback do
     {:ok, state}
   end
 
-  # Reported rather than granted here: the stream process refills as it consumes, which is what
-  # keeps the broker from sending further ahead than the stream has read.
-  @impl true
-  def handle_permits(%{consumed: 0}, state), do: {:ok, state}
+  @doc """
+  Flow policy for a reader's consumer, configured as
+  `{Pulsar.Reader.Callback, :report_permits, [stream_pid, reader_ref]}`.
 
-  def handle_permits(%{consumed: consumed}, state) do
-    send(state.stream_pid, {:pulsar_permits, state.reader_ref, self(), consumed})
-    {:ok, state}
+  Reports rather than grants: the stream process refills as it consumes, which is what keeps
+  the broker from sending further ahead than the stream has read.
+  """
+  @spec report_permits(map(), pid(), reference()) :: :ok
+  def report_permits(%{consumed: 0}, _stream_pid, _reader_ref), do: :ok
+
+  def report_permits(%{consumed: consumed}, stream_pid, reader_ref) do
+    send(stream_pid, {:pulsar_permits, reader_ref, self(), consumed})
+    :ok
   end
 end

--- a/lib/pulsar/reader/callback.ex
+++ b/lib/pulsar/reader/callback.ex
@@ -19,4 +19,14 @@ defmodule Pulsar.Reader.Callback do
     send(state.stream_pid, {:pulsar_message, state.reader_ref, self(), message})
     {:ok, state}
   end
+
+  # Reported rather than granted here: the stream process refills as it consumes, which is what
+  # keeps the broker from sending further ahead than the stream has read.
+  @impl true
+  def handle_permits(%{consumed: 0}, state), do: {:ok, state}
+
+  def handle_permits(%{consumed: consumed}, state) do
+    send(state.stream_pid, {:pulsar_permits, state.reader_ref, self(), consumed})
+    {:ok, state}
+  end
 end

--- a/lib/pulsar/reader/callback.ex
+++ b/lib/pulsar/reader/callback.ex
@@ -2,9 +2,8 @@ defmodule Pulsar.Reader.Callback do
   @moduledoc """
   Internal callback module for Pulsar.Reader.
 
-  This module handles messages from the consumer and forwards them to the
-  reader's stream process. It implements the `Pulsar.Consumer.Callback`
-  behaviour.
+  Implements the `Pulsar.Consumer.Callback` behaviour, forwarding messages to the reader's
+  stream process, and hosts the flow policy that reports what each delivery cost.
   """
 
   use Pulsar.Consumer.Callback

--- a/test/integration/consumer/flow_control_test.exs
+++ b/test/integration/consumer/flow_control_test.exs
@@ -166,7 +166,7 @@ defmodule Pulsar.Integration.Consumer.FlowControlTest do
       client: @client,
       initial_position: :earliest,
       consumer_count: count,
-      flow_policy: if(initial == 0, do: :manual, else: :auto),
+      flow_policy: if(initial == 0, do: {Pulsar.Test.Support.Flow, :never, []}, else: :auto),
       flow_initial: initial,
       flow_threshold: threshold,
       flow_refill: refill

--- a/test/integration/consumer/flow_control_test.exs
+++ b/test/integration/consumer/flow_control_test.exs
@@ -166,6 +166,7 @@ defmodule Pulsar.Integration.Consumer.FlowControlTest do
       client: @client,
       initial_position: :earliest,
       consumer_count: count,
+      flow_policy: if(initial == 0, do: :manual, else: :auto),
       flow_initial: initial,
       flow_threshold: threshold,
       flow_refill: refill

--- a/test/integration/consumer/partitioned_topic_test.exs
+++ b/test/integration/consumer/partitioned_topic_test.exs
@@ -218,6 +218,7 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
     opts =
       1
       |> subscription_options()
+      |> Keyword.put(:flow_policy, :manual)
       |> Keyword.put(:flow_initial, 0)
       |> Keyword.put(:partition_discovery_interval_ms, false)
 

--- a/test/integration/consumer/partitioned_topic_test.exs
+++ b/test/integration/consumer/partitioned_topic_test.exs
@@ -218,7 +218,7 @@ defmodule Pulsar.Integration.Consumer.PartitionedTopicTest do
     opts =
       1
       |> subscription_options()
-      |> Keyword.put(:flow_policy, :manual)
+      |> Keyword.put(:flow_policy, {Pulsar.Test.Support.Flow, :never, []})
       |> Keyword.put(:flow_initial, 0)
       |> Keyword.put(:partition_discovery_interval_ms, false)
 

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -215,7 +215,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
       subscription_type: type,
       initial_position: :earliest,
       consumer_count: count,
-      flow_policy: :manual,
+      flow_policy: {Pulsar.Test.Support.Flow, :never, []},
       flow_initial: 0,
       init_args: [notify_pid: self()]
     ]

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -207,14 +207,15 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
     ]
   end
 
-  # Manual flow control (flow_initial: 0 disables automatic permits), so the
-  # test can grant permits explicitly once all consumers are subscribed.
+  # Manual flow control granting nothing on subscribe, so the test can grant permits
+  # explicitly once all consumers are subscribed.
   defp manual_flow_options(type, count) do
     [
       client: @client,
       subscription_type: type,
       initial_position: :earliest,
       consumer_count: count,
+      flow_policy: :manual,
       flow_initial: 0,
       init_args: [notify_pid: self()]
     ]

--- a/test/support/flow.ex
+++ b/test/support/flow.ex
@@ -1,0 +1,29 @@
+defmodule Pulsar.Test.Support.Flow do
+  @moduledoc """
+  Flow policies for tests that grant permits themselves.
+  """
+
+  @doc """
+  Grants nothing, leaving every permit to `Pulsar.Consumer.send_flow/3`.
+  """
+  @spec never(map()) :: :ok
+  def never(_flow), do: :ok
+
+  @doc """
+  Grants nothing and reports what the delivery cost to `notify_pid`.
+  """
+  @spec report(map(), pid()) :: :ok
+  def report(flow, notify_pid) do
+    send(notify_pid, {:permits, flow})
+    :ok
+  end
+
+  @doc """
+  Reports what the delivery cost to `notify_pid`, then always grants `permits`.
+  """
+  @spec grant_fixed(map(), pid(), pos_integer()) :: {:grant, pos_integer()}
+  def grant_fixed(flow, notify_pid, permits) do
+    send(notify_pid, {:permits, flow})
+    {:grant, permits}
+  end
+end

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -23,14 +23,15 @@ defmodule Pulsar.Consumer.BatchAckTest do
       end
     end
 
-    def handle_permits(flow, answers) do
-      send(self(), {:permits, flow})
+  end
 
-      case Map.fetch(answers, :grant) do
-        :error -> super(flow, answers)
-        {:ok, :none} -> {:ok, answers}
-        {:ok, permits} -> {:grant, permits, answers}
-      end
+  # Stands in for a caller's flow policy, reporting what it was asked and answering as told.
+  defmodule Flow do
+    @moduledoc false
+
+    def decide(flow, notify_pid, answer) do
+      send(notify_pid, {:permits, flow})
+      answer
     end
   end
 
@@ -235,9 +236,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "still spends a permit on each message the broker sent" do
       state = %{
         worker_state(%{})
-        | flow_policy: :auto,
-          flow_initial: 100,
-          flow_threshold: 0,
+        | flow_policy: :manual,
           flow_outstanding_permits: 100
       }
 
@@ -322,9 +321,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "charges a permit for every message the broker sent, delivered or not" do
       state = %{
         worker_state(%{})
-        | flow_policy: :auto,
-          flow_initial: 100,
-          flow_threshold: 0,
+        | flow_policy: :manual,
           flow_outstanding_permits: 100
       }
 
@@ -363,18 +360,14 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
-  describe "handling permit consumption" do
+  describe "applying the flow policy" do
     test "reports one total for callback-visible and hidden consumption" do
       state = %{worker_state(%{}) | flow_outstanding_permits: 100}
 
       deliver(state, ["a", "b", "c"], compacted_out: [1], ack_set: [0b011])
 
       assert delivered_payloads() == ["a"]
-
-      assert [flow] = permits_reported()
-      assert flow.consumed == 3
-      assert flow.outstanding == 97
-      assert flow.mode == :manual
+      assert permits_reported() == [%{consumed: 3, outstanding: 97}]
     end
 
     test "counts a delivery diverted in full, which reaches no callback at all" do
@@ -384,10 +377,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
       assert delivered_payloads() == []
       assert diverted_payloads() == ["a", "b", "c"]
-
-      assert [flow] = permits_reported()
-      assert flow.consumed == 3
-      assert flow.outstanding == 97
+      assert permits_reported() == [%{consumed: 3, outstanding: 97}]
     end
 
     test "counts a delivery in full even when part of it fails to divert and is nacked" do
@@ -397,29 +387,29 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
       assert delivered_payloads() == []
       assert diverted_payloads() == ["a", "c"]
-
-      assert [flow] = permits_reported()
-      assert flow.consumed == 3
-      assert flow.outstanding == 97
+      assert permits_reported() == [%{consumed: 3, outstanding: 97}]
     end
 
-    test "grants what the callback asks for, without reporting again" do
-      state = %{worker_state(%{grant: 50}) | flow_outstanding_permits: 100}
+    test "grants what the policy asks for, without asking it again" do
+      state = %{
+        worker_state(%{})
+        | flow_policy: {Flow, :decide, [self(), {:grant, 50}]},
+          flow_outstanding_permits: 100
+      }
 
       new_state = deliver(state, ["a"])
 
-      assert [%{consumed: 1, outstanding: 99, mode: :manual}] = permits_reported()
+      assert permits_reported() == [%{consumed: 1, outstanding: 99}]
       assert new_state.flow_outstanding_permits == 149
 
       assert [flow] = Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
       assert flow.messagePermits == 50
     end
 
-    test "the default callback refills an automatic consumer that has reached its threshold" do
+    test "the :auto policy refills a consumer that has reached its threshold" do
       state = %{
         worker_state(%{})
         | flow_policy: :auto,
-          flow_initial: 100,
           flow_threshold: 50,
           flow_refill: 50,
           flow_outstanding_permits: 51
@@ -427,25 +417,31 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
       new_state = deliver(state, ["a", "b", "c"])
 
-      assert [flow] = permits_reported()
-      assert flow == %{consumed: 3, outstanding: 48, threshold: 50, refill: 50, mode: :auto}
       assert new_state.flow_outstanding_permits == 98
+      assert [%Binary.CommandFlow{messagePermits: 50}] = Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
     end
 
-    test "overriding the callback replaces the automatic refill policy" do
+    test "the :auto policy leaves a consumer above its threshold alone" do
       state = %{
-        worker_state(%{grant: :none})
+        worker_state(%{})
         | flow_policy: :auto,
-          flow_initial: 100,
           flow_threshold: 50,
           flow_refill: 50,
-          flow_outstanding_permits: 51
+          flow_outstanding_permits: 100
       }
 
       new_state = deliver(state, ["a", "b", "c"])
 
-      assert [%{consumed: 3, outstanding: 48, mode: :auto}] = permits_reported()
-      assert new_state.flow_outstanding_permits == 48
+      assert new_state.flow_outstanding_permits == 97
+      assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
+    end
+
+    test "the :manual policy never refills, however low the window gets" do
+      state = %{worker_state(%{}) | flow_policy: :manual, flow_outstanding_permits: 3}
+
+      new_state = deliver(state, ["a", "b", "c"])
+
+      assert new_state.flow_outstanding_permits == 0
       assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
     end
   end
@@ -499,7 +495,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
         callback_state: answers,
         broker_pid: self(),
         consumer_id: 1,
-        flow_policy: :manual,
+        flow_policy: {Flow, :decide, [self(), :ok]},
         flow_initial: 0
       ] ++ opts
     )

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -233,7 +233,13 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
 
     test "still spends a permit on each message the broker sent" do
-      state = %{worker_state(%{}) | flow_initial: 100, flow_threshold: 0, flow_outstanding_permits: 100}
+      state = %{
+        worker_state(%{})
+        | flow_policy: :auto,
+          flow_initial: 100,
+          flow_threshold: 0,
+          flow_outstanding_permits: 100
+      }
 
       new_state = deliver(state, ["a", "b", "c"], ack_set: [0b010])
 
@@ -314,7 +320,13 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
 
     test "charges a permit for every message the broker sent, delivered or not" do
-      state = %{worker_state(%{}) | flow_initial: 100, flow_threshold: 0, flow_outstanding_permits: 100}
+      state = %{
+        worker_state(%{})
+        | flow_policy: :auto,
+          flow_initial: 100,
+          flow_threshold: 0,
+          flow_outstanding_permits: 100
+      }
 
       new_state = deliver(state, ["a", "b", "c"], compacted_out: [1], ack_set: [0b011])
 
@@ -406,7 +418,8 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "the default callback refills an automatic consumer that has reached its threshold" do
       state = %{
         worker_state(%{})
-        | flow_initial: 100,
+        | flow_policy: :auto,
+          flow_initial: 100,
           flow_threshold: 50,
           flow_refill: 50,
           flow_outstanding_permits: 51
@@ -415,14 +428,15 @@ defmodule Pulsar.Consumer.BatchAckTest do
       new_state = deliver(state, ["a", "b", "c"])
 
       assert [flow] = permits_reported()
-      assert flow == %{consumed: 3, outstanding: 48, threshold: 50, refill: 50, mode: :automatic}
+      assert flow == %{consumed: 3, outstanding: 48, threshold: 50, refill: 50, mode: :auto}
       assert new_state.flow_outstanding_permits == 98
     end
 
     test "overriding the callback replaces the automatic refill policy" do
       state = %{
         worker_state(%{grant: :none})
-        | flow_initial: 100,
+        | flow_policy: :auto,
+          flow_initial: 100,
           flow_threshold: 50,
           flow_refill: 50,
           flow_outstanding_permits: 51
@@ -430,7 +444,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
       new_state = deliver(state, ["a", "b", "c"])
 
-      assert [%{consumed: 3, outstanding: 48, mode: :automatic}] = permits_reported()
+      assert [%{consumed: 3, outstanding: 48, mode: :auto}] = permits_reported()
       assert new_state.flow_outstanding_permits == 48
       assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
     end
@@ -485,6 +499,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
         callback_state: answers,
         broker_pid: self(),
         consumer_id: 1,
+        flow_policy: :manual,
         flow_initial: 0
       ] ++ opts
     )

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -22,6 +22,16 @@ defmodule Pulsar.Consumer.BatchAckTest do
         :nack -> {:error, :rejected, answers}
       end
     end
+
+    def handle_permits(flow, answers) do
+      send(self(), {:permits, flow})
+
+      case Map.fetch(answers, :grant) do
+        :error -> super(flow, answers)
+        {:ok, :none} -> {:ok, answers}
+        {:ok, permits} -> {:grant, permits, answers}
+      end
+    end
   end
 
   # Stands in for the dead letter producer. `Pulsar.Producer.send/3` routes a bare pid through
@@ -341,6 +351,91 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
+  describe "handling permit consumption" do
+    test "reports one total for callback-visible and hidden consumption" do
+      state = %{worker_state(%{}) | flow_outstanding_permits: 100}
+
+      deliver(state, ["a", "b", "c"], compacted_out: [1], ack_set: [0b011])
+
+      assert delivered_payloads() == ["a"]
+
+      assert [flow] = permits_reported()
+      assert flow.consumed == 3
+      assert flow.outstanding == 97
+      assert flow.mode == :manual
+    end
+
+    test "counts a delivery diverted in full, which reaches no callback at all" do
+      state = %{diverting_state(refuse: []) | flow_outstanding_permits: 100}
+
+      deliver(state, ["a", "b", "c"], redelivery_count: 1)
+
+      assert delivered_payloads() == []
+      assert diverted_payloads() == ["a", "b", "c"]
+
+      assert [flow] = permits_reported()
+      assert flow.consumed == 3
+      assert flow.outstanding == 97
+    end
+
+    test "counts a delivery in full even when part of it fails to divert and is nacked" do
+      state = %{diverting_state(refuse: ["b"]) | flow_outstanding_permits: 100}
+
+      deliver(state, ["a", "b", "c"], redelivery_count: 1)
+
+      assert delivered_payloads() == []
+      assert diverted_payloads() == ["a", "c"]
+
+      assert [flow] = permits_reported()
+      assert flow.consumed == 3
+      assert flow.outstanding == 97
+    end
+
+    test "grants what the callback asks for, without reporting again" do
+      state = %{worker_state(%{grant: 50}) | flow_outstanding_permits: 100}
+
+      new_state = deliver(state, ["a"])
+
+      assert [%{consumed: 1, outstanding: 99, mode: :manual}] = permits_reported()
+      assert new_state.flow_outstanding_permits == 149
+
+      assert [flow] = Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
+      assert flow.messagePermits == 50
+    end
+
+    test "the default callback refills an automatic consumer that has reached its threshold" do
+      state = %{
+        worker_state(%{})
+        | flow_initial: 100,
+          flow_threshold: 50,
+          flow_refill: 50,
+          flow_outstanding_permits: 51
+      }
+
+      new_state = deliver(state, ["a", "b", "c"])
+
+      assert [flow] = permits_reported()
+      assert flow == %{consumed: 3, outstanding: 48, threshold: 50, refill: 50, mode: :automatic}
+      assert new_state.flow_outstanding_permits == 98
+    end
+
+    test "overriding the callback replaces the automatic refill policy" do
+      state = %{
+        worker_state(%{grant: :none})
+        | flow_initial: 100,
+          flow_threshold: 50,
+          flow_refill: 50,
+          flow_outstanding_permits: 51
+      }
+
+      new_state = deliver(state, ["a", "b", "c"])
+
+      assert [%{consumed: 3, outstanding: 48, mode: :automatic}] = permits_reported()
+      assert new_state.flow_outstanding_permits == 48
+      assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
+    end
+  end
+
   ## Helpers
 
   # A consumer whose dead letter producer is the stub above, past its redelivery limit.
@@ -466,6 +561,14 @@ defmodule Pulsar.Consumer.BatchAckTest do
   defp delivered_payloads(acc \\ []) do
     receive do
       {:delivered, payload} -> delivered_payloads([payload | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp permits_reported(acc \\ []) do
+    receive do
+      {:permits, flow} -> permits_reported([flow | acc])
     after
       0 -> Enum.reverse(acc)
     end

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -5,6 +5,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
   alias Pulsar.Consumer.Ack
   alias Pulsar.Consumer.Worker
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+  alias Pulsar.Test.Support.Flow
 
   defmodule Callback do
     @moduledoc false
@@ -21,17 +22,6 @@ defmodule Pulsar.Consumer.BatchAckTest do
         :defer -> {:noreply, answers}
         :nack -> {:error, :rejected, answers}
       end
-    end
-
-  end
-
-  # Stands in for a caller's flow policy, reporting what it was asked and answering as told.
-  defmodule Flow do
-    @moduledoc false
-
-    def decide(flow, notify_pid, answer) do
-      send(notify_pid, {:permits, flow})
-      answer
     end
   end
 
@@ -236,7 +226,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "still spends a permit on each message the broker sent" do
       state = %{
         worker_state(%{})
-        | flow_policy: :manual,
+        | flow_policy: {Flow, :never, []},
           flow_outstanding_permits: 100
       }
 
@@ -321,7 +311,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "charges a permit for every message the broker sent, delivered or not" do
       state = %{
         worker_state(%{})
-        | flow_policy: :manual,
+        | flow_policy: {Flow, :never, []},
           flow_outstanding_permits: 100
       }
 
@@ -393,7 +383,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
     test "grants what the policy asks for, without asking it again" do
       state = %{
         worker_state(%{})
-        | flow_policy: {Flow, :decide, [self(), {:grant, 50}]},
+        | flow_policy: {Flow, :grant_fixed, [self(), 50]},
           flow_outstanding_permits: 100
       }
 
@@ -402,7 +392,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert permits_reported() == [%{consumed: 1, outstanding: 99}]
       assert new_state.flow_outstanding_permits == 149
 
-      assert [flow] = Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
+      assert [flow] = flow_commands()
       assert flow.messagePermits == 50
     end
 
@@ -418,7 +408,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
       new_state = deliver(state, ["a", "b", "c"])
 
       assert new_state.flow_outstanding_permits == 98
-      assert [%Binary.CommandFlow{messagePermits: 50}] = Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
+      assert [%Binary.CommandFlow{messagePermits: 50}] = flow_commands()
     end
 
     test "the :auto policy leaves a consumer above its threshold alone" do
@@ -433,16 +423,16 @@ defmodule Pulsar.Consumer.BatchAckTest do
       new_state = deliver(state, ["a", "b", "c"])
 
       assert new_state.flow_outstanding_permits == 97
-      assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
+      assert flow_commands() == []
     end
 
-    test "the :manual policy never refills, however low the window gets" do
-      state = %{worker_state(%{}) | flow_policy: :manual, flow_outstanding_permits: 3}
+    test "a policy that grants nothing never refills, however low the window gets" do
+      state = %{worker_state(%{}) | flow_policy: {Flow, :never, []}, flow_outstanding_permits: 3}
 
       new_state = deliver(state, ["a", "b", "c"])
 
       assert new_state.flow_outstanding_permits == 0
-      assert Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1)) == []
+      assert flow_commands() == []
     end
   end
 
@@ -495,7 +485,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
         callback_state: answers,
         broker_pid: self(),
         consumer_id: 1,
-        flow_policy: {Flow, :decide, [self(), :ok]},
+        flow_policy: {Flow, :report, [self()]},
         flow_initial: 0
       ] ++ opts
     )
@@ -567,6 +557,10 @@ defmodule Pulsar.Consumer.BatchAckTest do
 
   defp acks do
     Enum.filter(receive_commands(), &match?(%Binary.CommandAck{}, &1))
+  end
+
+  defp flow_commands do
+    Enum.filter(receive_commands(), &match?(%Binary.CommandFlow{}, &1))
   end
 
   defp delivered_payloads(acc \\ []) do

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -2,6 +2,7 @@ defmodule Pulsar.Consumer.OptionsTest do
   use ExUnit.Case, async: true
 
   alias Pulsar.Consumer.Options
+  alias Pulsar.Test.Support.Flow
 
   @required [topic: "t", subscription_name: "s", callback_module: MyApp.Handler]
 
@@ -32,7 +33,7 @@ defmodule Pulsar.Consumer.OptionsTest do
     end
 
     test "keeps flow_initial under a policy of its own, so a worker still starts with a window" do
-      policy = {Pulsar.Test.Support.Flow, :never, []}
+      policy = {Flow, :never, []}
       opts = validate!(flow_policy: policy, flow_initial: 25)
 
       assert opts[:flow_policy] == policy
@@ -45,19 +46,19 @@ defmodule Pulsar.Consumer.OptionsTest do
       end
     end
 
-    test "accepts a flow policy the given module can answer" do
-      policy = {Kernel, :inspect, [[]]}
+    test "allows a policy of its own to start with nothing, since permits can come from elsewhere" do
+      policy = {Flow, :never, []}
 
       assert validate!(flow_policy: policy, flow_initial: 0)[:flow_policy] == policy
     end
 
-    test "rejects a flow policy whose function does not take the flow it would be given" do
-      assert_raise NimbleOptions.ValidationError, ~r|inspect/3|, fn ->
-        validate!(flow_policy: {Kernel, :inspect, [1, 2]})
+    test "rejects a policy whose function cannot take the flow it would be given" do
+      assert_raise NimbleOptions.ValidationError, ~r|never/2|, fn ->
+        validate!(flow_policy: {Flow, :never, [:extra]})
       end
     end
 
-    test "rejects a flow policy that is neither a known atom nor an MFA" do
+    test "rejects a policy that is neither :auto nor an MFA" do
       assert_raise NimbleOptions.ValidationError, ~r/:auto or a \{module, function, args\}/, fn ->
         validate!(flow_policy: :whenever)
       end

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -44,6 +44,24 @@ defmodule Pulsar.Consumer.OptionsTest do
       end
     end
 
+    test "accepts a flow policy the given module can answer" do
+      policy = {Kernel, :inspect, [[]]}
+
+      assert validate!(flow_policy: policy, flow_initial: 0)[:flow_policy] == policy
+    end
+
+    test "rejects a flow policy whose function does not take the flow it would be given" do
+      assert_raise NimbleOptions.ValidationError, ~r|inspect/3|, fn ->
+        validate!(flow_policy: {Kernel, :inspect, [1, 2]})
+      end
+    end
+
+    test "rejects a flow policy that is neither a known atom nor an MFA" do
+      assert_raise NimbleOptions.ValidationError, ~r/:auto, :manual, or a \{module, function, args\}/, fn ->
+        validate!(flow_policy: :whenever)
+      end
+    end
+
     test "accepts a name as either a string or an atom" do
       assert validate!(name: "a-group")[:name] == "a-group"
       assert validate!(name: MyApp.Consumer)[:name] == MyApp.Consumer

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -27,6 +27,37 @@ defmodule Pulsar.Consumer.OptionsTest do
       assert opts[:partition_discovery_interval_ms] == 60_000
     end
 
+    test "defaults the flow policy to :auto" do
+      assert validate!([])[:flow_policy] == :auto
+    end
+
+    test "reads flow_initial: 0 as the manual policy it selected before :flow_policy existed" do
+      opts =
+        ExUnit.CaptureLog.capture_log(fn ->
+          send(self(), {:opts, validate!(flow_initial: 0)})
+        end)
+        |> then(fn log ->
+          assert log =~ "deprecated"
+          receive do: ({:opts, opts} -> opts)
+        end)
+
+      assert opts[:flow_policy] == :manual
+      assert opts[:flow_initial] == 0
+    end
+
+    test "keeps flow_initial under the manual policy, so a worker still starts with a window" do
+      opts = validate!(flow_policy: :manual, flow_initial: 25)
+
+      assert opts[:flow_policy] == :manual
+      assert opts[:flow_initial] == 25
+    end
+
+    test "rejects an automatic consumer that would be granted nothing to start with" do
+      assert_raise ArgumentError, ~r/never receives a message/, fn ->
+        validate!(flow_policy: :auto, flow_initial: 0)
+      end
+    end
+
     test "accepts a name as either a string or an atom" do
       assert validate!(name: "a-group")[:name] == "a-group"
       assert validate!(name: MyApp.Consumer)[:name] == MyApp.Consumer

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -31,20 +31,6 @@ defmodule Pulsar.Consumer.OptionsTest do
       assert validate!([])[:flow_policy] == :auto
     end
 
-    test "reads flow_initial: 0 as the manual policy it selected before :flow_policy existed" do
-      opts =
-        ExUnit.CaptureLog.capture_log(fn ->
-          send(self(), {:opts, validate!(flow_initial: 0)})
-        end)
-        |> then(fn log ->
-          assert log =~ "deprecated"
-          receive do: ({:opts, opts} -> opts)
-        end)
-
-      assert opts[:flow_policy] == :manual
-      assert opts[:flow_initial] == 0
-    end
-
     test "keeps flow_initial under the manual policy, so a worker still starts with a window" do
       opts = validate!(flow_policy: :manual, flow_initial: 25)
 

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -31,10 +31,11 @@ defmodule Pulsar.Consumer.OptionsTest do
       assert validate!([])[:flow_policy] == :auto
     end
 
-    test "keeps flow_initial under the manual policy, so a worker still starts with a window" do
-      opts = validate!(flow_policy: :manual, flow_initial: 25)
+    test "keeps flow_initial under a policy of its own, so a worker still starts with a window" do
+      policy = {Pulsar.Test.Support.Flow, :never, []}
+      opts = validate!(flow_policy: policy, flow_initial: 25)
 
-      assert opts[:flow_policy] == :manual
+      assert opts[:flow_policy] == policy
       assert opts[:flow_initial] == 25
     end
 
@@ -57,7 +58,7 @@ defmodule Pulsar.Consumer.OptionsTest do
     end
 
     test "rejects a flow policy that is neither a known atom nor an MFA" do
-      assert_raise NimbleOptions.ValidationError, ~r/:auto, :manual, or a \{module, function, args\}/, fn ->
+      assert_raise NimbleOptions.ValidationError, ~r/:auto or a \{module, function, args\}/, fn ->
         validate!(flow_policy: :whenever)
       end
     end


### PR DESCRIPTION
## Summary

Two consumers of this library cannot account for their own flow permits on 3.x, because the broker charges for messages that never reach a callback:

- **`Pulsar.Reader`** miscounts them, and on a compacted topic can stall outright — granting its initial permits, receiving only compacted-out entries, decrementing nothing, and never refilling.
- **`off_broadway_pulsar`** is blocked on the same accounting for its 3.x upgrade (efcasado/off_broadway_pulsar#79).

Fixes both by reporting the exact cost of every delivery to a `:flow_policy` — `:auto`, the built-in threshold/refill policy, or a `{module, function, args}` the consumer asks after each delivery.

**Consumers on automatic flow control are unaffected.** `:flow_policy` defaults to `:auto` and behaves exactly as before. This matters only if you manage permits yourself, which on 3.0 meant `flow_initial: 0` — that spelling is replaced, see migration below.

Closes #190.

## Motivation

The broker charges a permit for every message it sends. Some of those messages never reach a message callback:

- **Dead-letter diversions.** Once a delivery is selected for the DLQ, neither `handle_message/2` nor `handle_invalid_message/2` runs, whether the publish succeeds or fails.
- **Skipped batch members.** Members excluded by an `ack_set` on a partially acknowledged entry, and members `compacted_out` on a compacted topic, are acknowledged internally and never built into messages.

A caller managing its own flow could only count what reached a callback, so its view of the broker's window drifted upward, and the error accumulated monotonically. Once the drift exceeded the refill threshold, the caller believed it was above the threshold while the broker's real window had reached zero, and no further event could trigger a refill. The topic went quiet with no crash and no log.

This was a regression from 2.11.1, where a DLQ-bound message reached `handle_message/2` before diversion and no batch member was ever skipped. The 3.x delivery semantics are the better ones — a diverted message should not also reach application processing, and an already-acknowledged member should not be delivered again — so the goal here is to restore the accounting signal, not the old delivery behaviour.

`off_broadway_pulsar` hits this directly (efcasado/off_broadway_pulsar#79). So does `Pulsar.Reader`, in this repository: it granted permits from the stream process and decremented one per message it yielded, so a chunked message undercharged by a permit per chunk and skipped members went uncharged entirely.

## Implementation

**The worker reports what it already knew.** It already computed the exact cost of every delivery for its own window. It now hands that number to whatever `:flow_policy` names:

```elixir
flow_policy: :auto                          # outstanding <= threshold -> grant refill
flow_policy: {MyApp.Flow, :decide, [100]}   # apply(MyApp.Flow, :decide, [flow, 100])
```

A policy receives `%{consumed: permits, outstanding: permits}` and answers `:ok` or `{:grant, permits}`. `:consumed` is what the delivery cost — including the messages above that no callback sees — and `:outstanding` is what is left after it, before any grant the policy makes.

Two things follow from a policy only being asked after a delivery. It cannot grant the first permits, since without them nothing is delivered — those come from `:flow_initial` or from `send_flow/3` elsewhere. And it runs in the consumer process, so it must not call `send_flow/3` on that consumer, which is a call to itself and deadlocks; handing the decision to another process is the supported way to depend on external demand.

A policy that always answers `:ok` grants nothing, which is how a consumer leaves every refill to `send_flow/3`.

An MFA is validated at consumer start rather than at the first delivery, where an unloadable policy would take the worker down once per redelivery.

**`:flow_policy` replaces the magic value.** `flow_initial: 0` encoded a mode in a field that names a count, which the 3.0 docs had to explain away. The two are now independent:

- `:flow_policy` — who decides refills once running.
- `:flow_initial` — permits granted on subscribe, honoured under every policy.

That combination is expressible for the first time: a consumer can start with a window and still own every refill after it. It also closes a gap the old docs warned about — permits belong to a worker instance, so a replacement worker owning its own permits used to come back with a dead window until someone noticed and re-granted. Each worker now grants `:flow_initial` for itself, so replacements and late-discovered partitions self-heal.

`flow_policy: :auto` with `flow_initial: 0` is rejected at validation: the broker is granted nothing, so no delivery arrives to trigger a refill, and the consumer would sit silent forever.

**`Pulsar.Reader` converted.** Its consumer runs `{Pulsar.Reader.Callback, :report_permits, [stream_pid, reader_ref]}`, which reports the cost to the stream process and grants nothing. The stream charges it once it has read past everything that delivery produced, so refills stay driven by stream consumption and the mailbox is bounded exactly as before — only the arithmetic changes. `permits_by_consumer` is charged by the real cost instead of `1`, and the explicit startup grant in `wait_for_consumers_ready/2` is gone now that `:flow_initial` covers it.

Two ways a reader could go silent on 3.0, both fixed here:

- **Reading a compacted topic**, it could grant its initial permits, receive only compacted-out entries, decrement nothing, and never refill — yielding no messages and halting on the inactivity timeout.
- **After a worker restarted, or a partition was discovered later**, that worker was silent for good. The reader granted permits once, to the root, in `wait_for_consumers_ready/3`, and built `permits_by_consumer` from the workers alive at that moment. A worker appearing afterwards had `flow_initial: 0`, was never granted anything, and so never delivered — which meant nothing ever triggered a refill for it either. The reader kept streaming from its other partitions with no error, just a missing one. `:partition_discovery_interval_ms` is left at its 60s default here, so a topic that gains partitions mid-stream hit this without anything restarting.

**One smaller change rides along.** A failed flow command now exits the worker instead of logging and continuing. The old path left a consumer that would never receive another message.

## Breaking change and migration

Nothing to change for consumers on automatic flow control: `:flow_policy` defaults to `:auto`, which applies `:flow_threshold` and `:flow_refill` exactly as before.

`flow_initial: 0` no longer selects manual flow control. It now means what it says — grant nothing on subscribe — which under the default `:auto` policy is a consumer that can never receive a message, so it fails at validation with a message naming the fix:

```elixir
# Before
consumer_opts = [flow_initial: 0]

# After
consumer_opts = [flow_policy: {MyApp.Flow, :report, [self()]}, flow_initial: 0]

# Or grant an initial window and manage refills from there
consumer_opts = [flow_policy: {MyApp.Flow, :report, [self()]}, flow_initial: 100]
```

The failure is loud and immediate rather than a silent stall, which is why this is a hard error instead of a deprecation shim.

A caller that mirrors the broker's window by counting callbacks can stop. Use `:outstanding` directly, or forward `:consumed` to whichever process owns the decision:

```elixir
defmodule MyApp.Flow do
  def report(%{consumed: consumed}, owner) do
    send(owner, {:permits_consumed, consumed})
    :ok
  end
end

flow_policy: {MyApp.Flow, :report, [producer_pid]}
```

## Follow-up

#192 is a permit-accounting bug this change deliberately leaves alone: a chunked message costs a permit per chunk, but the consumer charges all of them at once when the last chunk arrives, so its window reads high until the message assembles. A message needing more chunks than the window stalls the subscription until the incomplete-chunk expiry gives up on it.

It is untouched here — `permits_consumed` is computed exactly as it is on `main` — and no flow policy can route around it, since every policy reads the same counter. Fixing it means charging each chunk on arrival and making both the assembled message and the two give-up paths contribute nothing, which is a different change to a different part of the accounting.

## Verification

- `mix test test/unit` — 391 passing (28 doctests, 363 tests)
- `mix credo --strict` — clean
- `mix dialyzer` — clean
- `mix compile --warnings-as-errors` — clean

New unit coverage drives the worker inline through both gaps: a batch losing one member to `compacted_out` and one to an `ack_set` reports all three permits with a single message delivered; a fully diverted delivery reports three with no callback reached at all; the same holds when part of the delivery fails to publish and is nacked. Plus a policy answering `{:grant, _}`, `:auto` refilling at its threshold and leaving an untouched consumer alone, a policy that grants nothing never refilling however low the window gets, and the `:flow_policy` validation rules.
