### PR TITLE
test(producer): wait for the deduplicated event instead of racing it

### DIFF
--- a/test/integration/producer/deduplication_test.exs
+++ b/test/integration/producer/deduplication_test.exs
@@ -106,8 +106,13 @@ defmodule Pulsar.Integration.Producer.DeduplicationTest do
       assert [ok: :deduplicated, ok: :deduplicated, ok: :deduplicated] =
                send_concurrently(producer, ["d", "e", "f"])
 
-      assert [%{count: 3}] =
-               Utils.collect_events([:pulsar, :producer, :message, :deduplicated], producer_names: [producer_name])
+      assert_receive {:telemetry_event,
+                      %{
+                        event: [:pulsar, :producer, :message, :deduplicated],
+                        measurements: %{count: 3},
+                        metadata: %{producer_name: ^producer_name}
+                      }},
+                     5_000
     end
   end
 


### PR DESCRIPTION
Fixes the intermittent `DeduplicationTest` failure that has been taking down `Test - producer` on unrelated PRs.

## What fails

```
1) test a topic with deduplication enabled a discarded batch answers every caller
   and reports the messages it carried
   test/integration/producer/deduplication_test.exs:95
   left:  [%{count: 3}]
   right: []
```

Three runs so far, all identical, all `right: []` — never a partial or split count. The `{:ok, :deduplicated}` assertions on the line above always pass, so the producer did discard the batch; only the telemetry event is missing.

## Why

`Utils.collect_events/2` drains the mailbox with `after 0`. It sees an event only if it has already been delivered.

That holds for every other producer event it is used with — `[:pulsar, :producer, :message, :published]` and `[:pulsar, :producer, :batch, :published]` are emitted at send time, before the caller is answered, so the worker's telemetry message reaches the test before the reply does.

`[:pulsar, :producer, :message, :deduplicated]` is the exception:

```elixir
defp report_deduplicated(receipt, state) do
  case resolve_send(state, receipt.sequence_id, {:ok, :deduplicated}) do   # replies to the callers
    {:ok, callers, new_state} ->
      report_discarded(receipt, length(callers), state)                    # logs, then emits
```

`resolve_send/3` → `answer/3` does `GenServer.reply/2` to all three callers first. So the Tasks return, `Task.await_many/2` hands control back to the test, and `collect_events/2` runs while the worker is still inside the `Logger.warning/1` that precedes the emit. Whoever wins decides the test. Under the producer suite's log volume on a loaded CI runner, the worker often loses.

## The fix

This test needs to *wait* for one event; `collect_events/2` is a *drain*. The waiting primitive already exists — `telemetry_test` delivers `{:telemetry_event, ...}` straight to the test pid, and twelve call sites across `topology_test.exs`, `resolver_test.exs`, `chunking_test.exs` and `dead_letter_policy_test.exs` already wait on it with `assert_receive`, pinned metadata included. So does this one now:

```elixir
assert_receive {:telemetry_event,
                %{
                  event: [:pulsar, :producer, :message, :deduplicated],
                  measurements: %{count: 3},
                  metadata: %{producer_name: ^producer_name}
                }},
               5_000
```

The explicit 5s is load-bearing: `assert_receive` defaults to 100ms, and the emit sits behind a `Logger.warning/1` under the producer suite's log volume — the very thing that makes this flake. The repro below fails at the default and passes at 5s.

`test/support/utils.ex` is untouched — the diff is six lines in one test file.

`collect_events/2` stays as it is, and the rest of its callers keep using it: they count or aggregate a population that has already settled behind a barrier (`assert_messages_received`, `wait_for`, a synchronous `Producer.stop`), which `assert_receive` expresses worse or not at all. The rule the failure teaches is just *wait for one event → `assert_receive`; count a settled population → `collect_events`*.

I left the production ordering alone. Emitting before answering would also close this window — and `expire_send/2` at `worker.ex:655` has the same emit-after-reply shape, so the class is still there for the next event someone tests — but that is a separate change to `Pulsar.Producer.Worker`, not a test fix.

## Verified

Reproduced by sleeping 200ms before the emit in `report_discarded/3`. On `main` that fails exactly as CI does (`right: []`). With `assert_receive` at its default timeout it fails as `no matching message after 100ms` — which is how the 5s came to be explicit rather than assumed. At 5s it passes with the sleep still in. Sleep removed afterwards; `lib/` is untouched on this branch.

The assertion is not vacuous — flipping the expected `count: 3` to `4` fails the test.

Against a local 4.2.4 cluster: deduplication test 4 passed, full producer suite 41 passed, unit suite 391 passed, `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
