### PR TITLE
feat(consumer): add cumulative acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ An Elixir client for [Apache Pulsar](https://pulsar.apache.org/).
 - 📤 Producers
 - 🪾 Partitioned topics
 - 🏎️ Compacted topics
+- ✅ ACK, NACK, and redelivery (see [guide](https://hexdocs.pm/pulsar_elixir/acknowledgements.html))
 - 📝 Schemas (see [guide](https://hexdocs.pm/pulsar_elixir/schemas.html))
 - 🔪 Chunking (see [guide](https://hexdocs.pm/pulsar_elixir/chunking.html))
-- 🍱 Batching (including batch-index ACK; see [guide](https://hexdocs.pm/pulsar_elixir/batching.html))
+- 🍱 Batching (see [guide](https://hexdocs.pm/pulsar_elixir/batching.html))
 - 🗜️ Compression
-- ☠️ NACK and dead-letter topics (see [guide](https://hexdocs.pm/pulsar_elixir/dead_letter_policies.html))
+- ☠️ Dead-letter topics (see [guide](https://hexdocs.pm/pulsar_elixir/dead_letter_policies.html))
 
 
 ## Installation

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,232 @@
+# Acknowledgement and Redelivery
+
+## What an Acknowledgement Means
+
+A consumer reads through a subscription. Acknowledging a message tells the broker that the
+subscription no longer owes that message; it does not delete the message from the topic or affect
+another subscription.
+
+The safe order is therefore:
+
+1. Receive the message
+2. Finish the side effect it represents
+3. Acknowledge it
+
+If the process stops before step 3, the broker can deliver the message again. If the side effect
+finished but its acknowledgement did not reach the broker, the message can also be delivered
+again. Pulsar consumption is at-least-once, so downstream work should be idempotent or deduplicated
+even when every callback normally succeeds.
+
+## The Callback Makes the Decision
+
+`Pulsar.Consumer.Callback`'s `handle_message/2` callback returns what should happen to the current
+message:
+
+| Result | Message outcome | Worker outcome |
+| --- | --- | --- |
+| `{:ok, state}` | Acknowledge | Continue |
+| `{:error, reason, state}` | Negatively acknowledge | Continue |
+| `{:noreply, state}` | Neither; the application decides later | Continue |
+| `{:stop, reason, state}` | Acknowledge | Finish with `reason` |
+
+The same outcomes apply to `handle_invalid_message/2`. Its default implementation acknowledges
+the invalid message so corrupt data is not redelivered forever.
+
+Most consumers only need automatic acknowledgement:
+
+```elixir
+defmodule Billing do
+  use Pulsar.Consumer.Callback
+
+  def handle_message(%Pulsar.Message{payload: order}, state) do
+    case MyApp.Billing.charge(order) do
+      :ok -> {:ok, state}
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+end
+
+{:ok, consumer} =
+  Pulsar.Consumer.start("orders", "billing", Billing,
+    redelivery_interval: 5_000
+  )
+
+:ok = Pulsar.Consumer.await_ready(consumer)
+```
+
+Here a successful charge is acknowledged immediately. A failed charge is marked for redelivery,
+which the configured interval requests from the broker.
+
+> #### A NACK does not schedule itself {: .warning}
+>
+> `:redelivery_interval` is absent by default. Without it, `{:error, ...}` and
+> `Pulsar.Consumer.nack/2` report a NACK but no timer asks the broker to redeliver it. The message
+> remains unacknowledged and normally returns only after the consumer reconnects or restarts.
+
+## Manual Acknowledgement
+
+Return `{:noreply, state}` when work continues outside the callback. Pass two opaque values to
+that work:
+
+- `self()`, the worker pid that received the message
+- `message.message_id`, the broker message id
+
+The process doing the work calls `Pulsar.Consumer.ack/2` or `Pulsar.Consumer.nack/2` when it knows
+the outcome:
+
+```elixir
+defmodule AsyncBilling do
+  use Pulsar.Consumer.Callback
+
+  def handle_message(%Pulsar.Message{} = message, state) do
+    worker = self()
+
+    Task.Supervisor.start_child(MyApp.TaskSupervisor, fn ->
+      case MyApp.Billing.charge(message.payload) do
+        :ok -> Pulsar.Consumer.ack(worker, message.message_id)
+        {:error, _reason} -> Pulsar.Consumer.nack(worker, message.message_id)
+      end
+    end)
+
+    {:noreply, state}
+  end
+end
+```
+
+The pid is deliberately the short-lived worker, not the stable consumer root or its registered
+name. An acknowledgement carries that worker's broker-side consumer id, so another worker cannot
+answer for it.
+
+Do not call `Pulsar.Consumer.ack(self(), ...)` synchronously from inside the callback. The callback
+already runs in that GenServer, so it would call itself and exit with `:calling_self`. Capture the
+pid and hand it to another process as above, or return `{:ok, state}` for automatic acknowledgement.
+
+Treat `message.message_id` as opaque. A chunked message can carry several broker ids, and both
+`ack/2` and `nack/2` accept that value directly. They also accept a list of ids when one call should
+cover several messages.
+
+## ACK Scope
+
+There are two independent controls, not three mutually exclusive ACK modes:
+
+- `:ack_type` chooses **individual** or **cumulative** scope
+- `:batch_index_ack_enabled` chooses whether an ACK can identify messages within a batch
+
+Together they produce four useful combinations:
+
+| `ack_type` | Batch-index ACK | What is acknowledged |
+| --- | --- | --- |
+| `:individual` | `false` | Named messages; a batch is sent as one entry after all its messages are acknowledged |
+| `:individual` | `true` | Named messages, tracked individually within their batch |
+| `:cumulative` | `false` | Everything through the target entry; a partial batch stops at the preceding safe entry |
+| `:cumulative` | `true` | Everything through the target message, including its position within a batch |
+
+`ack_type: :individual` is the default and works with every subscription type. Cumulative
+acknowledgement requires an `:exclusive` or `:failover` subscription, because `:shared` and
+`:key_shared` subscriptions have no single cursor to move. Invalid combinations are refused when
+the consumer starts.
+
+### Individual ACKs
+
+Individual acknowledgement is the safe general-purpose choice. One message can fail or finish
+later without a successful sibling acknowledging it. It suits parallel and out-of-order work,
+including `:shared` and `:key_shared` subscriptions.
+
+Without batch-index acknowledgement, the client counts successful members of a batch locally and
+acknowledges the entry once every member is done. Enable batch-index acknowledgement when a partly
+processed batch should redeliver only the messages still outstanding.
+
+### Cumulative ACKs
+
+A cumulative ACK covers every message before its target as well as the target itself:
+
+```elixir
+{:ok, consumer} =
+  Pulsar.Consumer.start("events", "projector", Projector,
+    subscription_type: :exclusive,
+    ack_type: :cumulative
+  )
+```
+
+When `Pulsar.Consumer.ack/2` receives several ids, the client sends only the furthest cumulative
+target. Automatic acknowledgement still happens after each callback that returns `{:ok, state}`;
+use `{:noreply, state}` between checkpoints when the intended behavior is one ACK covering several
+successfully processed messages:
+
+```elixir
+def handle_message(message, %{since_checkpoint: count} = state) do
+  :ok = MyApp.Projector.apply_in_order(message)
+  state = %{state | since_checkpoint: count + 1}
+
+  if state.since_checkpoint == 100 do
+    # This ACK also covers the preceding 99 messages.
+    {:ok, %{state | since_checkpoint: 0}}
+  else
+    {:noreply, state}
+  end
+end
+```
+
+> #### A later cumulative ACK passes earlier failures {: .warning}
+>
+> Cumulative scope does not remember that an earlier message was deferred or NACKed. A later ACK
+> acknowledges everything through its target, including that earlier message. Use cumulative
+> acknowledgement only when processing is ordered and a later success proves the whole prefix is
+> complete. Use individual acknowledgement when messages can finish or fail independently.
+
+### Batch-Index ACKs
+
+With `batch_index_ack_enabled: true`, the client sends an `ack_set` describing which messages of a
+batch remain outstanding. Individual ACKs can clear separate indexes; cumulative ACKs clear the
+whole prefix through their target. See [Batching](batching.html) for entry boundaries, redelivery,
+and the effect on backlog metrics.
+
+> #### Requires broker support, and cannot be detected {: .warning}
+>
+> The broker must set `acknowledgmentAtBatchIndexLevelEnabled=true`. Without it, the broker ignores
+> the set and can acknowledge the whole entry, including messages the application has not
+> processed. The protocol does not expose the setting, so the client cannot validate it.
+
+## What a NACK Does
+
+A NACK says that processing did not succeed; it does not undo callback state or immediately pull
+the message back. With `:redelivery_interval` configured, the worker collects NACKed message ids.
+On each interval it asks the broker to redeliver their entries and starts collecting again.
+
+Redelivery is entry-based:
+
+- An unbatched message is requested on its own
+- NACKing several members of one batch produces one redelivery request for the entry
+- Without batch-index state, previously acknowledged members of that batch can be delivered again
+
+The broker increments the redelivery count when it sends the message again. A dead letter policy
+can divert it after enough attempts; see [Dead Letter Policies](dead_letter_policies.html) for the
+retry threshold, failure behavior, and telemetry.
+
+## Batches and Chunks
+
+The broker stores and acknowledges entries, while callbacks see logical messages. Usually those
+are the same thing, but producer features can change the relationship:
+
+- A **batch** puts several messages in one entry. Individual ACKs are counted off until the entry
+  is complete, unless batch-index acknowledgement is enabled. See [Batching](batching.html).
+- A **chunked message** spans several entries. Its `message.message_id` covers every chunk, so pass
+  it through unchanged when acknowledging manually. See [Chunking](chunking.html).
+
+These are why application code should not inspect, reconstruct, or persist assumptions about the
+shape of a message id.
+
+## Choosing a Configuration
+
+| Workload | Recommended starting point |
+| --- | --- |
+| Independent or parallel processing | Default individual ACKs |
+| Ordered processing with periodic checkpoints | Cumulative ACKs on `:exclusive` or `:failover` |
+| Partial batches should redeliver narrowly | Add `batch_index_ack_enabled: true` after verifying broker support |
+| Work finishes outside the callback | Return `{:noreply, state}` and pass the worker pid and message id to it |
+| Failed work should retry | Set `:redelivery_interval` and return `{:error, ...}` or NACK manually |
+| Repeated failures need parking | Add a dead letter policy as well as a redelivery interval |
+
+Whatever the configuration, acknowledge only after the durable side effect is complete and make
+that side effect safe to repeat. A worker or connection can fail between the side effect and its
+ACK, and no ACK strategy can make that boundary exactly-once by itself.

--- a/docs/batching.md
+++ b/docs/batching.md
@@ -160,8 +160,34 @@ redelivery brings back only the rest:
 > batched alongside the acked one. Nothing in the protocol reports the setting, so the client
 > cannot check: Pulsar's shipped `broker.conf` enables it, `standalone.conf` does not.
 
-It costs one ack command per message rather than one per entry, so it only pays for itself when
-messages in a batch meet different fates.
+For individual acknowledgements it costs one ack command per message rather than one per entry,
+so it only pays for itself when messages in a batch meet different fates.
+
+### Cumulative acknowledgements and batches
+
+`ack_type: :cumulative` and `batch_index_ack_enabled: true` are independent settings. The first
+chooses whether an ack covers one message or everything through it; the second chooses whether
+that ack can identify a position within a batch.
+
+```elixir
+{:ok, consumer} = Pulsar.Consumer.start(
+  "orders", "billing", MyConsumer,
+  subscription_type: :exclusive,
+  ack_type: :cumulative,
+  batch_index_ack_enabled: true
+)
+```
+
+When a cumulative ack targets part of a batch:
+
+- With batch-index acknowledgement enabled, the ack set clears the prefix through the target.
+  Redelivery returns only the suffix that is still outstanding.
+- With it disabled, the cursor stops at the previous entry. The current batch remains outstanding
+  in full, avoiding acknowledgement of messages after the target.
+
+Cumulative acknowledgement is available only for `:exclusive` and `:failover` subscriptions,
+which have a single cursor to move. The broker-support warning above applies to cumulative and
+individual batch-index acknowledgements alike.
 
 ## Keys and `Key_Shared`
 
@@ -253,7 +279,8 @@ accepted before it, then publishes it as its own entry. This is what the Java an
     subscription_name: "billing",
     callback_module: MyConsumer,
 
-    batch_index_ack_enabled: false,  # Ask the broker to track per-message acks (default: false)
+    ack_type: :individual,           # :individual or :cumulative (default: :individual)
+    batch_index_ack_enabled: false,  # Track positions within batches (default: false)
     redelivery_interval: 5_000       # Needed for a nack to bring anything back
    ]
  ]}
@@ -280,6 +307,10 @@ accepted before it, then publishes it as its own entry. This is what the Java an
 
 - **`batch_index_ack_enabled`**: Whether acks name individual messages of an entry. Requires
   broker support, as described above.
+
+- **`ack_type`**: Whether an acknowledgement covers the named message (`:individual`) or every
+  message through it (`:cumulative`). Cumulative acknowledgement requires an `:exclusive` or
+  `:failover` subscription and combines with `batch_index_ack_enabled` as described above.
 
 ## Example: Batched Orders with Per-Key Ordering
 

--- a/docs/batching.md
+++ b/docs/batching.md
@@ -112,6 +112,9 @@ and can receive values that compaction has superseded.
 
 **This is the part that behaves differently, and the part worth reading twice.**
 
+For callback outcomes, manual ACK/NACK, cumulative scope, and redelivery outside batching, start
+with [Acknowledgement and Redelivery](acknowledgements.html).
+
 An ack names the entry a message arrived in. There is no way to say "message 3 of this entry"
 unless the broker is configured for it, so acking one message of a batch would acknowledge every
 message batched with it — and lose the ones not yet processed.

--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -10,6 +10,9 @@ ordered subscription it holds up everything behind it.
 A dead letter policy sets the point at which the consumer stops retrying, publishes the message to another
 topic, and acknowledges it. The subscription moves on, and the message is still there to inspect or replay.
 
+For how callback results become ACKs and NACKs before dead lettering is involved, see
+[Acknowledgement and Redelivery](acknowledgements.html).
+
 ## How Dead Lettering Works
 
 ### Consumer Side

--- a/docs/upgrading_to_3.0.md
+++ b/docs/upgrading_to_3.0.md
@@ -319,7 +319,8 @@ explicitly if your deployment relied on staggered consumer or producer startup.
 - `Pulsar.Client`, `Pulsar.Consumer`, and `Pulsar.Producer` document their options and API.
 - `Pulsar.Consumer.Callback` documents callback return values and lifecycle events.
 - The [architecture guide](architecture.html) covers ownership, startup, and recovery.
-- The [batching](batching.html), [chunking](chunking.html), [schemas](schemas.html), and
+- The [acknowledgement and redelivery](acknowledgements.html), [batching](batching.html),
+  [chunking](chunking.html), [schemas](schemas.html), and
   [dead letter policies](dead_letter_policies.html) guides cover those features in depth.
 - Broadway users should follow the
   [off_broadway_pulsar 2.0 upgrade guide](https://hexdocs.pm/off_broadway_pulsar/upgrading_to_2-0.html).

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -13,7 +13,8 @@ defmodule Pulsar.Consumer do
 
   `ack/2` and `nack/2` acknowledge manually, from a process other than the worker that
   delivered the message. `send_flow/3` grants permits to a worker or every worker behind
-  the consumer root.
+  the consumer root. See the [acknowledgement and redelivery guide](acknowledgements.html) for
+  callback outcomes, manual acknowledgement, ACK scope, and retries.
 
   ## Flow Control
 
@@ -211,15 +212,17 @@ defmodule Pulsar.Consumer do
   ## Cumulative acknowledgement
 
   `ack_type: :cumulative` acknowledges everything up to and including the message instead,
-  moving the subscription cursor in one command rather than one per message. Nothing is
-  counted off, and a message left unacked is acknowledged by the next ack that passes it.
+  moving the subscription cursor through it. When one call names several messages, only the
+  furthest target is sent. Nothing is counted off, and a message left unacked is acknowledged
+  by the next ack that passes it.
 
   A cumulative ack can stop part-way through a batch when `:batch_index_ack_enabled` is true:
   its ack set covers the prefix through the target and retains the suffix for redelivery. With
   the flag off, the cursor moves only to the previous entry and the batch is redelivered whole.
 
   It is only available on `:exclusive` and `:failover` subscriptions. See the `:ack_type`
-  option for what it covers.
+  option for what it covers. The [acknowledgement and redelivery guide](acknowledgements.html)
+  puts automatic and manual ACKs, NACKs, cumulative scope, batches, and retries together.
   """
   @spec ack(pid(), MessageIdData.t() | [MessageIdData.t()]) :: :ok | {:error, term()}
   def ack(consumer, message_ids) when is_pid(consumer), do: Worker.ack(consumer, message_ids)

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -207,6 +207,19 @@ defmodule Pulsar.Consumer do
 
   Every message must be acked eventually, or nacked with a `:redelivery_interval` configured to
   bring it back. One that is neither holds its entry's bookkeeping for the life of the consumer.
+
+  ## Cumulative acknowledgement
+
+  `ack_type: :cumulative` acknowledges everything up to and including the message instead,
+  moving the subscription cursor in one command rather than one per message. Nothing is
+  counted off, and a message left unacked is acknowledged by the next ack that passes it.
+
+  A cumulative ack can stop part-way through a batch when `:batch_index_ack_enabled` is true:
+  its ack set covers the prefix through the target and retains the suffix for redelivery. With
+  the flag off, the cursor moves only to the previous entry and the batch is redelivered whole.
+
+  It is only available on `:exclusive` and `:failover` subscriptions. See the `:ack_type`
+  option for what it covers.
   """
   @spec ack(pid(), MessageIdData.t() | [MessageIdData.t()]) :: :ok | {:error, term()}
   def ack(consumer, message_ids) when is_pid(consumer), do: Worker.ack(consumer, message_ids)

--- a/lib/pulsar/consumer/ack.ex
+++ b/lib/pulsar/consumer/ack.ex
@@ -14,31 +14,48 @@ defmodule Pulsar.Consumer.Ack do
   # An `ack_set` is `repeated int64` (`MessageIdData` in pulsar.proto), holding a bitset in the
   # layout Java's `BitSet.toLongArray/0` produces: 64 bits per signed word, lowest index first.
   @word_bits 64
+  @max_uint64 (1 <<< @word_bits) - 1
 
-  defstruct acked: %{}, nacked: MapSet.new(), batch_index_ack_enabled: false
+  defstruct acked: %{},
+            nacked: MapSet.new(),
+            batch_index_ack_enabled: false,
+            ack_type: :individual,
+            cumulative_cursor: nil
 
   @type entry_key :: {non_neg_integer(), non_neg_integer()}
 
   @typedoc "Messages of an entry, one bit per batch index."
   @type bitset :: non_neg_integer()
 
+  @typedoc """
+  How far a cumulative cursor has been moved: an entry, and either a batch index within it or
+  `:whole` for the entry in full. `:whole` sorts above every index, so a partial ack of an
+  entry never reads as further along than an ack of all of it.
+  """
+  @type cursor_position :: {non_neg_integer(), integer(), non_neg_integer() | :whole}
+
   @type message_id :: Binary.MessageIdData.t()
 
   @type t :: %__MODULE__{
           acked: %{optional(entry_key()) => bitset()},
           nacked: MapSet.t(message_id()),
-          batch_index_ack_enabled: boolean()
+          batch_index_ack_enabled: boolean(),
+          ack_type: :individual | :cumulative,
+          cumulative_cursor: cursor_position() | nil
         }
 
-  @type opt :: {:batch_index_ack_enabled, boolean()}
+  @type opt :: {:batch_index_ack_enabled, boolean()} | {:ack_type, :individual | :cumulative}
 
   @spec new([opt()]) :: t()
   def new(opts \\ []) do
-    %__MODULE__{batch_index_ack_enabled: Keyword.get(opts, :batch_index_ack_enabled, false)}
+    %__MODULE__{
+      batch_index_ack_enabled: Keyword.get(opts, :batch_index_ack_enabled, false),
+      ack_type: Keyword.get(opts, :ack_type, :individual)
+    }
   end
 
   @doc """
-  Records an acknowledgement locally, returning `{ids_to_send, ledger}`.
+  Records an acknowledgement locally, returning `{ids_to_send, tracker}`.
 
   Nothing here reaches the broker: the caller sends whatever comes back, which for a batched
   message is usually nothing.
@@ -74,8 +91,79 @@ defmodule Pulsar.Consumer.Ack do
       iex> {[acked], _acks} = Ack.record_ack(Ack.new(batch_index_ack_enabled: true), [id])
       iex> {acked.ack_set, acked.batch_size}
       {[0b110], 3}
+
+  A `:cumulative` tracker counts nothing off, since one ack covers everything up to the message
+  it names. Only the furthest id it is given goes out, and it names that message's entry:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> ids = for entry <- [42, 41], do: %MessageIdData{ledgerId: 7, entryId: entry}
+      iex> {[id], _acks} = Ack.record_ack(Ack.new(ack_type: :cumulative), ids)
+      iex> {id.entryId, id.batch_index}
+      {42, -1}
+
+  An id no further along than one already acknowledged is dropped rather than sent, since the
+  broker only ever moves the cursor forwards:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> at = fn entry -> %MessageIdData{ledgerId: 7, entryId: entry} end
+      iex> {[_id], acks} = Ack.record_ack(Ack.new(ack_type: :cumulative), [at.(42)])
+      iex> Ack.record_ack(acks, [at.(41)])
+      {[], acks}
+
+  Without batch-index acknowledgement, stopping part-way through a batch cannot move the cursor
+  into the entry. Acknowledging the entry would take the messages batched after this one with it,
+  so the entry before is as far as the cursor can go and the batch is redelivered whole:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 0, batch_size: 3}
+      iex> {[acked], _acks} = Ack.record_ack(Ack.new(ack_type: :cumulative), [id])
+      iex> {acked.entryId, acked.batch_index}
+      {41, -1}
+
+  With batch-index acknowledgement, a cumulative ack can stop within the entry. The set carries
+  the messages after the target as still outstanding:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 0, batch_size: 3}
+      iex> opts = [ack_type: :cumulative, batch_index_ack_enabled: true]
+      iex> {[acked], _acks} = Ack.record_ack(Ack.new(opts), [id])
+      iex> {acked.entryId, acked.batch_index, acked.ack_set}
+      {42, -1, [0b110]}
+
+  Acking the last message of the entry covers it in full, so it goes out whole either way:
+
+      iex> alias Pulsar.Consumer.Ack
+      iex> alias Pulsar.Protocol.Binary.Pulsar.Proto.MessageIdData
+      iex> id = %MessageIdData{ledgerId: 7, entryId: 42, batch_index: 2, batch_size: 3}
+      iex> {[acked], _acks} = Ack.record_ack(Ack.new(ack_type: :cumulative), [id])
+      iex> {acked.entryId, acked.batch_index, acked.ack_set}
+      {42, -1, []}
   """
   @spec record_ack(t(), [message_id()]) :: {[message_id()], t()}
+  def record_ack(%__MODULE__{ack_type: :cumulative} = ack, message_ids) do
+    # A redelivered batch omits previously acknowledged messages from callback delivery. The
+    # worker counts those ids off automatically for individual acknowledgement, but a cumulative
+    # ledger must not move merely because the broker reported an id as already acknowledged.
+    targets =
+      message_ids
+      |> Enum.reject(&already_acknowledged?/1)
+      |> Enum.map(&cumulative_target(&1, ack))
+
+    case targets do
+      [] ->
+        {[], ack}
+
+      targets ->
+        targets
+        |> Enum.max_by(&elem(&1, 0))
+        |> maybe_advance_cumulative_cursor(ack)
+    end
+  end
+
   def record_ack(%__MODULE__{} = ack, message_ids) do
     {to_send, new_ack} =
       Enum.reduce(message_ids, {[], ack}, fn message_id, {to_send, acc} ->
@@ -159,6 +247,70 @@ defmodule Pulsar.Consumer.Ack do
 
   ## Private
 
+  # How far a cumulative ack of `message_id` can move the cursor, and the id that says so.
+  #
+  # A cursor normally names entries, so a message part-way through a batch is the awkward case.
+  # With batch-index acknowledgement the ack set can put the cumulative mark inside the entry.
+  # Without it, the entry before is as far as the cursor can safely go without acknowledging the
+  # messages batched after the target.
+  defp cumulative_target(message_id, %{batch_index_ack_enabled: batch_index_ack_enabled}) do
+    case batch_entry(message_id) do
+      # Not batched, or the last message of its batch: the entry is covered in full.
+      nil ->
+        {whole_entry_cursor(message_id), entry_id(message_id)}
+
+      {_key, index, size} when index == size - 1 ->
+        {whole_entry_cursor(message_id), entry_id(message_id)}
+
+      {_key, index, size} when batch_index_ack_enabled ->
+        {cursor_position(message_id), cumulative_batch_index_ack_id(message_id, index, size)}
+
+      {_key, _index, _size} ->
+        previous_entry_target(message_id)
+    end
+  end
+
+  defp previous_entry_target(%Binary.MessageIdData{entryId: 0} = message_id) do
+    # Java and Go use entry -1 as the position immediately before a ledger's first entry. The
+    # protobuf field is uint64, so its wire representation is the largest uint64; keep -1 only in
+    # the logical cursor so it continues to sort before entry zero.
+    previous = %{entry_id(message_id) | entryId: @max_uint64}
+
+    {{message_id.ledgerId, -1, :whole}, previous}
+  end
+
+  defp previous_entry_target(%Binary.MessageIdData{} = message_id) do
+    previous = %{entry_id(message_id) | entryId: message_id.entryId - 1}
+
+    {whole_entry_cursor(previous), previous}
+  end
+
+  defp maybe_advance_cumulative_cursor({position, message_id}, %{cumulative_cursor: cursor} = ack)
+       when is_nil(cursor) or position > cursor, do: {[message_id], %{ack | cumulative_cursor: position}}
+
+  defp maybe_advance_cumulative_cursor(_target, ack), do: {[], ack}
+
+  # An entry acknowledged whole outranks any message within it, which `:whole` sorting above
+  # every integer index gives for free.
+  defp whole_entry_cursor(%Binary.MessageIdData{} = message_id), do: {message_id.ledgerId, message_id.entryId, :whole}
+
+  defp cursor_position(%Binary.MessageIdData{} = message_id) do
+    case batch_entry(message_id) do
+      nil -> whole_entry_cursor(message_id)
+      {_key, index, _size} -> {message_id.ledgerId, message_id.entryId, index}
+    end
+  end
+
+  defp already_acknowledged?(message_id) do
+    case {batch_entry(message_id), outstanding(message_id.ack_set)} do
+      {{_key, index, _size}, outstanding} when is_integer(outstanding) ->
+        not deliverable?(outstanding, index)
+
+      _ ->
+        false
+    end
+  end
+
   # A redelivered entry has to be dealt with in full again before it can be acknowledged, so
   # what it counted off before is dropped rather than counted on from.
   defp forget(ack, message_ids) do
@@ -204,13 +356,26 @@ defmodule Pulsar.Consumer.Ack do
 
   # `batch_size` is what the broker sizes its own bitset from.
   defp batch_index_ack_id(message_id, acked, size) do
-    %{message_id | batch_index: -1, batch_size: size, ack_set: encode_ack_set(acked, size)}
+    outstanding = bnot(acked) &&& every_message(size)
+    ack_set_id(message_id, outstanding, size)
   end
 
-  # Set bits are the messages still outstanding, not the acked ones: the broker starts an entry
-  # with every bit set and deletes it once nothing is left.
-  defp encode_ack_set(acked, size) do
-    outstanding = bnot(acked) &&& every_message(size)
+  # A cumulative batch-index ack clears the whole prefix through `index`, while retaining any
+  # messages the broker already reported as acknowledged on a redelivered entry.
+  defp cumulative_batch_index_ack_id(message_id, index, size) do
+    outstanding = outstanding(message_id.ack_set) || every_message(size)
+    outstanding = outstanding &&& bnot(every_message(index + 1)) &&& every_message(size)
+
+    ack_set_id(message_id, outstanding, size)
+  end
+
+  defp ack_set_id(message_id, outstanding, size) do
+    %{message_id | batch_index: -1, batch_size: size, ack_set: encode_bitset(outstanding, size)}
+  end
+
+  # Set bits are the messages still outstanding: the broker starts an entry with every bit set
+  # and deletes it once nothing is left.
+  defp encode_bitset(outstanding, size) do
     bits = word_count(size) * @word_bits
 
     for <<(word::little-signed-size(@word_bits) <- <<outstanding::little-size(bits)>>)>>, do: word

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -5,6 +5,9 @@ defmodule Pulsar.Consumer.Callback do
   This module provides a `use` macro that sets up your module as a consumer callback
   with default implementations for optional callbacks.
 
+  See the [acknowledgement and redelivery guide](acknowledgements.html) for how callback
+  results become ACKs, NACKs, manual acknowledgement, and retries.
+
   ## Usage
 
   Use this module in your consumer callback:

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -109,13 +109,39 @@ defmodule Pulsar.Consumer.Options do
       default: true,
       doc: "Create the topic if it does not exist."
     ],
+    ack_type: [
+      type: {:in, [:individual, :cumulative]},
+      default: :individual,
+      doc: """
+      What an acknowledgement covers. `:individual` acknowledges the messages it names.
+      `:cumulative` acknowledges everything up to and including them, sending only the
+      furthest one, which moves the subscription cursor in one command instead of one per
+      message.
+
+      **Only `:exclusive` and `:failover` subscriptions may ack cumulatively**, since a shared
+      subscription has no single cursor to move; the broker rejects it otherwise, so this is
+      refused at startup instead.
+
+      Cumulative acknowledgement covers messages that were never acked, and a nacked message
+      the cursor passes is acknowledged along with the rest.
+
+      Cumulative acknowledgement and batch-index acknowledgement are independent. When a
+      cumulative ack stops part-way through a batch, `:batch_index_ack_enabled: true` lets it
+      move into the entry and retain the later messages for redelivery. With the flag off, it
+      stops at the previous entry instead and the batch is redelivered whole.
+      """
+    ],
     batch_index_ack_enabled: [
       type: :boolean,
       default: false,
       doc: """
-      Tell the broker which messages of a batch an ack was for, so that a nack redelivers only
-      the rest of the entry instead of all of it. Costs one ack command per message rather
-      than one per entry.
+      Tell the broker which messages of a batch an ack covers. For individual acks this tracks
+      each acknowledged message; for cumulative acks it tracks the acknowledged prefix through
+      the target. Redelivery can then return only the messages still outstanding instead of the
+      whole entry. This option is independent of `:ack_type`.
+
+      For individual acknowledgement it can cost one ack command per message rather than one
+      per entry.
 
       **Requires `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker.** Without it the
       broker ignores the set and acknowledges the whole entry, losing the messages batched
@@ -235,6 +261,7 @@ defmodule Pulsar.Consumer.Options do
     |> NimbleOptions.validate!(@schema)
     |> validate_flow!()
     |> validate_consumer_count!()
+    |> validate_ack_type!()
   end
 
   defp validate_consumer_count!(opts) do
@@ -255,6 +282,21 @@ defmodule Pulsar.Consumer.Options do
               "granted nothing, so no delivery arrives to trigger a refill. Set a positive " <>
               ":flow_initial, or a {module, function, args} policy if permits will come from " <>
               "Pulsar.Consumer.send_flow/3."
+    end
+
+    opts
+  end
+
+  @cumulative_subscription_types [:exclusive, :failover]
+
+  defp validate_ack_type!(opts) do
+    subscription_type = Keyword.fetch!(opts, :subscription_type)
+
+    if Keyword.fetch!(opts, :ack_type) == :cumulative and subscription_type not in @cumulative_subscription_types do
+      raise ArgumentError,
+            "ack_type: :cumulative is not supported on a #{inspect(subscription_type)} subscription, which " <>
+              "has no single cursor to move: the broker rejects the acknowledgement. Use " <>
+              ":exclusive or :failover, or ack individually."
     end
 
     opts

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -114,9 +114,8 @@ defmodule Pulsar.Consumer.Options do
       default: :individual,
       doc: """
       What an acknowledgement covers. `:individual` acknowledges the messages it names.
-      `:cumulative` acknowledges everything up to and including them, sending only the
-      furthest one, which moves the subscription cursor in one command instead of one per
-      message.
+      `:cumulative` acknowledges everything up to and including the furthest one. When one
+      acknowledgement call names several messages, only that furthest target is sent.
 
       **Only `:exclusive` and `:failover` subscriptions may ack cumulatively**, since a shared
       subscription has no single cursor to move; the broker rejects it otherwise, so this is

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -181,7 +181,7 @@ defmodule Pulsar.Consumer.Worker do
       struct(__MODULE__, opts)
       | consumer_id: System.unique_integer([:positive, :monotonic]),
         consumer_name: Keyword.get(opts, :name),
-        acks: Ack.new(Keyword.take(opts, [:batch_index_ack_enabled])),
+        acks: Ack.new(Keyword.take(opts, [:batch_index_ack_enabled, :ack_type])),
         schema: build_schema(Keyword.get(opts, :schema)),
         max_redelivery: max_redelivery(Keyword.get(opts, :dead_letter_policy))
     }
@@ -392,11 +392,14 @@ defmodule Pulsar.Consumer.Worker do
     # A skipped message was still sent, and still charged a permit.
     permits_consumed = length(skipped_ids) + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
 
-    # No callback runs for a skipped message, so nothing else can count it off its entry.
+    # Individual acknowledgement counts skipped messages off so the local batch tally can
+    # complete. A cumulative acknowledgement follows Java's more conservative rule: filtering
+    # a message from delivery does not itself move the subscription cursor. A later visible ack
+    # can still pass and therefore cover it.
     new_state =
       new_state
       |> decrement_permits(permits_consumed)
-      |> ack_message_ids(skipped_ids)
+      |> record_skipped_ids(skipped_ids)
 
     # A delivery the policy is done with is diverted instead of delivered, not as well as.
     result =
@@ -620,6 +623,9 @@ defmodule Pulsar.Consumer.Worker do
     %{state | acks: Ack.record_nack(state.acks, nacked_ids)}
   end
 
+  defp record_skipped_ids(%__MODULE__{acks: %Ack{ack_type: :cumulative}} = state, _skipped_ids), do: state
+  defp record_skipped_ids(%__MODULE__{} = state, skipped_ids), do: ack_message_ids(state, skipped_ids)
+
   defp ack_message_ids(state, message_ids, validation_error \\ nil) do
     {to_send, acks} = Ack.record_ack(state.acks, message_ids)
 
@@ -632,7 +638,7 @@ defmodule Pulsar.Consumer.Worker do
   defp send_ack(state, message_ids, validation_error) do
     ack_command = %Binary.CommandAck{
       consumer_id: state.consumer_id,
-      ack_type: :Individual,
+      ack_type: Protocol.to_ack_type(state.acks.ack_type),
       message_id: message_ids,
       validation_error: validation_error
     }
@@ -1030,7 +1036,9 @@ defmodule Pulsar.Consumer.Worker do
   # compacted topic leaves entries holding messages compaction has replaced. Neither is delivered,
   # and both still count towards their entry, so they come back to be counted off.
   defp build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped_messages) do
-    base_message_id = command.message_id
+    # Preserve the broker's batch-index state on each unwrapped id. A later cumulative ack uses
+    # it as its starting point instead of making previously acknowledged messages outstanding.
+    base_message_id = %{command.message_id | ack_set: command.ack_set}
     batch_size = length(unwrapped_messages)
     outstanding = Ack.outstanding(command.ack_set)
 

--- a/lib/pulsar/protocol.ex
+++ b/lib/pulsar/protocol.ex
@@ -364,6 +364,8 @@ defmodule Pulsar.Protocol do
 
   @compressions %{none: :NONE, lz4: :LZ4, zlib: :ZLIB, zstd: :ZSTD, snappy: :SNAPPY}
 
+  @ack_types %{individual: :Individual, cumulative: :Cumulative}
+
   @doc """
   Translates a `:subscription_type` option to the wire's subscription type.
   """
@@ -381,4 +383,10 @@ defmodule Pulsar.Protocol do
   """
   @spec to_compression(atom()) :: atom()
   def to_compression(compression), do: Map.fetch!(@compressions, compression)
+
+  @doc """
+  Translates an `:ack_type` option to the wire's ack type.
+  """
+  @spec to_ack_type(atom()) :: atom()
+  def to_ack_type(ack_type), do: Map.fetch!(@ack_types, ack_type)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule Pulsar.MixProject do
           "README.md",
           "CHANGELOG.md",
           "docs/architecture.md",
+          "docs/acknowledgements.md",
           "docs/batching.md",
           "docs/chunking.md",
           "docs/dead_letter_policies.md",

--- a/test/integration/consumer/cumulative_ack_test.exs
+++ b/test/integration/consumer/cumulative_ack_test.exs
@@ -1,0 +1,171 @@
+defmodule Pulsar.Integration.Consumer.CumulativeAckTest do
+  use Pulsar.Test.Case, async: true
+
+  @topic "persistent://public/default/consumer-cumulative-ack-test"
+  @messages ["msg-1", "msg-2", "msg-3", "msg-4", "msg-5"]
+
+  # Acks only the messages it is told to, so the rest are left for the cursor to pass over.
+  defmodule SelectiveAckConsumer do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(opts, _context) do
+      {:ok, %{notify_pid: Keyword.fetch!(opts, :notify_pid), ack: Keyword.fetch!(opts, :ack)}}
+    end
+
+    def handle_message(message, state) do
+      send(state.notify_pid, {:received, message.payload})
+
+      if state.ack == :all or message.payload in state.ack do
+        {:ok, state}
+      else
+        {:noreply, state}
+      end
+    end
+  end
+
+  test "one ack acknowledges the messages before it that were never acked" do
+    topic = @topic <> "-through"
+    subscription = "through-sub"
+    :ok = produce(topic, "through")
+
+    consumer = start_consumer(topic, subscription, ack: ["msg-3"])
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    # msg-1 and msg-2 were only ever deferred, but the ack of msg-3 moved the cursor past them.
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- ["msg-4", "msg-5"], do: assert_receive({:received, ^payload}, 10_000)
+    refute_receive {:received, "msg-1"}, 2_000
+    refute_receive {:received, "msg-2"}, 2_000
+  end
+
+  test "leaves the messages after the cursor to be redelivered" do
+    topic = @topic <> "-remainder"
+    subscription = "remainder-sub"
+    :ok = produce(topic, "remainder")
+
+    consumer = start_consumer(topic, subscription, ack: ["msg-2"])
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- ["msg-3", "msg-4", "msg-5"], do: assert_receive({:received, ^payload}, 10_000)
+  end
+
+  test "acking every message leaves the subscription caught up" do
+    topic = @topic <> "-complete"
+    subscription = "complete-sub"
+    :ok = produce(topic, "complete")
+
+    consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    refute_receive {:received, _payload}, 3_000
+  end
+
+  # The cursor names entries, so a batch is where cumulative acking can overshoot.
+  test "does not acknowledge the messages batched after the one that was acked" do
+    topic = @topic <> "-batch"
+    subscription = "batch-sub"
+    :ok = produce_one_batch(topic, "batch")
+
+    consumer = start_consumer(topic, subscription, ack: ["msg-2"])
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    # msg-3 onwards were never processed, so the entry has to come back — and it comes back
+    # whole, since an entry is the unit of redelivery.
+    _consumer = start_consumer(topic, subscription, ack: :all)
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+  end
+
+  test "redelivers only the suffix after a cumulative batch-index ack" do
+    topic = @topic <> "-batch-index"
+    subscription = "batch-index-sub"
+    :ok = produce_one_batch(topic, "batch-index")
+
+    consumer = start_consumer(topic, subscription, [ack: ["msg-2"]], batch_index_ack_enabled: true)
+    for payload <- @messages, do: assert_receive({:received, ^payload}, 10_000)
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+
+    _consumer = start_consumer(topic, subscription, [ack: :all], batch_index_ack_enabled: true)
+    for payload <- ["msg-3", "msg-4", "msg-5"], do: assert_receive({:received, ^payload}, 10_000)
+    refute_receive {:received, "msg-1"}, 2_000
+    refute_receive {:received, "msg-2"}, 2_000
+  end
+
+  test "refuses a subscription the broker would reject the acknowledgement on" do
+    assert_raise ArgumentError, ~r/no single cursor/, fn ->
+      Pulsar.Consumer.start(@topic, "shared-sub", SelectiveAckConsumer,
+        client: @client,
+        ack_type: :cumulative,
+        subscription_type: :shared,
+        init_args: [notify_pid: self(), ack: :all]
+      )
+    end
+  end
+
+  ## Helpers
+
+  # Unbatched, so each message is its own entry and the cursor has somewhere to stop.
+  defp produce(topic, name) do
+    :ok = System.create_topic(topic)
+
+    {:ok, producer} = Pulsar.Producer.start(topic, client: @client, name: "#{name}-producer")
+    :ok = Pulsar.Producer.await_ready(producer)
+
+    for payload <- @messages do
+      assert {:ok, _message_id} = Pulsar.Producer.send(producer, payload)
+    end
+
+    :ok
+  end
+
+  # One batch, so all five messages share a single entry.
+  defp produce_one_batch(topic, name) do
+    :ok = System.create_topic(topic)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(topic,
+        client: @client,
+        name: "#{name}-producer",
+        batch_enabled: true,
+        batch_size: length(@messages),
+        flush_interval: 30_000
+      )
+
+    :ok = Pulsar.Producer.await_ready(producer)
+
+    results =
+      @messages
+      |> Enum.map(fn payload -> Task.async(fn -> Pulsar.Producer.send(producer, payload) end) end)
+      |> Task.await_many(10_000)
+
+    assert Enum.all?(results, &match?({:ok, _}, &1))
+
+    :ok
+  end
+
+  defp start_consumer(topic, subscription, init_args, consumer_opts \\ []) do
+    {:ok, consumer} =
+      Pulsar.Consumer.start(
+        topic,
+        subscription,
+        SelectiveAckConsumer,
+        [
+          client: @client,
+          ack_type: :cumulative,
+          subscription_type: :exclusive,
+          initial_position: :earliest,
+          init_args: [notify_pid: self()] ++ init_args
+        ] ++ consumer_opts
+      )
+
+    :ok = Pulsar.Consumer.await_ready(consumer)
+
+    consumer
+  end
+end

--- a/test/unit/consumer_ack_test.exs
+++ b/test/unit/consumer_ack_test.exs
@@ -20,6 +20,151 @@ defmodule Pulsar.Consumer.AckTest do
     end
   end
 
+  describe "record_ack/2 when cumulative" do
+    setup do: %{ack: Ack.new(ack_type: :cumulative)}
+
+    test "sends only the furthest of the ids it is given", %{ack: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [id(41), id(43), id(42)])
+
+      assert acked.entryId == 43
+    end
+
+    test "orders by ledger before entry, so a new ledger wins a lower entry id", %{ack: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [%{id(99) | ledgerId: 7}, %{id(1) | ledgerId: 8}])
+
+      assert {acked.ledgerId, acked.entryId} == {8, 1}
+    end
+
+    test "counts nothing off, since one ack covers the messages before it", %{ack: ack} do
+      {[_acked], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+
+      assert ack.acked == %{}
+    end
+
+    test "sends nothing for an id the cursor has already passed", %{ack: ack} do
+      {[_acked], ack} = Ack.record_ack(ack, [id(43)])
+
+      assert {[], ^ack} = Ack.record_ack(ack, [id(42)])
+      assert {[], ^ack} = Ack.record_ack(ack, [id(43)])
+    end
+
+    test "sends again once an id moves the cursor on", %{ack: ack} do
+      {[_acked], ack} = Ack.record_ack(ack, [id(43)])
+      {[acked], _ack} = Ack.record_ack(ack, [id(44)])
+
+      assert acked.entryId == 44
+    end
+
+    test "has nothing to send for no ids at all", %{ack: ack} do
+      assert {[], ^ack} = Ack.record_ack(ack, [])
+    end
+  end
+
+  # Without batch-index acknowledgement, stopping part-way through a batch cannot move the
+  # cursor into the entry. With it, the broker can retain the unread suffix in an ack set.
+  describe "record_ack/2 when cumulative, stopping inside a batch" do
+    setup do
+      %{
+        plain: Ack.new(ack_type: :cumulative),
+        indexed: Ack.new(ack_type: :cumulative, batch_index_ack_enabled: true)
+      }
+    end
+
+    test "goes no further than the entry before, rather than acknowledging the rest", %{plain: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+
+      assert {acked.entryId, acked.batch_index, acked.ack_set} == {41, -1, []}
+    end
+
+    test "uses the before-ledger sentinel when the batch is the ledger's first entry", %{plain: ack} do
+      message_id = batch_id(0, 3, entry: 0)
+
+      {[acked], ack} = Ack.record_ack(ack, [message_id])
+
+      assert acked.entryId == 0xFFFF_FFFF_FFFF_FFFF
+      assert ack.cumulative_cursor == {7, -1, :whole}
+
+      decoded = acked |> Binary.MessageIdData.encode() |> Binary.MessageIdData.decode()
+      assert decoded.entryId == 0xFFFF_FFFF_FFFF_FFFF
+    end
+
+    test "converts every id to a safe target before choosing the furthest one", %{plain: ack} do
+      earlier_ledger = %{id(99) | ledgerId: 6}
+      first_entry_of_later_ledger = %{batch_id(0, 3, entry: 0) | ledgerId: 7}
+
+      {[acked], ack} = Ack.record_ack(ack, [earlier_ledger, first_entry_of_later_ledger])
+
+      assert {acked.ledgerId, acked.entryId} == {7, 0xFFFF_FFFF_FFFF_FFFF}
+      assert ack.cumulative_cursor == {7, -1, :whole}
+    end
+
+    test "stops at the requested batch index when batch index acking is on", %{indexed: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+
+      assert {acked.entryId, acked.batch_index, acked.ack_set, acked.batch_size} ==
+               {42, -1, [0b110], 3}
+    end
+
+    test "clears the whole prefix through the cumulative target", %{indexed: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [batch_id(1, 4)])
+
+      assert acked.ack_set == [0b1100]
+    end
+
+    test "preserves messages the broker reported as already acknowledged", %{indexed: ack} do
+      message_id = %{batch_id(1, 4) | ack_set: [0b1011]}
+
+      {[acked], _ack} = Ack.record_ack(ack, [message_id])
+
+      assert acked.ack_set == [0b1000]
+    end
+
+    test "spans words when the cumulative target crosses a word boundary", %{indexed: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [batch_id(64, 70)])
+
+      assert acked.ack_set == [0, 0b111110]
+    end
+
+    test "acknowledges the entry whole once its last message is acked", %{plain: plain, indexed: indexed} do
+      for ack <- [plain, indexed] do
+        {[acked], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
+
+        assert {acked.entryId, acked.batch_index, acked.ack_set} == {42, -1, []}
+      end
+    end
+
+    test "moves on to the entry itself once the batch is complete", %{plain: ack} do
+      {[before], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+      {[], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+      {[whole], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
+
+      assert {before.entryId, whole.entryId} == {41, 42}
+    end
+
+    test "moves through batch indices before covering the entry", %{indexed: ack} do
+      {[first], ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+      {[second], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+      {[whole], _ack} = Ack.record_ack(ack, [batch_id(2, 3)])
+
+      assert {first.entryId, first.ack_set} == {42, [0b110]}
+      assert {second.entryId, second.ack_set} == {42, [0b100]}
+      assert {whole.entryId, whole.ack_set} == {42, []}
+    end
+
+    test "stays put while the same message is acked again", %{plain: ack} do
+      {[_acked], ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+
+      assert {[], ^ack} = Ack.record_ack(ack, [batch_id(1, 3)])
+      assert {[], ^ack} = Ack.record_ack(ack, [batch_id(0, 3)])
+    end
+
+    test "treats a batch of one as a whole entry, since there is nothing to stop before", %{plain: ack} do
+      {[acked], _ack} = Ack.record_ack(ack, [batch_id(0, 1)])
+
+      assert {acked.entryId, acked.batch_index} == {42, -1}
+    end
+  end
+
   describe "entry_id/1" do
     test "leaves an id that names no batch untouched" do
       assert Ack.entry_id(id()) == id()

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -215,6 +215,109 @@ defmodule Pulsar.Consumer.BatchAckTest do
     end
   end
 
+  describe "acking cumulatively" do
+    defp cumulative(answers, opts \\ []) do
+      worker_state(answers, Keyword.merge([ack_type: :cumulative, subscription_type: :failover], opts))
+    end
+
+    test "sends the wire ack type the subscription cursor moves on" do
+      deliver_unbatched(cumulative(%{}), "solo")
+
+      assert [%Binary.CommandAck{ack_type: :Cumulative}] = acks()
+    end
+
+    test "does not acknowledge the entry while messages batched after the acked one are deferred" do
+      deliver(cumulative(%{"b" => :defer, "c" => :defer}), ["a", "b", "c"])
+
+      # Acking the entry would take "b" and "c" with it, which nothing has processed. The entry
+      # before is as far as the cursor can go, and it moves the rest of the way once "c" is acked.
+      assert [ack] = acks()
+      assert [%{ledgerId: @ledger, entryId: 41, batch_index: -1}] = ack.message_id
+    end
+
+    test "acknowledges the entry once its last message is acked" do
+      deliver(cumulative(%{"a" => :defer, "b" => :defer}), ["a", "b", "c"])
+
+      assert [ack] = acks()
+      assert [%{ledgerId: @ledger, entryId: @entry, batch_index: -1}] = ack.message_id
+    end
+
+    test "moves through a batch with ack sets when batch index acking is on" do
+      deliver(cumulative(%{"c" => :defer}, batch_index_ack_enabled: true), ["a", "b", "c"])
+
+      assert [first, second] = acks()
+      assert first.ack_type == :Cumulative
+      assert second.ack_type == :Cumulative
+      assert [%{entryId: @entry, ack_set: [0b110], batch_size: 3}] = first.message_id
+      assert [%{entryId: @entry, ack_set: [0b100], batch_size: 3}] = second.message_id
+    end
+
+    test "starts from the broker's ack set when a partial entry is redelivered" do
+      state = cumulative(%{"d" => :defer}, batch_index_ack_enabled: true)
+
+      # "c" was already acknowledged, while "a", "b", and "d" remain outstanding.
+      deliver(state, ["a", "b", "c", "d"], ack_set: [0b1011])
+
+      assert delivered_payloads() == ["a", "b", "d"]
+      assert [first, second] = Enum.map(acks(), fn ack -> hd(ack.message_id) end)
+      assert first.ack_set == [0b1010]
+      assert second.ack_set == [0b1000]
+    end
+
+    test "leaves a deferred entry unacknowledged until something passes it" do
+      state = deliver_unbatched(cumulative(%{"a" => :defer}), "a")
+      assert [] == acks()
+
+      deliver_unbatched(state, "b", entry: @entry + 1)
+
+      assert [ack] = acks()
+      assert [%{entryId: 43}] = ack.message_id
+    end
+
+    test "sends nothing for a message that does not move the cursor on" do
+      # "a" and "b" both take the cursor to the entry before this one, so only the first of them
+      # is worth a command; "c" then covers the entry itself.
+      deliver(cumulative(%{"c" => :defer}), ["a", "b", "c"])
+
+      assert [ack] = acks()
+      assert [%{entryId: 41}] = ack.message_id
+    end
+
+    test "does not ack an entry the cursor has already passed" do
+      state = deliver_unbatched(cumulative(%{}), "b", entry: @entry + 1)
+      assert [%{message_id: [%{entryId: 43}]}] = acks()
+
+      deliver_unbatched(state, "a")
+
+      assert [] == acks()
+    end
+
+    test "does not let a trailing compacted member acknowledge a deferred visible message" do
+      for opts <- [[], [batch_index_ack_enabled: true]] do
+        deliver(cumulative(%{"a" => :defer}, opts), ["a", "compacted"], compacted_out: [1])
+
+        assert delivered_payloads() == ["a"]
+        assert acks() == []
+      end
+    end
+
+    test "does not let a compacted member advance a batch-index ack past an earlier callback" do
+      state = cumulative(%{"a" => :defer, "c" => :defer}, batch_index_ack_enabled: true)
+
+      deliver(state, ["a", "compacted", "c"], compacted_out: [1])
+
+      assert delivered_payloads() == ["a", "c"]
+      assert acks() == []
+    end
+
+    test "does not initiate a cumulative ack for an entirely compacted batch" do
+      deliver(cumulative(%{}), ["a", "b", "c"], compacted_out: [0, 1, 2])
+
+      assert delivered_payloads() == []
+      assert acks() == []
+    end
+  end
+
   describe "batch index acking" do
     test "sends partial acknowledgements before a callback stops within a batch" do
       state = worker_state(%{"b" => {:stop, :normal}}, batch_index_ack_enabled: true)
@@ -504,7 +607,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
   end
 
   defp worker_state(answers, opts \\ []) do
-    {ack_opts, opts} = Keyword.split(opts, [:batch_index_ack_enabled])
+    {ack_opts, opts} = Keyword.split(opts, [:batch_index_ack_enabled, :ack_type])
 
     struct(
       Worker,

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -99,6 +99,52 @@ defmodule Pulsar.Consumer.OptionsTest do
     end
   end
 
+  describe "validate!/1 ack type" do
+    test "acknowledges individually by default" do
+      assert validate!([])[:ack_type] == :individual
+    end
+
+    for subscription_type <- [:exclusive, :failover] do
+      test "allows cumulative acks on a #{subscription_type} subscription, which has one cursor" do
+        opts = validate!(ack_type: :cumulative, subscription_type: unquote(subscription_type))
+
+        assert opts[:ack_type] == :cumulative
+      end
+    end
+
+    test "allows cumulative and batch-index acknowledgement together" do
+      opts =
+        validate!(
+          ack_type: :cumulative,
+          batch_index_ack_enabled: true,
+          subscription_type: :exclusive
+        )
+
+      assert opts[:ack_type] == :cumulative
+      assert opts[:batch_index_ack_enabled]
+    end
+
+    for subscription_type <- [:shared, :key_shared] do
+      test "refuses cumulative acks on a #{subscription_type} subscription the broker would reject" do
+        assert_raise ArgumentError, ~r/no single cursor/, fn ->
+          validate!(ack_type: :cumulative, subscription_type: unquote(subscription_type))
+        end
+      end
+    end
+
+    test "refuses cumulative acks on the default subscription type rather than defaulting around it" do
+      assert_raise ArgumentError, ~r/:shared subscription/, fn ->
+        validate!(ack_type: :cumulative)
+      end
+    end
+
+    test "rejects an unknown ack type" do
+      assert_raise NimbleOptions.ValidationError, ~r/:ack_type/, fn ->
+        validate!(ack_type: :Cumulative)
+      end
+    end
+  end
+
   describe "validate!/1 with a dead letter policy" do
     test "is absent unless asked for" do
       refute Keyword.has_key?(validate!([]), :dead_letter_policy)

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -398,6 +398,24 @@ defmodule Pulsar.Consumer.WorkerTest do
       assert message.payload == @chunked
     end
 
+    test "acknowledge the assembled message with the configured cumulative type" do
+      compressed = :zlib.compress(@chunked)
+      half = div(byte_size(compressed), 2)
+      <<first::binary-size(^half), second::binary>> = compressed
+      opts = [uncompressed_size: byte_size(@chunked), total_chunk_msg_size: byte_size(compressed)]
+
+      state =
+        struct(reporting_state(),
+          subscription_type: :failover,
+          max_pending_chunked_messages: 10,
+          acks: Ack.new(ack_type: :cumulative)
+        )
+
+      {:noreply, _state} = deliver_chunks([{first, opts}, {second, opts}], state)
+
+      assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{ack_type: :Cumulative}}}
+    end
+
     test "rejects independently compressed chunks even when their sizes collide" do
       chunk = :binary.copy(<<"a">>, 11)
       compressed = :zlib.compress(chunk)
@@ -439,8 +457,10 @@ defmodule Pulsar.Consumer.WorkerTest do
   end
 
   defp deliver_chunks(chunks) do
-    state = struct(reporting_state(), max_pending_chunked_messages: 10)
+    deliver_chunks(chunks, struct(reporting_state(), max_pending_chunked_messages: 10))
+  end
 
+  defp deliver_chunks(chunks, state) do
     chunks
     |> Enum.with_index()
     |> Enum.reduce({:noreply, state}, fn {{payload, opts}, chunk_id}, {:noreply, acc} ->


### PR DESCRIPTION
Extracted from #152, which built cumulative acknowledgement on abstractions that 3.0 has since replaced.

Adds `ack_type: :cumulative` while retaining the existing `batch_index_ack_enabled` option. These are independent controls, matching Pulsar's Java and Go clients:

| `ack_type` | Batch-index disabled | Batch-index enabled |
|---|---|---|
| `:individual` (default) | Individual wire ACK; complete batches are acknowledged as entries | Individual wire ACK with `ack_set` |
| `:cumulative` | Cumulative wire ACK; a partial batch stops at the preceding safe entry boundary | Cumulative wire ACK with `ack_set`, acknowledging the prefix through the target |

Only `:exclusive` and `:failover` subscriptions have a single cursor and may use cumulative acknowledgement. `:shared` and `:key_shared` combinations are rejected at startup rather than at the first broker ACK. Batch-index acknowledgement remains valid with either ACK type and on every subscription type for which that ACK type is valid.

### Batches

With `ack_type: :cumulative, batch_index_ack_enabled: true`, acknowledging a message inside a batch sends the current entry with an ACK set whose prefix is cleared through that message. Previously acknowledged indexes reported by the broker are preserved. On redelivery, only the outstanding suffix is delivered.

With batch-index acknowledgement disabled, a partial cumulative ACK falls back to the preceding entry so it cannot acknowledge later, unprocessed batch members. If the batch is entry zero and no preceding entry can be represented, the client safely sends nothing until the entry can be acknowledged in full.
