### PR TITLE
feat(consumer): report reaching the end of a terminated topic

### DIFF
--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -742,16 +742,17 @@ defmodule Pulsar.Broker do
   end
 
   # Informational, so an unknown consumer is only worth a debug line: nothing to clean up.
-  defp handle_command(%Binary.CommandReachedEndOfTopic{consumer_id: consumer_id} = command, broker) do
-    case Map.get(broker.consumers, consumer_id) do
-      nil ->
-        Logger.debug("Received end of topic for unknown consumer #{consumer_id}")
-        :keep_state_and_data
+  defp handle_command(%Binary.CommandReachedEndOfTopic{consumer_id: consumer_id}, %__MODULE__{consumers: consumers})
+       when not is_map_key(consumers, consumer_id) do
+    Logger.debug("Received end of topic for unknown consumer #{consumer_id}")
+    :keep_state_and_data
+  end
 
-      {consumer_pid, _monitor_ref} ->
-        send(consumer_pid, {:broker_message, command})
-        :keep_state_and_data
-    end
+  defp handle_command(%Binary.CommandReachedEndOfTopic{consumer_id: consumer_id} = command, broker) do
+    {consumer_pid, _monitor_ref} = Map.fetch!(broker.consumers, consumer_id)
+    send(consumer_pid, {:broker_message, command})
+
+    :keep_state_and_data
   end
 
   defp handle_command(%Binary.CommandCloseProducer{producer_id: producer_id} = command, broker) do

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -741,6 +741,19 @@ defmodule Pulsar.Broker do
     end
   end
 
+  # Informational, so an unknown consumer is only worth a debug line: nothing to clean up.
+  defp handle_command(%Binary.CommandReachedEndOfTopic{consumer_id: consumer_id} = command, broker) do
+    case Map.get(broker.consumers, consumer_id) do
+      nil ->
+        Logger.debug("Received end of topic for unknown consumer #{consumer_id}")
+        :keep_state_and_data
+
+      {consumer_pid, _monitor_ref} ->
+        send(consumer_pid, {:broker_message, command})
+        :keep_state_and_data
+    end
+  end
+
   defp handle_command(%Binary.CommandCloseProducer{producer_id: producer_id} = command, broker) do
     case Map.get(broker.producers, producer_id) do
       nil ->

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -40,6 +40,7 @@ defmodule Pulsar.Consumer.Callback do
   - `handle_info/2` - Handle other messages (default: `{:noreply, state}`)
   - `became_active/1` - Called when this consumer becomes the active consumer of a `:failover` subscription (default: `{:noreply, state}`)
   - `became_passive/1` - Called when this consumer becomes a passive (standby) consumer of a `:failover` subscription (default: `{:noreply, state}`)
+  - `reached_end_of_topic/1` - Called when this consumer has drained a terminated topic (default: `{:noreply, state}`)
   - `handle_invalid_message/2` - Called instead of `handle_message/2` for a message whose
     bytes could not be trusted (default: log a warning and acknowledge it, so it is not
     redelivered). Override it to record or divert such messages; see `Pulsar.Message.valid?/1`
@@ -193,6 +194,41 @@ defmodule Pulsar.Consumer.Callback do
   takeover; not meaningful for other subscription types. A passive consumer
   never receives messages, so there is nothing to pause or resume.
 
+  ## End of Topic
+
+  `reached_end_of_topic/1` is called when the consumer has read to the end of a topic that
+  has been terminated, meaning no further message will ever be published to it. The default
+  implementation keeps the consumer running, which is what a partitioned consumer wants:
+  each partition reaches its end separately, and the others still have messages to deliver.
+
+  Every consumer on the subscription is told, not just whichever one read last: each of the
+  `:consumer_count` processes on a shared subscription hears it, both the active and the
+  passive consumers of a failover one, and each partition's process separately. A shutdown
+  that waits for the whole topic waits for every worker to report, not for the first.
+
+  A worker can be told more than once. Unacknowledged messages are redelivered after the
+  notification, and draining them reaches the end again; so does every reconnect, since the
+  broker sends it to each new session on a terminated topic. Track which workers have
+  reported rather than counting notifications, and keep whatever the callback does here
+  idempotent.
+
+  This says the topic is finished, not the subscription. Answer `{:stop, reason, state}` to
+  shut this worker down once it has nothing left to read:
+
+      def reached_end_of_topic(state) do
+        {:stop, :normal, state}
+      end
+
+  > #### Stopping here is not yet permanent {: .warning}
+  >
+  > A stopped worker is not restarted, but neither outcome of stopping one is what you want.
+  > Stop the last worker of a group and the group shuts down with it, and topology
+  > reconciliation revives it about a minute later: it subscribes again, reaches the end
+  > again, and stops again, on a loop. Stop only some of a `:consumer_count` and the group
+  > keeps running short of workers, since reconciliation only revives whole groups, never
+  > refills one. Use `Pulsar.Consumer.stop/2` from another process to take a consumer down
+  > for good.
+
   ## Manual Acknowledgment
 
   When you return `{:noreply, state}` from `handle_message/2`, the message will NOT be automatically
@@ -262,6 +298,7 @@ defmodule Pulsar.Consumer.Callback do
                       handle_info: 2,
                       became_active: 1,
                       became_passive: 1,
+                      reached_end_of_topic: 1,
                       handle_invalid_message: 2
   @callback terminate(reason, state) :: term()
   @callback handle_call(term(), GenServer.from(), state) ::
@@ -284,6 +321,10 @@ defmodule Pulsar.Consumer.Callback do
               | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
               | {:stop, term(), state}
   @callback became_passive(state) ::
+              {:noreply, state}
+              | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
+              | {:stop, term(), state}
+  @callback reached_end_of_topic(state) ::
               {:noreply, state}
               | {:noreply, state, timeout() | :hibernate | {:continue, term()}}
               | {:stop, term(), state}
@@ -322,6 +363,10 @@ defmodule Pulsar.Consumer.Callback do
         {:noreply, state}
       end
 
+      def reached_end_of_topic(state) do
+        {:noreply, state}
+      end
+
       def handle_invalid_message(message, state) do
         require Logger
 
@@ -337,6 +382,7 @@ defmodule Pulsar.Consumer.Callback do
                      handle_info: 2,
                      became_active: 1,
                      became_passive: 1,
+                     reached_end_of_topic: 1,
                      handle_invalid_message: 2
     end
   end

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -358,13 +358,19 @@ defmodule Pulsar.Consumer.Worker do
   def handle_info({:broker_message, %Binary.CommandActiveConsumerChange{is_active: true}}, state) do
     Logger.info("Consumer #{state.consumer_id} became the active consumer for subscription #{state.subscription_name}")
 
-    dispatch_active_state_change(state, :became_active)
+    dispatch_event(state, :became_active)
   end
 
   def handle_info({:broker_message, %Binary.CommandActiveConsumerChange{is_active: false}}, state) do
     Logger.info("Consumer #{state.consumer_id} became a passive consumer for subscription #{state.subscription_name}")
 
-    dispatch_active_state_change(state, :became_passive)
+    dispatch_event(state, :became_passive)
+  end
+
+  def handle_info({:broker_message, %Binary.CommandReachedEndOfTopic{}}, state) do
+    Logger.info("Consumer #{state.consumer_id} reached the end of terminated topic #{state.topic}")
+
+    dispatch_event(state, :reached_end_of_topic)
   end
 
   def handle_info({:broker_message, message_data}, state) do
@@ -463,7 +469,7 @@ defmodule Pulsar.Consumer.Worker do
     end
   end
 
-  defp dispatch_active_state_change(state, callback_fun) do
+  defp dispatch_event(state, callback_fun) do
     case apply(state.callback_module, callback_fun, [state.callback_state]) do
       {:noreply, new_callback_state} ->
         {:noreply, %{state | callback_state: new_callback_state}}

--- a/test/integration/consumer/end_of_topic_test.exs
+++ b/test/integration/consumer/end_of_topic_test.exs
@@ -1,0 +1,110 @@
+defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
+  use Pulsar.Test.Case, async: true
+
+  alias Pulsar.Test.Support.DummyConsumer
+
+  @topic "persistent://public/default/consumer-end-of-topic-test"
+  @messages ["msg-1", "msg-2", "msg-3"]
+
+  test "tells a consumer that has drained a terminated topic" do
+    topic = @topic <> "-drained"
+    consumer = start_consumer(topic, "drained-sub")
+    [worker] = Topology.workers(consumer)
+
+    drain()
+    :ok = System.terminate_topic(topic)
+
+    assert_receive {:consumer_end_of_topic, ^worker}, 10_000
+    assert Process.alive?(worker)
+  end
+
+  test "leaves the consumer and its connection alive" do
+    topic = @topic <> "-alive"
+    consumer = start_consumer(topic, "alive-sub")
+
+    drain()
+    :ok = System.terminate_topic(topic)
+    assert_receive {:consumer_end_of_topic, _worker}, 10_000
+
+    # A terminated topic still admits a new subscription, which a downed connection could not.
+    :ok = Pulsar.Consumer.stop(consumer, client: @client)
+    start_consumer(topic, "alive-replay-sub", create_topic?: false, seed?: false)
+
+    drain()
+  end
+
+  test "lets the callback stop the worker" do
+    topic = @topic <> "-stopping"
+    consumer = start_consumer(topic, "stopping-sub", init_args: [stop_at_end_of_topic: true])
+    [worker] = Topology.workers(consumer)
+
+    drain()
+
+    ref = Process.monitor(worker)
+    :ok = System.terminate_topic(topic)
+
+    assert_receive {:consumer_end_of_topic, ^worker}, 10_000
+    assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 5_000
+  end
+
+  test "tells every consumer on a shared subscription" do
+    topic = @topic <> "-shared"
+    consumer = start_consumer(topic, "shared-sub", consumer_count: 3, subscription_type: :shared)
+    workers = Topology.workers(consumer)
+    assert length(workers) == 3
+
+    drain()
+    :ok = System.terminate_topic(topic)
+
+    for worker <- workers, do: assert_receive({:consumer_end_of_topic, ^worker}, 10_000)
+  end
+
+  test "tells the passive consumer of a failover subscription too" do
+    topic = @topic <> "-failover"
+    consumer = start_consumer(topic, "failover-sub", consumer_count: 2, subscription_type: :failover)
+    workers = Topology.workers(consumer)
+    assert length(workers) == 2
+
+    drain()
+    :ok = System.terminate_topic(topic)
+
+    for worker <- workers, do: assert_receive({:consumer_end_of_topic, ^worker}, 10_000)
+  end
+
+  test "tells each partition's consumer separately" do
+    topic = @topic <> "-partitioned"
+    :ok = System.create_topic(topic, 3)
+    consumer = start_consumer(topic, "partitioned-sub", create_topic?: false)
+    workers = Topology.workers(consumer)
+    assert length(workers) == 3
+
+    drain()
+    :ok = System.terminate_topic(topic, partitioned?: true)
+
+    for worker <- workers, do: assert_receive({:consumer_end_of_topic, ^worker}, 10_000)
+  end
+
+  ## Helpers
+
+  defp start_consumer(topic, subscription, opts \\ []) do
+    {create_topic?, opts} = Keyword.pop(opts, :create_topic?, true)
+    {seed?, opts} = Keyword.pop(opts, :seed?, true)
+    if create_topic?, do: :ok = System.create_topic(topic)
+    if seed?, do: Utils.seed_topic(topic, @messages, client: @client)
+
+    {init_args, opts} = Keyword.pop(opts, :init_args, [])
+    opts = Keyword.merge([client: @client, initial_position: :earliest], opts)
+    opts = Keyword.put(opts, :init_args, [forward_to: self()] ++ init_args)
+
+    {:ok, consumer} = Pulsar.Consumer.start(topic, subscription, DummyConsumer, opts)
+    :ok = Pulsar.Consumer.await_ready(consumer, client: @client)
+
+    consumer
+  end
+
+  defp drain do
+    for payload <- @messages do
+      assert_receive {:consumer, _worker, %Pulsar.Message{payload: ^payload}}, 10_000
+    end
+  end
+end

--- a/test/support/dummy_consumer.ex
+++ b/test/support/dummy_consumer.ex
@@ -8,13 +8,15 @@ defmodule Pulsar.Test.Support.DummyConsumer do
     * `{:consumer, pid, message}` for every message, valid or not
     * `{:consumer_active, pid, active?}` when the broker makes it the active consumer of a
       `:failover` subscription, or takes that over
+    * `{:consumer_end_of_topic, pid}` when it has drained a terminated topic
 
   `pid` is the worker itself, which is what tells the consumers of one topic apart. A test
   asserts on deliveries with `assert_receive`, and on the absence of one with `refute_receive`,
   rather than asking the callback what it has collected.
 
   The only thing it decides for itself is what to answer with: `fail_all: true` rejects every
-  message, so redelivery and dead lettering have something to act on.
+  message, so redelivery and dead lettering have something to act on, and
+  `stop_at_end_of_topic: true` shuts the worker down once it reaches the end of one.
 
   A consumer started in `setup_all` cannot forward to the test that asserts on it, since that
   callback runs in its own process. Either start it in the test, or point it at the right one
@@ -26,7 +28,12 @@ defmodule Pulsar.Test.Support.DummyConsumer do
     forward_to = Keyword.get(opts, :forward_to)
     notify(forward_to, {:consumer_started, self(), context})
 
-    {:ok, %{forward_to: forward_to, fail_all: Keyword.get(opts, :fail_all, false)}}
+    {:ok,
+     %{
+       forward_to: forward_to,
+       fail_all: Keyword.get(opts, :fail_all, false),
+       stop_at_end_of_topic: Keyword.get(opts, :stop_at_end_of_topic, false)
+     }}
   end
 
   @doc """
@@ -65,6 +72,12 @@ defmodule Pulsar.Test.Support.DummyConsumer do
     notify(state.forward_to, {:consumer_active, self(), false})
 
     {:noreply, state}
+  end
+
+  def reached_end_of_topic(state) do
+    notify(state.forward_to, {:consumer_end_of_topic, self()})
+
+    if state.stop_at_end_of_topic, do: {:stop, :normal, state}, else: {:noreply, state}
   end
 
   def handle_call({:forward_to, pid}, _from, state) do

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -133,6 +133,19 @@ defmodule Pulsar.Test.Support.System do
     end
   end
 
+  # Closes the topic to new messages, so a consumer that drains it is told it has reached the end.
+  # A partitioned topic needs `partitioned?: true`, since the plain command is refused for it.
+  def terminate_topic(topic, opts \\ []) do
+    broker = broker()
+    subcommand = if Keyword.get(opts, :partitioned?, false), do: "partitioned-terminate", else: "terminate"
+    command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", subcommand, topic]
+
+    case docker_exec(command) do
+      {_output, 0} -> :ok
+      {output, code} -> raise "terminating #{topic} failed (exit #{code}): #{output}"
+    end
+  end
+
   def unload_topic(topic) do
     broker = broker()
     command = ["bin/pulsar-admin", "--admin-url", broker.admin_url, "topics", "unload", topic]

--- a/test/unit/broker_test.exs
+++ b/test/unit/broker_test.exs
@@ -242,6 +242,24 @@ defmodule Pulsar.BrokerTest do
     assert log =~ "No requester found for request 12345"
   end
 
+  describe "reaching the end of a terminated topic" do
+    test "hands the command to the consumer it names" do
+      broker = %Broker{consumers: %{7 => {self(), make_ref()}}}
+      command = %Proto.CommandReachedEndOfTopic{consumer_id: 7}
+
+      assert :keep_state_and_data = Broker.connected(:internal, {:command, command}, broker)
+      assert_receive {:broker_message, ^command}
+    end
+
+    test "drops it for a consumer that has already gone" do
+      broker = %Broker{consumers: %{}}
+      command = %Proto.CommandReachedEndOfTopic{consumer_id: 7}
+
+      assert :keep_state_and_data = Broker.connected(:internal, {:command, command}, broker)
+      refute_receive {:broker_message, _command}, 100
+    end
+  end
+
   describe "drop_ssl_opts/1" do
     test "strips TLS-only options before a plain TCP connect" do
       opts = [verify: :verify_peer, cacertfile: "/ca.pem", certfile: "/c.pem", keyfile: "/k.pem"]

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -33,6 +33,15 @@ defmodule Pulsar.Consumer.WorkerTest do
     end
   end
 
+  defmodule StoppingCallback do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def handle_message(_message, state), do: {:ok, state}
+
+    def reached_end_of_topic(state), do: {:stop, :normal, state}
+  end
+
   @topic "persistent://public/default/orders"
   @chunked "first second"
 
@@ -410,6 +419,21 @@ defmodule Pulsar.Consumer.WorkerTest do
 
       assert map_size(state.chunked_message_contexts) == 1
       refute_received {:telemetry, _measurements, _metadata}
+    end
+  end
+
+  describe "reaching the end of a terminated topic" do
+    test "keeps consuming by default" do
+      state = %{worker_state() | callback_state: :unchanged}
+
+      assert {:noreply, ^state} = Worker.handle_info({:broker_message, %Binary.CommandReachedEndOfTopic{}}, state)
+    end
+
+    test "lets the callback stop the worker" do
+      state = %{worker_state() | callback_module: StoppingCallback}
+
+      assert {:stop, :normal, ^state} =
+               Worker.handle_info({:broker_message, %Binary.CommandReachedEndOfTopic{}}, state)
     end
   end
 


### PR DESCRIPTION
Extracted from #152, which built this on abstractions 3.0 has since replaced. Nothing here needs Pulsar 5. What survived the port is the feature, not the crash fix that came with it: since #161 the broker never forwards the command, so the crash is not reachable on `main`.

The broker sends `CommandReachedEndOfTopic` once a consumer has read to the end of a terminated topic, meaning no further message will ever be published to it. Today that command has nowhere to go: it decodes, falls through `Pulsar.Broker`'s catch-all as `Unhandled command`, and nothing is told the topic is finished.

This adds `reached_end_of_topic/1`, an optional `Pulsar.Consumer.Callback` alongside `became_active/1` and `became_passive/1`, and routes the command to the worker it names.

## What a callback can do with it

The default keeps consuming, since a partitioned consumer reaches the end of one partition while the others still have messages to deliver. A callback with nothing left to read answers `{:stop, reason, state}` instead.

Every consumer on the subscription is told, not only whichever one read last: each process of a `:consumer_count`, the passive consumers of a failover subscription as well as the active one, and each partition separately. And a worker can be told more than once, since redelivered messages reach the end again and so does every reconnect. Code that shuts down on a drained topic therefore tracks which workers have reported rather than counting notifications.

Two limits are documented rather than papered over. The end of a topic is not the end of a subscription, so a terminated topic still redelivers what went unacknowledged. And stopping from the callback is not permanent: stopping the last worker of a group shuts the group down, and topology reconciliation revives it about a minute later; stopping some of a `:consumer_count` leaves the group short, since reconciliation only revives whole groups. That is #198, a design change in the topology layer rather than a patch to this PR; `Pulsar.Consumer.stop/2` is how to take a consumer down for good today.

## Tests

The integration tests terminate a real topic with `pulsar-admin` and check who hears about it: a lone consumer, all three of a shared subscription, both consumers of a failover one including the passive standby, and each partition of a partitioned topic. They also cover that the connection survives, by having a fresh subscription read the topic afterwards, and that a stopping callback takes its worker down with `:normal`.
