### PR TITLE
fix(consumer): recover from a payload that cannot be decompressed

### DIFF
--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -262,7 +262,9 @@ The consumer emits telemetry events for chunk lifecycle:
 
 Each of these carries `uuid` alongside the `topic`, `base_topic`, `partition`,
 `subscription_name` and `consumer_id` that every consumer event carries, and the two that give
-up on a message also carry `reason`.
+up on a message also carry `reason`. `:complete` carries `validation_error`, `nil` unless the
+assembled message failed to decompress, in which case `total_size` counts the compressed bytes
+the callback is handed rather than a message that could be read.
 `received_chunks` against `num_chunks` says how much of the message had arrived before it was
 dropped, and `age_ms` on `:complete` is how long assembly took, which is what
 `:expire_incomplete_chunked_message_after` should be set against.

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -183,7 +183,7 @@ Flow control permits are only decremented when messages are assembled and delive
 The `Pulsar.Message.num_broker_messages/1` helper returns the correct permit count:
 
 ```elixir
-# Non-chunked message
+# Non-chunked message (a batch that failed validation reports the batch count instead)
 Pulsar.Message.num_broker_messages(message) # => 1
 
 # Complete chunked message with 3 chunks

--- a/docs/upgrading_to_3.0.md
+++ b/docs/upgrading_to_3.0.md
@@ -271,11 +271,20 @@ often for one of these reasons:
 
 - `:checksum_mismatch` — the frame failed its CRC32C check. 2.x did not verify checksums at all,
   so such a message was parsed as though it were intact.
+- `:decompression_failed` — the frame arrived intact and its metadata read, but the codec could
+  not turn the payload back into the message that was sent. 2.x raised here, taking the worker
+  down under every codec but `:zstd`, which handed the callback an error tuple in place of the
+  payload.
+- `:uncompressed_size_corruption` — the payload decoded, or the chunks reassembled, to a
+  different size than the producer recorded. 2.x did not check.
 
-The default implementation logs and acknowledges, so invalid messages are not redelivered forever;
-override it to record or divert them instead, and match `:validation_error` with a catch-all —
-malformed framing is reported under its own reasons. Each of them also counts against the
-`[:pulsar, :consumer, :message, :invalid]` telemetry event, whose `reason` is the same atom.
+Either of the last two keeps `metadata`, and `payload` holds the bytes as they arrived, still
+compressed. The default implementation logs and acknowledges, so invalid messages are not
+redelivered forever; override it to record or divert them instead, and match `:validation_error`
+with a catch-all — malformed framing is reported under its own reasons. Each of them also counts
+against the `[:pulsar, :consumer, :message, :invalid]` telemetry event, whose `reason` is the same
+atom, whose `decompression_reason` narrows the two above, and whose `detail` carries what the
+codec itself reported.
 
 A message that arrived intact but incomplete is not invalid: an expired or evicted chunked message
 still reaches `handle_message/2`. Check `Pulsar.Message.complete?/1` there before reading it.

--- a/docs/upgrading_to_3.0.md
+++ b/docs/upgrading_to_3.0.md
@@ -1,8 +1,8 @@
 # Upgrading to 3.0
 
 3.0 makes `Pulsar.Client`, `Pulsar.Consumer` and `Pulsar.Producer` the API, moves configuration
-out of `config :pulsar` and into the supervision tree, and fixes two things that were on the
-wire: partition key routing and chunk framing.
+out of `config :pulsar` and into the supervision tree, and changes partition key routing and
+compressed chunk framing.
 
 Most of it is caught by the compiler or at boot. Four changes are not, and they are the ones to
 read first:
@@ -12,8 +12,8 @@ read first:
 - [`init/1` became `init/2`](#callback-initialization), and a stale `init/1` is never called.
 - [Partition keys hash differently](#partition-key-routing), so a key moves to another
   partition of a partitioned topic.
-- [Chunked messages are framed differently](#chunking) when compression is on, and a
-  mixed-version deployment cannot read them.
+- [Compressed chunk framing changed](#chunking) to match other Pulsar SDKs; drain messages
+  produced by 2.x before upgrading when both chunking and compression are enabled.
 
 Bump the dependency:
 
@@ -266,10 +266,19 @@ matching on it.
 ### Invalid messages
 
 `:validation_error` and `c:Pulsar.Consumer.Callback.handle_invalid_message/2` are new. A message
-whose frame failed its CRC32C check is delivered there instead of `handle_message/2`, with
-`payload` holding unverified bytes. The default implementation logs a warning and acknowledges
-it, so it is not redelivered; override it to record or divert such messages. 2.x had no checksum
-verification, so this is new behaviour rather than a rename.
+whose bytes could not be turned into a payload goes there instead of `handle_message/2`, most
+often for one of these reasons:
+
+- `:checksum_mismatch` — the frame failed its CRC32C check. 2.x did not verify checksums at all,
+  so such a message was parsed as though it were intact.
+
+The default implementation logs and acknowledges, so invalid messages are not redelivered forever;
+override it to record or divert them instead, and match `:validation_error` with a catch-all —
+malformed framing is reported under its own reasons. Each of them also counts against the
+`[:pulsar, :consumer, :message, :invalid]` telemetry event, whose `reason` is the same atom.
+
+A message that arrived intact but incomplete is not invalid: an expired or evicted chunked message
+still reaches `handle_message/2`. Check `Pulsar.Message.complete?/1` there before reading it.
 
 ## Callback initialization
 
@@ -383,38 +392,17 @@ One related tightening: `:partition_key` must be a binary now, where 2.x accepte
 
 ## Chunking
 
-2.x compressed each chunk on its own. Every other Pulsar client compresses the whole message and
-then splits the compressed bytes, and 3.0 now does the same — which is what makes a chunked
-message readable by a Java consumer, and what makes 2.x and 3.0 unable to read each other's.
-
-The incompatibility is limited to producers with **both** `:chunking_enabled` and
-`:compression` set. Uncompressed chunked messages are framed the same way in both versions and
-cross freely.
-
-How it fails depends on the codec. Under `:lz4`, `:snappy` and `:zlib` the consumer assembles the
-chunks, hands them to the decompressor, and the decompressor rejects bytes that are not one
-compressed stream — which takes the worker down, and the unacknowledged message is redelivered
-into the same crash. Under `:zstd` it is quiet: decompression answers an error tuple instead of
-raising, and that tuple reaches your callback in place of `payload`. Compressed chunked messages
-already on a topic when you upgrade behave the same way.
-
-So if you use compression together with chunking, drain the topic before upgrading, and upgrade
-producers and consumers together.
-
-Two smaller changes come with it. A payload is now compressed *before* it is measured against
-`:max_message_size`, so a large payload that compresses under the limit is sent whole and never
-chunked at all. And the chunk size is capped so a chunk plus its metadata stays inside the
-broker's advertised frame limit, which makes chunks slightly smaller than `:max_message_size`;
-a producer whose `:properties` leave no room for a payload now gets `{:error, :metadata_too_large}`
-rather than a frame the broker rejects.
+Uncompressed chunked messages remain compatible across versions. If both
+`:chunking_enabled` and `:compression` are enabled, drain messages produced by 2.x before
+upgrading and move producers and consumers to 3.0 together; 3.0 does not read the old compressed
+chunk framing.
 
 Combining `:batch_enabled` with `:chunking_enabled` raises now. 2.x accepted both and batched,
 silently ignoring `:chunking_enabled`, so a payload over `:max_message_size` went into a batch
 entry whole rather than being split.
 
 Incomplete chunked messages reach the callback with `chunk_metadata.complete == false`, as
-before, but their payload is whatever chunks arrived — still compressed, since a partial message
-cannot be decompressed. Treat it as opaque.
+before. Check `Pulsar.Message.complete?/1` before reading an incomplete message.
 
 ## Removed options
 

--- a/lib/pulsar/broker.ex
+++ b/lib/pulsar/broker.ex
@@ -748,12 +748,6 @@ defmodule Pulsar.Broker do
       {consumer_pid, _monitor_ref} ->
         Logger.warning("Message for consumer #{consumer_id} failed validation: #{reason}")
 
-        :telemetry.execute(
-          [:pulsar, :consumer, :message, :invalid],
-          %{count: 1},
-          %{consumer_id: consumer_id, reason: reason}
-        )
-
         send(consumer_pid, {:broker_message, {:invalid, command, bytes, reason}})
         :keep_state_and_data
     end

--- a/lib/pulsar/consumer/chunked_message_context.ex
+++ b/lib/pulsar/consumer/chunked_message_context.ex
@@ -85,6 +85,8 @@ defmodule Pulsar.Consumer.ChunkedMessageContext do
       | chunks: Map.put(ctx.chunks, chunk_id, payload),
         chunk_message_ids: Map.put(ctx.chunk_message_ids, chunk_id, message_id),
         received_chunks: if(already_has_chunk, do: ctx.received_chunks, else: ctx.received_chunks + 1),
+        total_chunk_msg_size:
+          if(chunk_id == 0, do: Map.get(metadata, :total_chunk_msg_size, 0), else: ctx.total_chunk_msg_size),
         first_chunk_message_id: if(chunk_id == 0, do: message_id, else: ctx.first_chunk_message_id),
         last_chunk_message_id: message_id,
         commands: ctx.commands ++ [command],
@@ -182,5 +184,10 @@ defmodule Pulsar.Consumer.ChunkedMessageContext do
   @spec all_message_ids(t()) :: [term()]
   def all_message_ids(ctx) do
     Map.values(ctx.chunk_message_ids)
+  end
+
+  @doc false
+  def metadata(ctx, chunk_id) do
+    Enum.find(ctx.metadatas, &(&1.chunk_id == chunk_id))
   end
 end

--- a/lib/pulsar/consumer/chunked_message_context.ex
+++ b/lib/pulsar/consumer/chunked_message_context.ex
@@ -24,7 +24,7 @@ defmodule Pulsar.Consumer.ChunkedMessageContext do
           chunks: %{non_neg_integer() => binary()},
           chunk_message_ids: %{non_neg_integer() => term()},
           num_chunks_from_msg: non_neg_integer(),
-          total_chunk_msg_size: non_neg_integer(),
+          total_chunk_msg_size: non_neg_integer() | nil,
           received_chunks: non_neg_integer(),
           first_chunk_message_id: term(),
           last_chunk_message_id: term(),

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -17,7 +17,10 @@ defmodule Pulsar.Consumer.Worker do
 
   require Logger
 
-  @zstd_decompression_buffer_size 64 * 1024
+  # ezstd fills this buffer up to 1000 times per call, so it is what caps how large a zstd
+  # message can be. Sizing it to what the producer declared keeps one round the common case.
+  @zstd_min_buffer_size 64 * 1024
+  @zstd_max_buffer_size 1024 * 1024
 
   @terminal_errors [
     :AuthenticationError,
@@ -912,18 +915,12 @@ defmodule Pulsar.Consumer.Worker do
     NimbleLZ4.decompress(compressed_payload, metadata.uncompressed_size)
   end
 
-  defp uncompress(%Binary.MessageMetadata{compression: :ZSTD}, compressed_payload) do
-    case :ezstd.create_decompression_context(@zstd_decompression_buffer_size) do
-      context when is_reference(context) ->
-        payload = :ezstd.decompress_streaming(context, compressed_payload)
+  defp uncompress(%Binary.MessageMetadata{compression: :ZSTD} = metadata, compressed_payload) do
+    buffer_size = metadata.uncompressed_size |> max(@zstd_min_buffer_size) |> min(@zstd_max_buffer_size)
 
-        case payload do
-          payload when is_list(payload) -> {:ok, IO.iodata_to_binary(payload)}
-          {:error, _reason} = error -> error
-        end
-
-      {:error, _reason} = error ->
-        error
+    with context when is_reference(context) <- :ezstd.create_decompression_context(buffer_size),
+         payload when is_list(payload) <- :ezstd.decompress_streaming(context, compressed_payload) do
+      {:ok, IO.iodata_to_binary(payload)}
     end
   end
 
@@ -934,6 +931,12 @@ defmodule Pulsar.Consumer.Worker do
   # Protobuf preserves unknown enum values as integers.
   defp uncompress(%Binary.MessageMetadata{compression: compression}, _compressed_payload) do
     {:error, {:unsupported_compression, compression}}
+  end
+
+  # Chunk ids outside the range the producer announced can fill the context without chunk 0
+  # ever arriving, leaving nothing that describes the reassembled payload.
+  defp uncompress_assembled(nil, _payload, _total_chunk_msg_size, _ctx) do
+    {:error, :missing_first_chunk}
   end
 
   defp uncompress_assembled(metadata, payload, total_chunk_msg_size, ctx)
@@ -1084,6 +1087,9 @@ defmodule Pulsar.Consumer.Worker do
         {:total_chunk_msg_size_mismatch, _} ->
           {:uncompressed_size_corruption, :total_chunk_msg_size_mismatch}
 
+        :missing_first_chunk ->
+          {:uncompressed_size_corruption, :missing_first_chunk}
+
         {:unsupported_compression, _} ->
           {:decompression_failed, :unsupported_compression}
 
@@ -1099,8 +1105,7 @@ defmodule Pulsar.Consumer.Worker do
       %{count: 1},
       state
       |> consumer_metadata()
-      |> Map.put(:reason, validation_error)
-      |> Map.put(:decompression_reason, decompression_reason)
+      |> Map.merge(%{reason: validation_error, decompression_reason: decompression_reason, detail: reason})
     )
 
     validation_error
@@ -1112,8 +1117,7 @@ defmodule Pulsar.Consumer.Worker do
       %{count: 1},
       state
       |> consumer_metadata()
-      |> Map.put(:reason, reason)
-      |> Map.put(:decompression_reason, nil)
+      |> Map.merge(%{reason: reason, decompression_reason: nil, detail: nil})
     )
   end
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -17,6 +17,8 @@ defmodule Pulsar.Consumer.Worker do
 
   require Logger
 
+  @zstd_decompression_buffer_size 64 * 1024
+
   @terminal_errors [
     :AuthenticationError,
     :AuthorizationError,
@@ -366,6 +368,7 @@ defmodule Pulsar.Consumer.Worker do
     {messages, skipped_ids, new_state} =
       case message_data do
         {:invalid, command, bytes, validation_error} ->
+          report_invalid_message(state, validation_error)
           {[build_invalid_message(command, bytes, validation_error)], [], state}
 
         {command, metadata, payload, broker_metadata} ->
@@ -375,9 +378,7 @@ defmodule Pulsar.Consumer.Worker do
             {state_after, msgs} = maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
             {msgs, [], state_after}
           else
-            payload = maybe_uncompress(metadata, payload)
-            unwrapped = unwrap_messages(metadata, payload)
-            {msgs, skipped_ids} = build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+            {msgs, skipped_ids} = build_messages_from_entry(command, metadata, payload, broker_metadata, state)
             {msgs, skipped_ids, state}
           end
 
@@ -893,26 +894,91 @@ defmodule Pulsar.Consumer.Worker do
   defp max_redelivery(nil), do: nil
   defp max_redelivery(policy) when is_list(policy), do: Keyword.fetch!(policy, :max_redelivery)
 
-  defp maybe_uncompress(%Binary.MessageMetadata{compression: :NONE}, payload) do
-    payload
+  defp maybe_uncompress(%Binary.MessageMetadata{compression: :NONE}, payload), do: {:ok, payload}
+
+  defp maybe_uncompress(%Binary.MessageMetadata{} = metadata, compressed_payload) do
+    with {:ok, payload} <- uncompress(metadata, compressed_payload) do
+      verify_uncompressed_size(payload, metadata.uncompressed_size)
+    end
   end
 
-  defp maybe_uncompress(%Binary.MessageMetadata{compression: :ZLIB}, compressed_payload) do
-    :zlib.uncompress(compressed_payload)
+  defp uncompress(%Binary.MessageMetadata{compression: :ZLIB}, compressed_payload) do
+    {:ok, :zlib.uncompress(compressed_payload)}
+  rescue
+    error in ErlangError -> {:error, error.original}
   end
 
-  defp maybe_uncompress(%Binary.MessageMetadata{compression: :LZ4} = metadata, compressed_payload) do
-    {:ok, payload} = NimbleLZ4.decompress(compressed_payload, metadata.uncompressed_size)
-    payload
+  defp uncompress(%Binary.MessageMetadata{compression: :LZ4} = metadata, compressed_payload) do
+    NimbleLZ4.decompress(compressed_payload, metadata.uncompressed_size)
   end
 
-  defp maybe_uncompress(%Binary.MessageMetadata{compression: :ZSTD}, compressed_payload) do
-    :ezstd.decompress(compressed_payload)
+  defp uncompress(%Binary.MessageMetadata{compression: :ZSTD}, compressed_payload) do
+    case :ezstd.create_decompression_context(@zstd_decompression_buffer_size) do
+      context when is_reference(context) ->
+        payload = :ezstd.decompress_streaming(context, compressed_payload)
+
+        case payload do
+          payload when is_list(payload) -> {:ok, IO.iodata_to_binary(payload)}
+          {:error, _reason} = error -> error
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
-  defp maybe_uncompress(%Binary.MessageMetadata{compression: :SNAPPY}, compressed_payload) do
-    {:ok, payload} = :snappyer.decompress(compressed_payload)
-    payload
+  defp uncompress(%Binary.MessageMetadata{compression: :SNAPPY}, compressed_payload) do
+    :snappyer.decompress(compressed_payload)
+  end
+
+  # Protobuf preserves unknown enum values as integers.
+  defp uncompress(%Binary.MessageMetadata{compression: compression}, _compressed_payload) do
+    {:error, {:unsupported_compression, compression}}
+  end
+
+  defp uncompress_assembled(metadata, payload, total_chunk_msg_size, ctx)
+       when total_chunk_msg_size in [0, nil] or byte_size(payload) == total_chunk_msg_size do
+    if independently_compressed_chunks?(ctx) do
+      {:error, :unsupported_chunk_framing}
+    else
+      maybe_uncompress(metadata, payload)
+    end
+  end
+
+  defp uncompress_assembled(_metadata, payload, total_chunk_msg_size, _ctx) do
+    {:error, {:total_chunk_msg_size_mismatch, expected: total_chunk_msg_size, actual: byte_size(payload)}}
+  end
+
+  defp independently_compressed_chunks?(%ChunkedMessageContext{num_chunks_from_msg: num_chunks} = ctx)
+       when num_chunks > 1 do
+    case ChunkedMessageContext.metadata(ctx, 0) do
+      %Binary.MessageMetadata{compression: compression} when compression != :NONE ->
+        Enum.all?(0..(num_chunks - 1), &independently_compressed_chunk?(ctx, &1))
+
+      _ ->
+        false
+    end
+  end
+
+  defp independently_compressed_chunks?(_ctx), do: false
+
+  defp independently_compressed_chunk?(ctx, chunk_id) do
+    with %Binary.MessageMetadata{} = metadata <- ChunkedMessageContext.metadata(ctx, chunk_id),
+         payload when is_binary(payload) <- Map.get(ctx.chunks, chunk_id),
+         {:ok, _uncompressed} <- maybe_uncompress(metadata, payload) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  # A payload the codec accepted is only whole if it is the size the producer recorded
+  # before compressing.
+  defp verify_uncompressed_size(payload, 0), do: {:ok, payload}
+  defp verify_uncompressed_size(payload, size) when byte_size(payload) == size, do: {:ok, payload}
+
+  defp verify_uncompressed_size(payload, size) do
+    {:error, {:uncompressed_size_mismatch, expected: size, actual: byte_size(payload)}}
   end
 
   # A partly acknowledged entry is redelivered whole, carrying a set of what is still owed, and a
@@ -971,30 +1037,92 @@ defmodule Pulsar.Consumer.Worker do
   defp compacted_out?(%Binary.SingleMessageMetadata{compacted_out: true}), do: true
   defp compacted_out?(_single_metadata), do: false
 
-  # Pulsar's validation errors all describe damaged message contents, with nothing
-  # for a frame that was malformed around them, so every reason is reported as the
-  # nearest available. Pulsar.Message.validation_error carries the exact one.
-  defp validation_error(message) do
-    if Pulsar.Message.valid?(message), do: nil, else: :ChecksumMismatch
-  end
+  defp validation_error(%Pulsar.Message{validation_error: nil}), do: nil
+  defp validation_error(%Pulsar.Message{validation_error: :decompression_failed}), do: :DecompressionError
+  defp validation_error(%Pulsar.Message{validation_error: :uncompressed_size_corruption}), do: :UncompressedSizeCorruption
+  defp validation_error(%Pulsar.Message{}), do: :ChecksumMismatch
 
   # A chunk's uuid lives in the metadata that failed validation, so a corrupt chunk
   # cannot be tied back to its siblings; those expire as an incomplete message.
-  defp build_invalid_message(command, bytes, validation_error) do
+  defp build_invalid_message(command, bytes, validation_error, metadata \\ nil, broker_metadata \\ nil) do
     %Pulsar.Message{
       payload: bytes,
       message_id: command.message_id,
       chunk_metadata: nil,
       validation_error: validation_error,
-      raw: %{command: command, metadata: nil, single_metadata: nil, broker_metadata: nil}
+      raw: %{command: command, metadata: metadata, single_metadata: nil, broker_metadata: broker_metadata}
     }
   end
 
-  defp build_message_from_chunk(chunk_metadata, payload) do
+  defp build_messages_from_entry(command, metadata, payload, broker_metadata, state) do
+    case maybe_uncompress(metadata, payload) do
+      {:ok, uncompressed} ->
+        unwrapped = unwrap_messages(metadata, uncompressed)
+        build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+
+      {:error, reason} ->
+        validation_error = report_unreadable_payload(state, reason)
+
+        {[
+           build_invalid_message(
+             command,
+             payload,
+             validation_error,
+             metadata,
+             broker_metadata
+           )
+         ], []}
+    end
+  end
+
+  defp report_unreadable_payload(state, reason) do
+    {validation_error, decompression_reason} =
+      case reason do
+        {:uncompressed_size_mismatch, _} ->
+          {:uncompressed_size_corruption, :uncompressed_size_mismatch}
+
+        {:total_chunk_msg_size_mismatch, _} ->
+          {:uncompressed_size_corruption, :total_chunk_msg_size_mismatch}
+
+        {:unsupported_compression, _} ->
+          {:decompression_failed, :unsupported_compression}
+
+        :unsupported_chunk_framing ->
+          {:decompression_failed, :unsupported_chunk_framing}
+
+        _ ->
+          {:decompression_failed, :decompression_error}
+      end
+
+    :telemetry.execute(
+      [:pulsar, :consumer, :message, :invalid],
+      %{count: 1},
+      state
+      |> consumer_metadata()
+      |> Map.put(:reason, validation_error)
+      |> Map.put(:decompression_reason, decompression_reason)
+    )
+
+    validation_error
+  end
+
+  defp report_invalid_message(state, reason) do
+    :telemetry.execute(
+      [:pulsar, :consumer, :message, :invalid],
+      %{count: 1},
+      state
+      |> consumer_metadata()
+      |> Map.put(:reason, reason)
+      |> Map.put(:decompression_reason, nil)
+    )
+  end
+
+  defp build_message_from_chunk(chunk_metadata, payload, validation_error \\ nil) do
     %Pulsar.Message{
       payload: payload,
       message_id: Map.get(chunk_metadata, :message_ids, []),
       chunk_metadata: chunk_metadata,
+      validation_error: validation_error,
       raw: %{
         command: Map.get(chunk_metadata, :commands, []),
         metadata: Map.get(chunk_metadata, :metadatas, []),
@@ -1130,10 +1258,18 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp complete_chunked_message(state, uuid, ctx, num_chunks) do
-    # Every chunk repeats the metadata of the message it came from, so any of them says how
-    # the reassembled payload was compressed.
+    metadata = ChunkedMessageContext.metadata(ctx, 0)
     assembled_payload = ChunkedMessageContext.assemble_payload(ctx)
-    complete_payload = maybe_uncompress(hd(ctx.metadatas), assembled_payload)
+
+    {complete_payload, validation_error} =
+      case uncompress_assembled(metadata, assembled_payload, ctx.total_chunk_msg_size, ctx) do
+        {:ok, payload} ->
+          {payload, nil}
+
+        {:error, reason} ->
+          validation_error = report_unreadable_payload(state, reason)
+          {assembled_payload, validation_error}
+      end
 
     :telemetry.execute(
       [:pulsar, :consumer, :chunk, :complete],
@@ -1142,7 +1278,7 @@ defmodule Pulsar.Consumer.Worker do
         total_size: byte_size(complete_payload),
         age_ms: ChunkedMessageContext.age_ms(ctx)
       },
-      Map.put(consumer_metadata(state), :uuid, uuid)
+      Map.merge(consumer_metadata(state), %{uuid: uuid, validation_error: validation_error})
     )
 
     final_state = %{state | chunked_message_contexts: Map.delete(state.chunked_message_contexts, uuid)}
@@ -1158,7 +1294,7 @@ defmodule Pulsar.Consumer.Worker do
       broker_metadatas: ctx.broker_metadatas
     }
 
-    message = build_message_from_chunk(chunk_metadata, complete_payload)
+    message = build_message_from_chunk(chunk_metadata, complete_payload, validation_error)
     {final_state, [message]}
   end
 

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -304,19 +304,8 @@ defmodule Pulsar.Message do
   end
 
   # A payload that failed after its metadata was decoded keeps its batch count.
-  def num_broker_messages(%__MODULE__{
-        validation_error: :decompression_failed,
-        raw: %{metadata: %{num_messages_in_batch: count}}
-      })
-      when is_integer(count) and count > 0 do
-    count
-  end
-
-  def num_broker_messages(%__MODULE__{
-        validation_error: :uncompressed_size_corruption,
-        raw: %{metadata: %{num_messages_in_batch: count}}
-      })
-      when is_integer(count) and count > 0 do
+  def num_broker_messages(%__MODULE__{validation_error: error, raw: %{metadata: %{num_messages_in_batch: count}}})
+      when error in [:decompression_failed, :uncompressed_size_corruption] and is_integer(count) and count > 0 do
     count
   end
 

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -17,8 +17,9 @@ defmodule Pulsar.Message do
     For complete chunked messages: `%{chunked: true, complete: true, uuid: "...", num_chunks: N}`
     For incomplete chunked messages: `%{chunked: true, complete: false, error: :reason, uuid: "..."}`
 
-  - `validation_error` - `nil` for messages that arrived intact. Otherwise why the
-    frame could not be trusted, in which case `payload` holds unverified bytes. See `valid?/1`.
+  - `validation_error` - `nil` for messages that arrived intact. Otherwise why `payload` cannot
+    be treated as data: the frame could not be read, or it could and its payload did not
+    decompress. See `valid?/1`.
 
   - `raw` - The underlying protocol structs, as a map of `:command`, `:metadata`,
     `:single_metadata` and `:broker_metadata`. **Unstable**: its shape follows the wire
@@ -269,7 +270,8 @@ defmodule Pulsar.Message do
   @doc """
   Returns the number of broker messages (permits) consumed.
 
-  For non-chunked messages, this is always 1.
+  For ordinary non-chunked messages, this is 1. An invalid batched message still reports the
+  batch count when its payload failed validation after the metadata was decoded.
   For chunked messages, this is the number of chunks actually received.
 
   This is used for flow control permit accounting.
@@ -288,13 +290,37 @@ defmodule Pulsar.Message do
       iex> expired = %{chunked: true, complete: false, message_ids: [1, 2]}
       iex> Pulsar.Message.num_broker_messages(%Pulsar.Message{chunk_metadata: expired})
       2
+
+  A batch that could not be decompressed still knows how many messages it carried:
+
+      iex> raw = %{metadata: %{num_messages_in_batch: 5}}
+      iex> undecompressable = %Pulsar.Message{validation_error: :decompression_failed, raw: raw}
+      iex> Pulsar.Message.num_broker_messages(undecompressable)
+      5
   """
   @spec num_broker_messages(t()) :: pos_integer()
   def num_broker_messages(%__MODULE__{chunk_metadata: %{message_ids: ids}}) when is_list(ids) do
     length(ids)
   end
 
-  # An invalid frame's batch count was in the metadata that failed validation, and
+  # A payload that failed after its metadata was decoded keeps its batch count.
+  def num_broker_messages(%__MODULE__{
+        validation_error: :decompression_failed,
+        raw: %{metadata: %{num_messages_in_batch: count}}
+      })
+      when is_integer(count) and count > 0 do
+    count
+  end
+
+  def num_broker_messages(%__MODULE__{
+        validation_error: :uncompressed_size_corruption,
+        raw: %{metadata: %{num_messages_in_batch: count}}
+      })
+      when is_integer(count) and count > 0 do
+    count
+  end
+
+  # Any other invalid frame had its batch count in the metadata that failed validation, and
   # CommandMessage does not carry it, so 1 is the most that can be assumed. A
   # corrupt batch therefore under-counts what the broker charged for it: enough of
   # them and outstanding permits never reach the refill threshold, and the consumer
@@ -346,11 +372,22 @@ defmodule Pulsar.Message do
   @doc """
   Returns `true` if the message arrived intact, `false` if it did not.
 
-  An invalid message failed its CRC32C check or carried metadata that could not be
-  read, so its `metadata` is `nil` and its `payload` is unverified: the bytes the
-  framing points at, or the whole message section when even that does not hold. It
-  is delivered so the callback can record or divert it, but the payload must not be
-  treated as data. `validation_error` says what went wrong.
+  A message is invalid when its bytes could not be turned into a payload, and
+  `validation_error` says why:
+
+  - The frame itself could not be read: `:checksum_mismatch` when it failed its CRC32C check,
+    `:malformed_frame`, `:malformed_message_metadata` or `:malformed_broker_entry_metadata`
+    when its framing did not hold. Its `metadata` is `nil` and its `payload` is the bytes the
+    framing points at, or the whole message section when even that does not hold.
+  - `:decompression_failed` - the frame was intact and its metadata readable, but its payload
+    could not be turned back into the message that was sent. `metadata` is kept and `payload`
+    holds the bytes as they arrived, still compressed.
+  - `:uncompressed_size_corruption` - the decoded or reassembled payload did not match the
+    size advertised by the producer. `metadata` is kept and `payload` holds the bytes as they
+    arrived, still compressed when compression was enabled.
+
+  Any of them is delivered so the callback can record or divert it, but no such payload may be
+  treated as data. Match `validation_error` with a catch-all: more reasons may be added.
 
   Messages that fail validation are routed to `c:Pulsar.Consumer.Callback.handle_invalid_message/2`,
   so `handle_message/2` never receives one and rarely needs this check.

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -2,7 +2,12 @@ defmodule Pulsar.Consumer.WorkerTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  alias Pulsar.Consumer.Ack
   alias Pulsar.Consumer.Worker
+  alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
+
+  # An unreadable payload is reported at :warning, which every test here provokes on purpose.
+  @moduletag :capture_log
 
   defmodule Callback do
     @moduledoc false
@@ -14,7 +19,27 @@ defmodule Pulsar.Consumer.WorkerTest do
     def handle_message(_message, state), do: {:ok, state}
   end
 
+  defmodule Reporting do
+    @moduledoc false
+    use Pulsar.Consumer.Callback
+
+    def init(pid, _context), do: {:ok, pid}
+
+    def handle_message(message, pid) do
+      send(pid, {:handled, message})
+      {:ok, pid}
+    end
+
+    def handle_invalid_message(message, pid) do
+      send(pid, {:invalid, message})
+      {:ok, pid}
+    end
+  end
+
   @topic "persistent://public/default/orders"
+  @chunked "first second"
+
+  def forward(_event, measurements, metadata, pid), do: send(pid, {:telemetry, measurements, metadata})
 
   defp worker_state do
     struct(Worker,
@@ -25,6 +50,36 @@ defmodule Pulsar.Consumer.WorkerTest do
       subscription_type: :shared,
       consumer_name: "orders-order-service-partition-2-1",
       callback_module: Callback
+    )
+  end
+
+  # This path only casts to the broker, so the test process can stand in for one.
+  defp reporting_state do
+    struct(worker_state(),
+      callback_module: Reporting,
+      callback_state: self(),
+      consumer_id: 1,
+      broker_pid: self(),
+      acks: Ack.new(),
+      flow_policy: :auto,
+      flow_outstanding_permits: 100,
+      flow_threshold: 0,
+      flow_refill: 50
+    )
+  end
+
+  defp delivery(compression, payload, opts) do
+    metadata = struct(Binary.MessageMetadata, [producer_name: "orders-producer", compression: compression] ++ opts)
+    command = %Binary.CommandMessage{message_id: %Binary.MessageIdData{ledgerId: 1, entryId: 1}}
+
+    {:broker_message, {command, metadata, payload, nil}}
+  end
+
+  defp chunk_delivery(chunk_id, payload, opts) do
+    delivery(
+      :ZLIB,
+      payload,
+      [uuid: "orders-producer-1", chunk_id: chunk_id, num_chunks_from_msg: 2] ++ opts
     )
   end
 
@@ -54,5 +109,235 @@ defmodule Pulsar.Consumer.WorkerTest do
     test "stops without a state when the callback refuses to initialize" do
       assert {:stop, :init_refused, nil} = Worker.handle_continue({:init_callback, :refuse}, worker_state())
     end
+  end
+
+  test "reports protocol-invalid messages from the worker" do
+    handler = {__MODULE__, :protocol_invalid, self()}
+    event = [:pulsar, :consumer, :message, :invalid]
+    :ok = :telemetry.attach(handler, event, &__MODULE__.forward/4, self())
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    command = %Binary.CommandMessage{message_id: %Binary.MessageIdData{ledgerId: 1, entryId: 2}}
+    invalid_delivery = {:broker_message, {:invalid, command, <<"invalid">>, :checksum_mismatch}}
+
+    assert {:noreply, _state} = Worker.handle_info(invalid_delivery, reporting_state())
+
+    assert_received {:telemetry, %{count: 1}, metadata}
+    assert metadata.reason == :checksum_mismatch
+    assert metadata.decompression_reason == nil
+    assert metadata.topic == "persistent://public/default/orders-partition-2"
+
+    assert_received {:invalid, invalid}
+    assert invalid.validation_error == :checksum_mismatch
+  end
+
+  describe "a payload that cannot be decompressed" do
+    for compression <- [:ZLIB, :LZ4, :ZSTD, :SNAPPY] do
+      test "reaches handle_invalid_message/2 under #{compression}" do
+        delivery = delivery(unquote(compression), <<"not a compressed frame">>, uncompressed_size: 64)
+
+        assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+        assert_received {:invalid, invalid}
+        refute_received {:handled, _message}
+
+        assert invalid.validation_error == :decompression_failed
+      end
+    end
+
+    # CompressionType has no sixth value; this is the worker surviving one anyway.
+    test "reaches it under a codec this client does not know" do
+      delivery = delivery(9, <<"compressed by something else">>, uncompressed_size: 64)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:invalid, invalid}
+      assert invalid.validation_error == :decompression_failed
+    end
+
+    test "reaches it when the payload decompresses to the wrong size" do
+      delivery = delivery(:ZLIB, :zlib.compress(<<"first ">>) <> :zlib.compress(<<"second">>), uncompressed_size: 12)
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:invalid, invalid}
+      assert invalid.validation_error == :uncompressed_size_corruption
+    end
+
+    test "keeps the compressed bytes and the metadata it arrived with" do
+      delivery = delivery(:ZSTD, <<"garbage">>, uncompressed_size: 64)
+
+      Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:invalid, invalid}
+
+      assert invalid.payload == <<"garbage">>
+      assert Pulsar.Message.producer_name(invalid) == "orders-producer"
+    end
+
+    test "acknowledges it as the protocol's DecompressionError" do
+      delivery = delivery(:ZSTD, <<"garbage">>, uncompressed_size: 64)
+
+      Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
+      assert ack.validation_error == :DecompressionError
+    end
+
+    test "acknowledges an output-size mismatch as UncompressedSizeCorruption" do
+      delivery = delivery(:ZLIB, :zlib.compress(<<"first ">>) <> :zlib.compress(<<"second">>), uncompressed_size: 12)
+
+      Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
+      assert ack.validation_error == :UncompressedSizeCorruption
+    end
+
+    test "credits every message of an undecompressable batch to the flow window" do
+      delivery = delivery(:ZSTD, <<"garbage">>, uncompressed_size: 64, num_messages_in_batch: 5)
+
+      {:noreply, state} = Worker.handle_info(delivery, reporting_state())
+
+      assert state.flow_outstanding_permits == 95
+
+      assert_received {:invalid, invalid}
+      assert Pulsar.Message.num_broker_messages(invalid) == 5
+    end
+
+    test "reports the codec's reason in telemetry" do
+      handler = {__MODULE__, :size_mismatch, self()}
+      event = [:pulsar, :consumer, :message, :invalid]
+      :ok = :telemetry.attach(handler, event, &__MODULE__.forward/4, self())
+      on_exit(fn -> :telemetry.detach(handler) end)
+      delivery = delivery(:ZLIB, :zlib.compress(<<"first ">>) <> :zlib.compress(<<"second">>), uncompressed_size: 12)
+      Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:telemetry, %{count: 1}, metadata}
+      assert metadata.reason == :uncompressed_size_corruption
+      assert metadata.decompression_reason == :uncompressed_size_mismatch
+    end
+
+    test "reports decompression failures through the invalid-message event" do
+      handler = {__MODULE__, :invalid_message, self()}
+      event = [:pulsar, :consumer, :message, :invalid]
+      :ok = :telemetry.attach(handler, event, &__MODULE__.forward/4, self())
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      Worker.handle_info(delivery(:ZSTD, <<"garbage">>, uncompressed_size: 64), reporting_state())
+
+      assert_received {:telemetry, %{count: 1}, metadata}
+      assert metadata.reason == :decompression_failed
+      assert metadata.decompression_reason == :decompression_error
+      assert metadata.topic == "persistent://public/default/orders-partition-2"
+    end
+
+    test "decodes an empty zstd payload" do
+      delivery = delivery(:ZSTD, :ezstd.compress(<<>>), uncompressed_size: 0)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:handled, message}
+      assert message.payload == <<>>
+      assert Pulsar.Message.valid?(message)
+    end
+
+    test "a payload that does decompress is delivered as usual" do
+      delivery = delivery(:ZSTD, :ezstd.compress(<<"the real payload">>), uncompressed_size: 16)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:handled, message}
+      refute_received {:invalid, _message}
+
+      assert message.payload == "the real payload"
+      assert Pulsar.Message.valid?(message)
+    end
+  end
+
+  describe "chunks that were compressed one by one" do
+    # A pre-3.0 producer split the payload and then compressed each chunk, recording that
+    # chunk's own uncompressed size and the message's uncompressed total. zlib reads the
+    # reassembled streams as the first of them, which is the size the chunk recorded.
+    setup do
+      chunks =
+        for plain <- [<<"first ">>, <<"second">>] do
+          {:zlib.compress(plain), uncompressed_size: byte_size(plain), total_chunk_msg_size: byte_size(@chunked)}
+        end
+
+      {:ok, chunks: chunks, assembled: Enum.map_join(chunks, fn {payload, _opts} -> payload end)}
+    end
+
+    test "reach handle_invalid_message/2 assembled and still compressed", context do
+      {:noreply, _state} = deliver_chunks(context.chunks)
+
+      assert_received {:invalid, invalid}
+      refute_received {:handled, _message}
+
+      assert invalid.validation_error == :uncompressed_size_corruption
+      assert invalid.payload == context.assembled
+      assert Pulsar.Message.complete?(invalid)
+    end
+
+    test "credit one permit per chunk to the flow window", context do
+      {:noreply, state} = deliver_chunks(context.chunks)
+
+      assert state.flow_outstanding_permits == 98
+
+      assert_received {:invalid, invalid}
+      assert Pulsar.Message.num_broker_messages(invalid) == 2
+    end
+
+    test "are delivered as usual when the producer compressed the whole message" do
+      compressed = :zlib.compress(@chunked)
+      half = div(byte_size(compressed), 2)
+      <<first::binary-size(^half), second::binary>> = compressed
+
+      # 3.0 compresses before splitting, so every chunk repeats the whole message's
+      # uncompressed size and the compressed total.
+      opts = [uncompressed_size: byte_size(@chunked), total_chunk_msg_size: byte_size(compressed)]
+
+      {:noreply, _state} = deliver_chunks([{first, opts}, {second, opts}])
+
+      assert_received {:handled, message}
+      refute_received {:invalid, _message}
+
+      assert message.payload == @chunked
+    end
+
+    test "rejects independently compressed chunks even when their sizes collide" do
+      chunk = :binary.copy(<<"a">>, 11)
+      compressed = :zlib.compress(chunk)
+      opts = [uncompressed_size: byte_size(chunk), total_chunk_msg_size: byte_size(chunk) * 2]
+
+      {:noreply, _state} = deliver_chunks([{compressed, opts}, {compressed, opts}])
+
+      assert_received {:invalid, invalid}
+      refute_received {:handled, _message}
+      assert invalid.validation_error == :decompression_failed
+    end
+
+    test "uses chunk zero metadata when chunks arrive out of order" do
+      compressed = :zlib.compress(@chunked)
+      half = div(byte_size(compressed), 2)
+      <<first::binary-size(^half), second::binary>> = compressed
+      canonical = [uncompressed_size: byte_size(@chunked), total_chunk_msg_size: byte_size(compressed)]
+      inconsistent = [uncompressed_size: 1, total_chunk_msg_size: byte_size(compressed)]
+      state = struct(reporting_state(), max_pending_chunked_messages: 10)
+
+      {:noreply, state} = Worker.handle_info(chunk_delivery(1, second, inconsistent), state)
+      {:noreply, _state} = Worker.handle_info(chunk_delivery(0, first, canonical), state)
+
+      assert_received {:handled, message}
+      assert message.payload == @chunked
+    end
+  end
+
+  defp deliver_chunks(chunks) do
+    state = struct(reporting_state(), max_pending_chunked_messages: 10)
+
+    chunks
+    |> Enum.with_index()
+    |> Enum.reduce({:noreply, state}, fn {{payload, opts}, chunk_id}, {:noreply, acc} ->
+      Worker.handle_info(chunk_delivery(chunk_id, payload, opts), acc)
+    end)
   end
 end

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -6,7 +6,7 @@ defmodule Pulsar.Consumer.WorkerTest do
   alias Pulsar.Consumer.Worker
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
 
-  # An unreadable payload is reported at :warning, which every test here provokes on purpose.
+  # The default handle_invalid_message/2 logs at :warning.
   @moduletag :capture_log
 
   defmodule Callback do
@@ -230,6 +230,16 @@ defmodule Pulsar.Consumer.WorkerTest do
       assert metadata.topic == "persistent://public/default/orders-partition-2"
     end
 
+    test "decodes a zstd payload larger than one decompression round" do
+      payload = :binary.copy(<<"abcdefgh">>, 262_144)
+      delivery = delivery(:ZSTD, :ezstd.compress(payload), uncompressed_size: byte_size(payload))
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+
+      assert_received {:handled, message}
+      assert message.payload == payload
+    end
+
     test "decodes an empty zstd payload" do
       delivery = delivery(:ZSTD, :ezstd.compress(<<>>), uncompressed_size: 0)
 
@@ -329,6 +339,18 @@ defmodule Pulsar.Consumer.WorkerTest do
       assert_received {:handled, message}
       assert message.payload == @chunked
     end
+  end
+
+  test "a chunked message counted complete without its first chunk is invalid, not a crash" do
+    state = struct(reporting_state(), max_pending_chunked_messages: 10)
+
+    {:noreply, state} = Worker.handle_info(chunk_delivery(1, :zlib.compress(<<"second">>), []), state)
+    {:noreply, _state} = Worker.handle_info(chunk_delivery(2, :zlib.compress(<<"third">>), []), state)
+
+    assert_received {:invalid, invalid}
+    refute_received {:handled, _message}
+
+    assert invalid.validation_error == :uncompressed_size_corruption
   end
 
   defp deliver_chunks(chunks) do

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -15,6 +15,15 @@ defmodule Pulsar.MessageTest do
     assert Message.num_broker_messages(%Message{validation_error: :checksum_mismatch}) == 1
   end
 
+  test "num_broker_messages/1 preserves a decoded batch count for size corruption" do
+    message = %Message{
+      validation_error: :uncompressed_size_corruption,
+      raw: %{metadata: %{num_messages_in_batch: 3}}
+    }
+
+    assert Message.num_broker_messages(message) == 3
+  end
+
   # The point of the accessors: the same question has one answer whether the broker delivered
   # the message on its own, inside a batch, or split across chunks.
   describe "accessors across delivery shapes" do


### PR DESCRIPTION
## Summary

This PR makes compressed-payload failures recoverable at the consumer boundary. Codec errors and unsupported compression values no longer crash the consumer worker or cause a restart loop; unreadable payloads are delivered to `handle_invalid_message/2` and acknowledged according to their validation reason.

Fixes #203.

## Changes

- Handle zlib, zstd, LZ4, Snappy, and unknown-codec failures without crashing the consumer worker.
- Reject legacy 2.x independently-compressed chunk framing instead of silently delivering only the first compressed stream.
- Decode empty Zstandard frames correctly.
- Classify decoded-size and reassembled-size mismatches as `UncompressedSizeCorruption` rather than `DecompressionError`.
- Select chunk-zero metadata deterministically when chunks arrive out of order.
- Emit each recoverable message-invalid telemetry event once from the worker, with the worker's stable consumer metadata and decompression cause.
- Keep the broker responsible for decoding and routing invalid frames, without changing its consumer state representation.
- Preserve batch permit accounting for invalid messages whose metadata was decoded.
- Add regression coverage for these cases and keep the upgrade guide focused on actionable migration steps.

## Compatibility

3.0 changes compressed chunk framing to match other Pulsar SDKs. If both chunking and compression are enabled, drain messages produced by 2.x before upgrading and move producers and consumers to 3.0 together. Uncompressed chunked messages remain compatible across versions.

## Scope

Application-level bounded decompression is not addressed here. Decoded-size validation currently occurs after codec decompression, and the Zstandard streaming buffer is not an application-level output limit; compression-bomb protection should be handled separately.

DLQ semantics and incomplete-chunk callback routing are intentionally out of scope. Message-invalid telemetry is centralized in the worker; broker-level stream failures continue to use connection frame-error telemetry.

## Validation

- `mix test --exclude integration`: 413 passed, 127 excluded
- Client and consumer integration suites: 67 passed
- Focused broker/consumer worker tests: 29 passed
- `mix credo --strict`
- `mix dialyzer`
- `mix format --check-formatted`
- `git diff --check`

## Follow-ups

- [#205 — Protect consumers from unbounded decompression output](https://github.com/efcasado/pulsar-elixir/issues/205): add application-level output bounds and compression-bomb protection across supported codecs.
- [#206 — Make invalid-message callback and acknowledgment semantics consistent](https://github.com/efcasado/pulsar-elixir/issues/206): define consistent routing for valid, invalid, and incomplete chunked messages, including default acknowledgment and opt-in redelivery/DLQ behavior.
