### PR TITLE
fix(broker): a close-on-exit ack was logged as an unknown request

### DIFF
--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -476,56 +476,15 @@ defmodule Pulsar.Broker do
 
   # Automatic cleanup when monitored processes exit
   def connected(:info, {:DOWN, monitor_ref, :process, pid, reason}, broker) do
-    # Find and remove the consumer/producer that died
-    {consumer_id, new_consumers} = remove_by_monitor_ref(broker.consumers, monitor_ref, pid)
-    {producer_id, new_producers} = remove_by_monitor_ref(broker.producers, monitor_ref, pid)
+    {consumer_id, new_consumers} = remove_by_monitor_ref(broker.consumers, monitor_ref)
+    {producer_id, new_producers} = remove_by_monitor_ref(broker.producers, monitor_ref)
 
-    broker_after_consumer =
-      if consumer_id do
-        Logger.info("Consumer #{consumer_id} exited: #{inspect(reason)}, sending CloseConsumer to server")
+    broker =
+      broker
+      |> close_after_exit(:consumer, consumer_id, pid, reason)
+      |> close_after_exit(:producer, producer_id, pid, reason)
 
-        close_consumer_command = %Binary.CommandCloseConsumer{
-          consumer_id: consumer_id,
-          request_id: System.unique_integer([:positive, :monotonic])
-        }
-
-        case send_command_internal(close_consumer_command, broker) do
-          {:ok, updated_broker} ->
-            updated_broker
-
-          {{:error, send_error}, updated_broker} ->
-            Logger.warning("Failed to send CloseConsumer for consumer #{consumer_id}: #{inspect(send_error)}")
-
-            updated_broker
-        end
-      else
-        broker
-      end
-
-    broker_after_producer =
-      if producer_id do
-        Logger.info("Producer #{producer_id} exited: #{inspect(reason)}, sending CloseProducer to server")
-
-        close_producer_command = %Binary.CommandCloseProducer{
-          producer_id: producer_id,
-          request_id: System.unique_integer([:positive, :monotonic])
-        }
-
-        case send_command_internal(close_producer_command, broker_after_consumer) do
-          {:ok, updated_broker} ->
-            updated_broker
-
-          {{:error, send_error}, updated_broker} ->
-            Logger.warning("Failed to send CloseProducer for producer #{producer_id}: #{inspect(send_error)}")
-
-            updated_broker
-        end
-      else
-        broker_after_consumer
-      end
-
-    new_broker = %{broker_after_producer | consumers: new_consumers, producers: new_producers}
-    {:keep_state, new_broker}
+    {:keep_state, %{broker | consumers: new_consumers, producers: new_producers}}
   end
 
   def connected(:info, message, _broker) do
@@ -1000,16 +959,44 @@ defmodule Pulsar.Broker do
     _ -> :ok
   end
 
-  # Helper to find and remove entries by monitor reference
-  defp remove_by_monitor_ref(map, target_monitor_ref, target_pid) do
-    Enum.reduce(map, {nil, map}, fn
-      {id, {pid, monitor_ref}}, {found_id, acc_map} ->
-        if monitor_ref == target_monitor_ref and pid == target_pid do
-          # Found the matching entry, remove it
-          {id, Map.delete(acc_map, id)}
-        else
-          {found_id, acc_map}
-        end
-    end)
+  # A registered consumer or producer that exits owes the server a close. A failed send is
+  # dropped rather than retried: the entry goes either way, so a reconnect never carries a stale one.
+  defp close_after_exit(broker, _kind, nil, _pid, _reason), do: broker
+
+  defp close_after_exit(broker, kind, id, pid, reason) do
+    label = kind |> Atom.to_string() |> String.capitalize()
+    request_id = System.unique_integer([:positive, :monotonic])
+    timestamp = System.monotonic_time(:millisecond)
+
+    # The reply is addressed to the process that just exited, so sending it is a no-op. Registering
+    # it anyway keeps one bookkeeping path: the ack clears the entry, or the sweeper times it out.
+    new_requests = Map.put(broker.requests, request_id, {{pid, make_ref()}, timestamp})
+    broker = %{broker | requests: new_requests}
+
+    Logger.info("#{label} #{id} exited: #{inspect(reason)}, sending Close#{label} to server")
+
+    case send_command_internal(close_command(kind, id, request_id), broker) do
+      {:ok, updated_broker} ->
+        updated_broker
+
+      {{:error, send_error}, updated_broker} ->
+        Logger.warning("Failed to send Close#{label} for #{kind} #{id}: #{inspect(send_error)}")
+        updated_broker
+    end
+  end
+
+  defp close_command(:consumer, consumer_id, request_id) do
+    %Binary.CommandCloseConsumer{consumer_id: consumer_id, request_id: request_id}
+  end
+
+  defp close_command(:producer, producer_id, request_id) do
+    %Binary.CommandCloseProducer{producer_id: producer_id, request_id: request_id}
+  end
+
+  defp remove_by_monitor_ref(map, monitor_ref) do
+    case Enum.find(map, fn {_id, {_pid, ref}} -> ref == monitor_ref end) do
+      nil -> {nil, map}
+      {id, _entry} -> {id, Map.delete(map, id)}
+    end
   end
 end

--- a/test/unit/broker_test.exs
+++ b/test/unit/broker_test.exs
@@ -1,6 +1,8 @@
 defmodule Pulsar.BrokerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Pulsar.Broker
   alias Pulsar.Protocol
   alias Pulsar.Protocol.Binary.Pulsar.Proto
@@ -67,6 +69,41 @@ defmodule Pulsar.BrokerTest do
   defp buffered({head, pending, _size}), do: :erlang.iolist_to_binary([head | pending])
   defp buffered(binary) when is_binary(binary), do: binary
 
+  defp down(broker, monitor_ref, pid \\ self()) do
+    Broker.connected(:info, {:DOWN, monitor_ref, :process, pid, :shutdown}, broker)
+  end
+
+  defp age_requests(broker, by) do
+    requests = Map.new(broker.requests, fn {id, {from, timestamp}} -> {id, {from, timestamp - by}} end)
+
+    %{broker | requests: requests}
+  end
+
+  defp dead_pid do
+    pid = spawn(fn -> :ok end)
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+
+    pid
+  end
+
+  defp socket_pair do
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, port} = :inet.port(listen)
+    {:ok, client} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+    {:ok, server} = :gen_tcp.accept(listen, 1_000)
+    :ok = :gen_tcp.close(listen)
+
+    {client, server}
+  end
+
+  defp read_command(server) do
+    {:ok, <<size::32>> = head} = :gen_tcp.recv(server, 4, 1_000)
+    {:ok, body} = :gen_tcp.recv(server, size, 1_000)
+
+    Protocol.decode(head <> body)
+  end
+
   test "ignores lifecycle events from stale sockets" do
     broker = %Broker{socket: :current_socket}
 
@@ -80,6 +117,129 @@ defmodule Pulsar.BrokerTest do
     for event <- events do
       assert :keep_state_and_data = Broker.connected(:info, event, broker)
     end
+  end
+
+  describe "a monitored process exiting" do
+    setup do
+      {client, server} = socket_pair()
+
+      %{broker: %Broker{socket_module: :gen_tcp, socket: client}, server: server}
+    end
+
+    test "closes the consumer it was registered as", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      broker = %{broker | consumers: %{7 => {self(), monitor_ref}}}
+
+      {result, log} = with_log(fn -> down(broker, monitor_ref) end)
+
+      assert {:keep_state, updated} = result
+      assert updated.consumers == %{}
+      assert {:ok, %Proto.CommandCloseConsumer{consumer_id: 7}} = read_command(server)
+      assert log =~ "Consumer 7 exited: :shutdown, sending CloseConsumer to server"
+    end
+
+    test "closes the producer it was registered as", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      broker = %{broker | producers: %{3 => {self(), monitor_ref}}}
+
+      {result, log} = with_log(fn -> down(broker, monitor_ref) end)
+
+      assert {:keep_state, updated} = result
+      assert updated.producers == %{}
+      assert {:ok, %Proto.CommandCloseProducer{producer_id: 3}} = read_command(server)
+      assert log =~ "Producer 3 exited: :shutdown, sending CloseProducer to server"
+    end
+
+    test "leaves the other registrations alone when a consumer exits", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      sibling = {spawn(fn -> :ok end), make_ref()}
+      producer = {spawn(fn -> :ok end), make_ref()}
+      broker = %{broker | consumers: %{7 => {self(), monitor_ref}, 8 => sibling}, producers: %{3 => producer}}
+
+      assert {:keep_state, updated} = down(broker, monitor_ref)
+      assert updated.consumers == %{8 => sibling}
+      assert updated.producers == %{3 => producer}
+      assert {:ok, %Proto.CommandCloseConsumer{consumer_id: 7}} = read_command(server)
+    end
+
+    test "leaves the other registrations alone when a producer exits", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      sibling = {spawn(fn -> :ok end), make_ref()}
+      consumer = {spawn(fn -> :ok end), make_ref()}
+      broker = %{broker | producers: %{3 => {self(), monitor_ref}, 4 => sibling}, consumers: %{7 => consumer}}
+
+      assert {:keep_state, updated} = down(broker, monitor_ref)
+      assert updated.producers == %{4 => sibling}
+      assert updated.consumers == %{7 => consumer}
+      assert {:ok, %Proto.CommandCloseProducer{producer_id: 3}} = read_command(server)
+    end
+
+    test "sends nothing for a process that was never registered", %{broker: broker, server: server} do
+      assert {:keep_state, updated} = down(broker, make_ref())
+      assert updated == broker
+
+      # TCP preserves order, so anything the broker had written would arrive ahead of this.
+      :ok = :gen_tcp.send(broker.socket, "sentinel")
+      assert {:ok, "sentinel"} = :gen_tcp.recv(server, 8, 1_000)
+    end
+
+    test "deregisters even when the close cannot be sent", %{broker: broker, server: server} do
+      :ok = :gen_tcp.close(server)
+      :ok = :gen_tcp.close(broker.socket)
+
+      monitor_ref = make_ref()
+      broker = %{broker | consumers: %{7 => {self(), monitor_ref}}}
+
+      {result, log} = with_log(fn -> down(broker, monitor_ref) end)
+
+      assert {:keep_state, updated} = result
+      assert updated.consumers == %{}
+      assert log =~ "Failed to send CloseConsumer for consumer 7"
+    end
+
+    test "registers the close so its reply is not reported as unmatched", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      broker = %{broker | consumers: %{7 => {self(), monitor_ref}}}
+
+      assert {:keep_state, updated} = down(broker, monitor_ref)
+      assert {:ok, %Proto.CommandCloseConsumer{request_id: request_id}} = read_command(server)
+      assert Map.has_key?(updated.requests, request_id)
+
+      success = %Proto.CommandSuccess{request_id: request_id}
+
+      {result, log} = with_log(fn -> Broker.connected(:internal, {:command, success}, updated) end)
+
+      assert {:keep_state, replied} = result
+      assert replied.requests == %{}
+      refute log =~ "No requester found"
+    end
+
+    test "lets the sweeper time out a close the server never acknowledged", %{broker: broker, server: server} do
+      monitor_ref = make_ref()
+      consumers = %{7 => {dead_pid(), monitor_ref}}
+      broker = %{broker | consumers: consumers, request_timeout: 1_000, cleanup_interval: 60_000}
+
+      assert {:keep_state, pending} = down(broker, monitor_ref, dead_pid())
+      assert {:ok, %Proto.CommandCloseConsumer{}} = read_command(server)
+      assert map_size(pending.requests) == 1
+
+      aged = age_requests(pending, 60_000)
+
+      assert {:keep_state, cleaned, _actions} =
+               Broker.connected({:timeout, :cleanup_stale_requests}, nil, aged)
+
+      assert cleaned.requests == %{}
+    end
+  end
+
+  test "warns about a reply nobody is waiting for" do
+    broker = %Broker{}
+    success = %Proto.CommandSuccess{request_id: 12_345}
+
+    {result, log} = with_log(fn -> Broker.connected(:internal, {:command, success}, broker) end)
+
+    assert {:keep_state, _broker} = result
+    assert log =~ "No requester found for request 12345"
   end
 
   describe "drop_ssl_opts/1" do


### PR DESCRIPTION
Extracted from #152, which cleaned this up on the way to routing a third kind of registered process. No Pulsar 5.

### The duplication

`Pulsar.Broker`'s `:DOWN` handler carried the consumer and producer cases as two nearly identical `if` expressions, each building a close command, sending it, and threading the broker through by hand (`broker` → `broker_after_consumer` → `broker_after_producer`) — the kind of chain that quietly goes wrong when a third case is added. One `close_after_exit/5` covers both.

Log output is unchanged: `Consumer 7 exited: :shutdown, sending CloseConsumer to server` still reads exactly as it did, and the tests now pin the strings.

### Quieter teardowns

The close command was minted with a `request_id` that was never registered, so the server's ack landed unmatched and every clean teardown drew `No requester found for request N` at warning level. It is now registered like any other request, with the exiting process as the reply target — replying to a dead pid is a no-op, so the ack clears the entry and the existing sweeper covers the case where none arrives.

Across the integration suite: 92 occurrences → 0, with no `Request N timed out` or `Cleaned up N stale requests` appearing in their place.

### Tests it never had

Over a real socket pair, so the frame the broker writes is read back and decoded:

- the exiting worker is closed on the server and deregistered, for consumers and producers, with the log line asserted
- other registrations on the same connection, including the other kind, are left alone
- a process that was never registered sends nothing
- a close that cannot be sent still deregisters, and says so
- the close registers a request that its ack clears, and the sweeper reclaims one that is never acked

### Held back from this PR

#152 also added a watcher registry here (`register_watcher/4` plus routing for the pushed scalable-topic commands). It has no caller until scalable topics land, so shipping it now would be untestable dead code. It belongs with that work.

`handle_command/2` still carries five copies of the same "look up the registry, send to the pid, else warn" block. Routing a third kind of process means a sixth copy, not a third `close_command/3` clause — worth collapsing before the watcher work, but a separate change.

`mix test` (424 unit, integration suite against Pulsar 4.2.4), `mix credo --strict`, and `mix dialyzer` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
