### PR TITLE
fix(topology): leave a group that stopped intentionally stopped

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,10 +143,17 @@ batching domain per partition. Consumer groups may contain several workers, conf
 itself. This is why names, stop operations, client listings, and publishing target the logical
 resource instead of a particular worker.
 
-The stable root represents that logical resource even when none of its groups currently has
-a live worker. It remains registered and appears in client listings while operations report
-that no workers are available. This lets reconciliation recover the resource without changing
-the pid applications use to address it.
+The stable root represents that logical resource across worker restarts and broker
+reconnections. It remains registered and appears in client listings while operations report
+that no workers are available, so the pid applications use to address the resource does not
+change while its workers churn.
+
+Groups are significant children of the root, which sets `auto_shutdown: :all_significant`. A
+group whose workers have all stopped for good takes no further part, and once the last group
+is gone the root stops too rather than lingering with nothing consuming or producing. The root
+spec is `restart: :transient`, so a resource that stopped is not started over by the client's
+supervisor. `:all_significant` rather than `:any_significant` lets partitions of a terminated
+topic, which reach their end at their own pace, each finish draining.
 
 Producer publishing resolves the logical root, selects a partition group, and sends through
 that group's worker. Consumer workers receive broker messages and invoke the configured
@@ -181,11 +188,10 @@ periodically checks for newly added partitions and adds the missing groups witho
 the existing ones. Pulsar topics do not shrink, so a lower transient metadata result does not
 remove groups.
 
-Independently of those broker checks, Discovery periodically reconciles the topology shape it
-already knows. This local pass revives stopped groups for both partitioned and non-partitioned
-topics without making a metadata request. Setting `:partition_discovery_interval_ms` to
-`false` disables only later metadata checks; initial discovery and local group recovery remain
-enabled.
+A group that has stopped is never restarted from a reconciliation pass. Its workers stopped
+for a reason retrying cannot change, so reviving it would only walk it back into the same
+answer. Setting `:partition_discovery_interval_ms` to `false` disables later metadata checks;
+initial discovery still runs.
 
 `Pulsar.Reader` builds on this lifecycle. Each enumeration creates a temporary non-durable
 consumer below the selected client, waits internally for the expected workers to become
@@ -216,10 +222,10 @@ Recovery happens at the narrowest useful boundary:
 - An unexpected worker failure is restarted inside its group.
 - A broker connection loss restarts the workers that depended on it while the client remains
   available.
-- A terminal broker rejection, such as an incompatible schema, ends that worker's immediate
-  retry cycle. A group with no viable workers shuts down, but the stable root and Discovery
-  remain available. A later reconciliation pass can try the stopped group again without
-  immediately repeating the terminal failure.
+- A terminal broker rejection, such as an incompatible schema or an `:exclusive` subscription
+  already held, stops that worker rather than restarting it into the same answer. Its group
+  shuts down once its last worker has gone, and the resource once its last group has. Callers
+  then see `{:error, :not_found}` rather than a registered resource with nothing in it.
 - A consumer branch failure is isolated from the producer branch, and vice versa.
 - A client or branch restart recreates declared resources; runtime resources remain the
   responsibility of their caller.
@@ -237,10 +243,9 @@ the stateless <code>Pulsar.Topology.Resolver</code> performs broker metadata and
 These modules remain behind the Consumer and Producer facades.
 
 After a metadata lookup, Discovery reconciles the root and remembers the resulting partition
-count. A separate local schedule reconciles that known shape without contacting a broker. A
-pass first restarts stopped groups whose child specifications remain under the root, then adds
-missing partition groups from highest index to lowest. Existing groups are not replaced, and
-a lower metadata result never removes partitions.
+count. A pass adds missing partition groups from highest index to lowest. Existing groups are
+not replaced, groups that have stopped are left alone, and a lower metadata result never
+removes partitions.
 
 Starting higher indexes first lets producer routing treat growth as one transition. Routing
 uses the contiguous partition range beginning at zero, so a partial 4-to-6 expansion continues
@@ -257,14 +262,13 @@ Discovery and reconciliation logs report topology changes and failures. Their te
 use `[:pulsar, :topology, :discovery, ...]` and
 `[:pulsar, :topology, :reconciliation, ...]`; resolver spans use
 `[:pulsar, :topology, :resolver, ...]`. Metadata polling follows
-`:partition_discovery_interval_ms`, while local recovery remains enabled when polling is
-disabled.
+`:partition_discovery_interval_ms`.
 
 ## Design Invariants
 
 1. A consumer or producer cannot outlive the client context it depends on.
-2. Each logical consumer or producer has one registered stable root, even while it has no
-   live workers.
+2. Each logical consumer or producer has one registered stable root, which persists while its
+   workers restart and stops once every one of its groups has stopped for good.
 3. Partitions, groups, and worker pids stay behind the public facade.
 4. Starting establishes ownership, not readiness.
 5. Consumer and producer failures are isolated from each other.

--- a/lib/pulsar/backoff.ex
+++ b/lib/pulsar/backoff.ex
@@ -7,7 +7,7 @@ defmodule Pulsar.Backoff do
   # Maximum total wait in a bounded retry, the kind `run/3` drives.
   @retry_budget 3_000
 
-  @retryable_errors [:disconnected, :ServiceNotReady]
+  @retryable_errors [:disconnected, :no_broker_available, :ServiceNotReady]
 
   @spec next(non_neg_integer()) :: pos_integer()
   def next(0), do: :rand.uniform(100)
@@ -19,8 +19,13 @@ defmodule Pulsar.Backoff do
   @doc """
   Runs a broker operation using Pulsar's standard retry policy and budget.
 
-  Disconnected brokers and `ServiceNotReady` responses can recover without the caller
-  changing anything. Other errors are returned immediately.
+  A broker that is disconnected, not yet registered, or still reporting `ServiceNotReady`
+  can recover without the caller changing anything. Other errors are returned immediately.
+
+  Retrying here is also what paces a worker that cannot start. Returning at once would let
+  its group restart it in a tight loop and exhaust the restart budget, which reads as a
+  clean `:shutdown` and takes the whole resource down; a bounded retry spends the budget
+  slowly enough for the broker to come back.
   """
   @spec run((-> result)) :: result when result: term()
   def run(fun) when is_function(fun, 0), do: run(fun, &retryable?/1, @retry_budget)

--- a/lib/pulsar/consumer.ex
+++ b/lib/pulsar/consumer.ex
@@ -146,9 +146,9 @@ defmodule Pulsar.Consumer do
   A pid must be the stable root returned by `start/1` or `start_link/1`. Worker pids used for
   acknowledgement are not consumer roots and return `{:error, :not_found}` here.
 
-  A root started as a static child will be restarted by its supervisor; remove that child
-  from the supervision tree instead. A consumer declared on a client is not a static child:
-  stopping it removes it until the client restarts.
+  A root started as a static child is `:transient`, so stopping it leaves it stopped, but its
+  child spec stays in the supervision tree until that supervisor restarts. A consumer declared
+  on a client is not a static child: stopping it removes it until the client restarts.
   """
   @spec stop(pid() | String.t() | atom(), keyword()) :: :ok | {:error, :not_found}
   def stop(consumer, opts \\ [])

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -219,15 +219,10 @@ defmodule Pulsar.Consumer.Callback do
         {:stop, :normal, state}
       end
 
-  > #### Stopping here is not yet permanent {: .warning}
-  >
-  > A stopped worker is not restarted, but neither outcome of stopping one is what you want.
-  > Stop the last worker of a group and the group shuts down with it, and topology
-  > reconciliation revives it about a minute later: it subscribes again, reaches the end
-  > again, and stops again, on a loop. Stop only some of a `:consumer_count` and the group
-  > keeps running short of workers, since reconciliation only revives whole groups, never
-  > refills one. Use `Pulsar.Consumer.stop/2` from another process to take a consumer down
-  > for good.
+  Stopping is permanent. A stopped worker is not restarted, a group shuts down once its last
+  worker stops, and the consumer shuts down once its last group does, so a non-partitioned
+  consumer that stops here goes away entirely. Stopping only some of a `:consumer_count`
+  leaves the group running with fewer workers.
 
   ## Manual Acknowledgment
 

--- a/lib/pulsar/consumer/dead_letter.ex
+++ b/lib/pulsar/consumer/dead_letter.ex
@@ -48,7 +48,7 @@ defmodule Pulsar.Consumer.DeadLetter do
           %{
             id: {:dead_letter, topic},
             start: {Producer, :start_link_unregistered, [producer_opts]},
-            restart: :permanent,
+            restart: :transient,
             type: :supervisor
           }
         ]

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -38,7 +38,10 @@ defmodule Pulsar.Consumer.Options do
     consumer_count: [
       type: :pos_integer,
       default: 1,
-      doc: "Number of consumer processes to start for the topic, or for each partition."
+      doc: """
+      Number of consumer processes to start for the topic, or for each partition. Must be `1`
+      for an `:exclusive` subscription, which admits a single consumer.
+      """
     ],
     init_args: [
       type: :any,
@@ -228,7 +231,23 @@ defmodule Pulsar.Consumer.Options do
   Validates consumer options.
   """
   @spec validate!(keyword()) :: keyword()
-  def validate!(opts), do: opts |> NimbleOptions.validate!(@schema) |> validate_flow!()
+  def validate!(opts) do
+    opts
+    |> NimbleOptions.validate!(@schema)
+    |> validate_flow!()
+    |> validate_consumer_count!()
+  end
+
+  defp validate_consumer_count!(opts) do
+    if Keyword.fetch!(opts, :subscription_type) == :exclusive and Keyword.fetch!(opts, :consumer_count) > 1 do
+      raise ArgumentError,
+            "subscription_type: :exclusive admits a single consumer, so the ones past the first " <>
+              "are refused the subscription and stop on arrival. Set consumer_count: 1, or use " <>
+              "subscription_type: :failover to keep the rest standing by."
+    end
+
+    opts
+  end
 
   defp validate_flow!(opts) do
     if Keyword.fetch!(opts, :flow_policy) == :auto and Keyword.fetch!(opts, :flow_initial) == 0 do

--- a/lib/pulsar/consumer/options.ex
+++ b/lib/pulsar/consumer/options.ex
@@ -204,8 +204,7 @@ defmodule Pulsar.Consumer.Options do
       default: 60_000,
       doc: """
       For a partitioned topic, how often to look for partitions added since startup.
-      `false` disables later metadata checks, but not initial topic discovery or local
-      recovery of groups that have stopped.
+      `false` disables later metadata checks, but not initial topic discovery.
       """
     ],
     startup_delay_ms: [

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -551,8 +551,6 @@ defmodule Pulsar.Consumer.Worker do
   defp publish_to_dead_letter({:error, :no_dead_letter_producer}, _message, _origin_topic) do
     exit({:shutdown, :dead_letter_unavailable})
   end
-  
-  defp publish_to_dead_letter({:error, _reason} = error, _message, _origin_topic), do: error
 
   defp dead_letter_metadata(state, redelivery_count) do
     state

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -548,6 +548,10 @@ defmodule Pulsar.Consumer.Worker do
     DeadLetter.divert(producer, message, origin_topic)
   end
 
+  defp publish_to_dead_letter({:error, :no_dead_letter_producer}, _message, _origin_topic) do
+    exit({:shutdown, :dead_letter_unavailable})
+  end
+  
   defp publish_to_dead_letter({:error, _reason} = error, _message, _origin_topic), do: error
 
   defp dead_letter_metadata(state, redelivery_count) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -221,8 +221,8 @@ defmodule Pulsar.Consumer.Worker do
 
       # Errors a second attempt cannot change: bad credentials stay bad, a malformed topic
       # stays malformed, and an :exclusive subscription already taken stays taken. Stopping
-      # with :shutdown leaves the worker down instead of restarting it into the same answer,
-      # and the group follows once its last worker has gone.
+      # with :shutdown leaves the worker down instead of restarting it into the same answer;
+      # the group follows once its last worker has gone, and the topology once its last group.
       {:error, {code, _message} = reason} when code in @terminal_errors ->
         {:stop, {:shutdown, reason}, state}
 

--- a/lib/pulsar/producer.ex
+++ b/lib/pulsar/producer.ex
@@ -256,8 +256,8 @@ defmodule Pulsar.Producer do
   A pid must be the stable root returned by `start/1` or `start_link/1`. Group and worker pids
   are not producer roots and return `{:error, :not_found}` here.
 
-  A root started as a static child will be restarted by its supervisor; remove that child
-  from the supervision tree instead.
+  A root started as a static child is `:transient`, so stopping it leaves it stopped, but its
+  child spec stays in the supervision tree until that supervisor restarts.
   """
   @spec stop(pid() | String.t() | atom(), keyword()) :: :ok | {:error, :not_found}
   def stop(producer, opts \\ [])

--- a/lib/pulsar/producer/options.ex
+++ b/lib/pulsar/producer/options.ex
@@ -134,8 +134,7 @@ defmodule Pulsar.Producer.Options do
       default: 60_000,
       doc: """
       For a partitioned topic, how often to look for partitions added since startup.
-      `false` disables later metadata checks, but not initial topic discovery or local
-      recovery of groups that have stopped.
+      `false` disables later metadata checks, but not initial topic discovery.
       """
     ],
     startup_delay_ms: [

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -38,7 +38,8 @@ defmodule Pulsar.Topology do
     %{
       id: {module, id},
       start: {module, :start_link, [opts]},
-      restart: :permanent,
+      # A root shuts itself down once its last group has gone; :permanent would start it over.
+      restart: :transient,
       type: :supervisor
     }
   end
@@ -413,7 +414,12 @@ defmodule Pulsar.Topology do
     # resolve their own brokers asynchronously, so none of them delays this root coming up.
     children = companions ++ [discovery]
 
-    Supervisor.init(children, [strategy: :one_for_one] ++ restart_intensity())
+    # :all_significant and not :any_significant: partitions of a terminated topic reach their end
+    # at their own pace, and the ones still draining have to be allowed to finish.
+    Supervisor.init(
+      children,
+      [strategy: :one_for_one, auto_shutdown: :all_significant] ++ restart_intensity()
+    )
   end
 
   # Popped rather than read: `:companions` configures this root and is not part of what a worker
@@ -444,24 +450,17 @@ defmodule Pulsar.Topology do
 
   @doc false
   @spec reconcile(pid(), non_neg_integer(), map()) ::
-          {:ok,
-           %{
-             partition_count: non_neg_integer(),
-             added_groups: [non_neg_integer()],
-             revived_groups: [non_neg_integer()]
-           }}
+          {:ok, %{partition_count: non_neg_integer(), added_groups: [non_neg_integer()]}}
           | {:error, term()}
   def reconcile(root, desired, config) when is_integer(desired) and desired >= 0 do
     children = Supervisor.which_children(root)
 
-    with {:ok, revived_groups} <- restart_stopped_groups(root, children),
-         {:ok, partition_count, added_groups} <- reconcile_children(root, children, desired, config) do
-      {:ok,
-       %{
-         partition_count: partition_count,
-         added_groups: added_groups,
-         revived_groups: revived_groups
-       }}
+    case reconcile_children(root, children, desired, config) do
+      {:ok, partition_count, added_groups} ->
+        {:ok, %{partition_count: partition_count, added_groups: added_groups}}
+
+      {:error, _reason} = error ->
+        error
     end
   catch
     :exit, reason -> {:error, reason}
@@ -477,31 +476,6 @@ defmodule Pulsar.Topology do
       end)
 
     reconcile_shape(topology_shape(topic?, partitions), root, desired, config)
-  end
-
-  defp restart_stopped_groups(root, children) do
-    children
-    |> Enum.reduce_while({:ok, []}, fn
-      {{:topic, :non_partitioned} = id, :undefined, :supervisor, _modules}, {:ok, revived} ->
-        restart_stopped_group(root, id, 0, revived)
-
-      {{:partition, index} = id, :undefined, :supervisor, _modules}, {:ok, revived} ->
-        restart_stopped_group(root, id, index, revived)
-
-      _child, {:ok, revived} ->
-        {:cont, {:ok, revived}}
-    end)
-    |> then(fn
-      {:ok, revived} -> {:ok, Enum.sort(revived)}
-      {:error, _reason} = error -> error
-    end)
-  end
-
-  defp restart_stopped_group(root, id, index, revived) do
-    case restart_group(root, id) do
-      :ok -> {:cont, {:ok, [index | revived]}}
-      {:error, reason} -> {:halt, {:error, {:group_restart_failed, id, reason}}}
-    end
   end
 
   defp topology_shape(true, partitions) do
@@ -561,16 +535,6 @@ defmodule Pulsar.Topology do
       {:ok, _pid} -> :ok
       {:ok, _pid, _info} -> :ok
       {:error, {:already_started, _pid}} -> :ok
-      {:error, :already_present} -> restart_group(root, Map.fetch!(child_spec, :id))
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp restart_group(root, id) do
-    case Supervisor.restart_child(root, id) do
-      {:ok, _pid} -> :ok
-      {:ok, _pid, _info} -> :ok
-      {:error, state} when state in [:running, :restarting] -> :ok
       {:error, reason} -> {:error, reason}
     end
   end
@@ -606,6 +570,7 @@ defmodule Pulsar.Topology do
       id: id,
       start: {Group, :start_link, [worker, worker_count, opts]},
       restart: :transient,
+      significant: true,
       type: :supervisor
     }
   end

--- a/lib/pulsar/topology.ex
+++ b/lib/pulsar/topology.ex
@@ -18,7 +18,7 @@ defmodule Pulsar.Topology do
   # A broker losing its connection exits every worker registered with it at once, so a group of
   # N workers sees N restarts in the same instant. Correlated failures can likewise reach several
   # partition groups or topology roots. OTP's default of 3 in 5 seconds would treat that fan-out
-  # as a crash loop, degrading groups until reconciliation, replacing stable root pids, or
+  # as a crash loop, shutting groups down for good, replacing stable root pids, or
   # rebuilding a resource branch. This budget absorbs several full reconnects; bounded worker
   # retries handle fast loops, and the supervisors above the resource branches retain OTP's
   # default as the final escalation boundary.

--- a/lib/pulsar/topology/discovery.ex
+++ b/lib/pulsar/topology/discovery.ex
@@ -13,10 +13,6 @@ defmodule Pulsar.Topology.Discovery do
 
   require Logger
 
-  # A terminal worker response should leave enough time for broker-side state to change before
-  # its group is tried again. This local pass is deliberately independent of metadata polling.
-  @reconciliation_interval_ms 60_000
-
   @spec start_link({pid(), map(), keyword()}) :: GenServer.on_start()
   def start_link(args), do: GenServer.start_link(__MODULE__, args)
 
@@ -30,12 +26,10 @@ defmodule Pulsar.Topology.Discovery do
       topic: Keyword.fetch!(opts, :topic),
       client: Keyword.fetch!(opts, :client),
       discovery_interval: Keyword.fetch!(opts, :partition_discovery_interval_ms),
-      reconciliation_interval: Keyword.get(controller_opts, :reconciliation_interval_ms, @reconciliation_interval_ms),
       resolver: Keyword.get(controller_opts, :resolver, &Resolver.partition_count/2),
       status: :initializing,
       desired: nil,
-      discovery_backoff: 0,
-      reconciliation_backoff: 0
+      discovery_backoff: 0
     }
 
     {:ok, state, {:continue, :discover}}
@@ -50,8 +44,6 @@ defmodule Pulsar.Topology.Discovery do
   @impl true
   def handle_info(:discover, state), do: discover(state)
 
-  def handle_info(:reconcile, state), do: reconcile_known(state)
-
   defp discover(state) do
     Logger.debug("Discovering topology metadata for #{state.topic}")
 
@@ -59,7 +51,7 @@ defmodule Pulsar.Topology.Discovery do
       {:ok, desired} ->
         Logger.debug("Topology metadata for #{state.topic} reports #{desired} partitions")
 
-        case reconcile(state, desired, :discovery) do
+        case reconcile(state, desired) do
           {:ok, outcome} -> ready(state, outcome)
           {:error, reason} -> retry_discovery(state, :reconciliation, reason)
         end
@@ -100,40 +92,14 @@ defmodule Pulsar.Topology.Discovery do
     kind, reason -> {:error, {:resolver_failed, kind, reason}}
   end
 
-  defp reconcile_known(%{desired: nil} = state), do: {:noreply, state}
+  defp reconcile(state, desired) do
+    Logger.debug("Reconciling topology for #{state.topic}: desired_partitions=#{desired}")
 
-  defp reconcile_known(state) do
-    case reconcile(state, state.desired, :local) do
-      {:ok, outcome} ->
-        state = %{
-          state
-          | desired: outcome.partition_count,
-            status: status(outcome.partition_count),
-            reconciliation_backoff: 0
-        }
-
-        {:noreply, schedule_reconciliation(state)}
-
-      {:error, reason} ->
-        wait = Backoff.next(state.reconciliation_backoff)
-
-        Logger.warning("Topology reconciliation for #{state.topic} failed: #{inspect(reason)}; retrying in #{wait}ms")
-
-        Process.send_after(self(), :reconcile, wait)
-        {:noreply, %{state | reconciliation_backoff: wait}}
-    end
-  end
-
-  defp reconcile(state, desired, source) do
-    Logger.debug("Reconciling topology for #{state.topic}: source=#{source}, desired_partitions=#{desired}")
-
-    case span(:reconciliation, state, %{source: source, desired_partition_count: desired}, fn ->
+    case span(:reconciliation, state, %{desired_partition_count: desired}, fn ->
            reconcile_topology(state, desired)
          end) do
       {:ok, outcome} = result ->
-        summary =
-          "partitions=#{outcome.partition_count}, added_groups=#{inspect(outcome.added_groups)}, " <>
-            "revived_groups=#{inspect(outcome.revived_groups)}"
+        summary = "partitions=#{outcome.partition_count}, added_groups=#{inspect(outcome.added_groups)}"
 
         cond do
           state.status == :initializing ->
@@ -141,9 +107,6 @@ defmodule Pulsar.Topology.Discovery do
 
           outcome.added_groups != [] ->
             Logger.info("Topology reconciliation for #{state.topic} changed topology: #{summary}")
-
-          outcome.revived_groups != [] ->
-            Logger.debug("Topology reconciliation for #{state.topic} restarted groups: #{summary}")
 
           true ->
             Logger.debug("Topology reconciliation for #{state.topic} completed: #{summary}")
@@ -167,8 +130,6 @@ defmodule Pulsar.Topology.Discovery do
   end
 
   defp ready(state, outcome) do
-    initial? = is_nil(state.desired)
-
     state = %{
       state
       | status: status(outcome.partition_count),
@@ -176,10 +137,7 @@ defmodule Pulsar.Topology.Discovery do
         discovery_backoff: 0
     }
 
-    state = schedule_discovery(state)
-    state = if initial?, do: schedule_reconciliation(state), else: state
-
-    {:noreply, state}
+    {:noreply, schedule_discovery(state)}
   end
 
   defp schedule_discovery(%{desired: 0} = state), do: state
@@ -187,11 +145,6 @@ defmodule Pulsar.Topology.Discovery do
 
   defp schedule_discovery(state) do
     Process.send_after(self(), :discover, state.discovery_interval)
-    state
-  end
-
-  defp schedule_reconciliation(state) do
-    Process.send_after(self(), :reconcile, state.reconciliation_interval)
     state
   end
 

--- a/lib/pulsar/topology/discovery.ex
+++ b/lib/pulsar/topology/discovery.ex
@@ -1,9 +1,9 @@
 defmodule Pulsar.Topology.Discovery do
   @moduledoc false
 
-  # Initializes a topology from broker metadata, polls for partition growth when enabled,
-  # and reconciles known groups locally. Resolution and retry happen in this process so the
-  # stable Pulsar.Topology root can start even while no broker is available.
+  # Initializes a topology from broker metadata and polls for partition growth when enabled.
+  # Resolution and retry happen in this process so the stable Pulsar.Topology root can start
+  # even while no broker is available.
 
   use GenServer
 

--- a/test/integration/consumer/dead_letter_policy_test.exs
+++ b/test/integration/consumer/dead_letter_policy_test.exs
@@ -1,6 +1,7 @@
 defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
   use Pulsar.Test.Case, async: true
 
+  alias Pulsar.Consumer.DeadLetter
   alias Pulsar.Protocol.Binary.Pulsar.Proto
   alias Pulsar.Test.Support.DummyConsumer
 
@@ -277,50 +278,48 @@ defmodule Pulsar.Integration.Consumer.DeadLetterPolicyTest do
                    5_000
   end
 
-  @tag telemetry_listen: [[:pulsar, :consumer, :dead_letter, :failed]]
-  test "reports a dead letter topic it cannot publish to" do
-    topic = "#{@topic}-telemetry-failed"
-    subscription = "telemetry-failed"
-    dead_letter_topic = "#{topic}-#{subscription}-DLQ"
+  test "stops the consumer, leaving the message unacknowledged, once the dead letter producer has gone" do
+    topic = "persistent://public/default/dlq-producer-gone-topic"
+    subscription = "dlq-producer-gone"
+    payload = "outlives-the-consumer"
 
-    {:ok, group} =
+    {:ok, consumer_group} =
       Pulsar.Consumer.start(topic, subscription, DummyConsumer,
-        init_args: [fail_all: true, forward_to: self()],
         client: @client,
-        initial_position: :earliest,
         redelivery_interval: 100,
-        dead_letter_policy: [max_redelivery: 1]
+        dead_letter_policy: [max_redelivery: 1],
+        init_args: [fail_all: true, forward_to: self()]
       )
 
-    :ok = Pulsar.Consumer.await_ready(group)
-    [consumer] = Topology.workers(group)
+    :ok = Pulsar.Consumer.await_ready(consumer_group)
+    [consumer] = Topology.workers(consumer_group)
 
-    # A root with no dead letter child, so the producer cannot be resolved and diverting fails
-    # the way it does against a dead letter topic that is unavailable. Pointing the worker at
-    # nil instead would stop it diverting at all, which is a different path.
-    {:ok, empty_root} = Supervisor.start_link([], strategy: :one_for_one)
-    :sys.replace_state(consumer, &%{&1 | dead_letter_root: empty_root})
+    {:ok, dead_letter_root} = DeadLetter.producer(consumer_group)
+    dead_letter_ref = Process.monitor(dead_letter_root)
 
-    command = %Proto.CommandMessage{
-      consumer_id: 1,
-      message_id: %Proto.MessageIdData{ledgerId: 1, entryId: 1},
-      redelivery_count: 5
-    }
+    :ok = Supervisor.stop(dead_letter_root)
+    assert_receive {:DOWN, ^dead_letter_ref, :process, ^dead_letter_root, :normal}
 
-    send(consumer, {:broker_message, {:invalid, command, "corrupt", :checksum_mismatch}})
+    assert DeadLetter.producer(consumer_group) == {:error, :no_dead_letter_producer}
 
-    assert_receive {:telemetry_event,
-                    %{
-                      event: [:pulsar, :consumer, :dead_letter, :failed],
-                      measurements: %{count: 1},
-                      # Named even though the producer could not be resolved, which is when
-                      # an alert on this event most needs to say which topic is affected.
-                      metadata: %{
-                        topic: ^topic,
-                        dead_letter_topic: ^dead_letter_topic,
-                        reason: :no_dead_letter_producer
-                      }
-                    }},
-                   5_000
+    consumer_ref = Process.monitor(consumer)
+    group_ref = Process.monitor(consumer_group)
+
+    Utils.seed_topic(topic, [payload], client: @client)
+
+    assert_receive {:DOWN, ^consumer_ref, :process, ^consumer, {:shutdown, :dead_letter_unavailable}}, 15_000
+
+    assert_receive {:DOWN, ^group_ref, :process, ^consumer_group, :shutdown}, 15_000
+
+    {:ok, replacement} =
+      Pulsar.Consumer.start(topic, subscription, DummyConsumer,
+        client: @client,
+        init_args: [forward_to: self()]
+      )
+
+    :ok = Pulsar.Consumer.await_ready(replacement)
+    [worker] = Topology.workers(replacement)
+
+    assert_receive {:consumer, ^worker, %Pulsar.Message{payload: ^payload}}, 15_000
   end
 end

--- a/test/integration/consumer/end_of_topic_test.exs
+++ b/test/integration/consumer/end_of_topic_test.exs
@@ -47,6 +47,48 @@ defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
     assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 5_000
   end
 
+  # Regression for #198.
+  test "leaves a consumer that stopped at the end of the topic stopped" do
+    topic = @topic <> "-stays-stopped"
+    consumer = start_consumer(topic, "stays-stopped-sub", init_args: [stop_at_end_of_topic: true])
+    [worker] = Topology.workers(consumer)
+
+    drain()
+
+    ref = Process.monitor(consumer)
+    :ok = System.terminate_topic(topic)
+
+    assert_receive {:consumer_end_of_topic, ^worker}, 10_000
+
+    assert_receive {:DOWN, ^ref, :process, ^consumer, :shutdown}, 10_000
+
+    refute_receive {:consumer_end_of_topic, _worker}, 5_000
+    refute consumer in Pulsar.Client.consumers(@client)
+  end
+
+  test "keeps draining the other partitions when one of them stops at its end" do
+    topic = @topic <> "-partitioned-stopping"
+    :ok = System.create_topic(topic, 2)
+
+    consumer =
+      start_consumer(topic, "partitioned-stopping-sub",
+        create_topic?: false,
+        init_args: [stop_at_end_of_topic: true]
+      )
+
+    assert [_first, _second] = workers = Topology.workers(consumer)
+
+    drain()
+
+    refs = Map.new(workers, &{Process.monitor(&1), &1})
+    consumer_ref = Process.monitor(consumer)
+    :ok = System.terminate_topic(topic, partitioned?: true)
+
+    for {ref, worker} <- refs, do: assert_receive({:DOWN, ^ref, :process, ^worker, :normal}, 10_000)
+
+    assert_receive {:DOWN, ^consumer_ref, :process, ^consumer, :shutdown}, 10_000
+  end
+
   test "tells every consumer on a shared subscription" do
     topic = @topic <> "-shared"
     consumer = start_consumer(topic, "shared-sub", consumer_count: 3, subscription_type: :shared)

--- a/test/integration/consumer/end_of_topic_test.exs
+++ b/test/integration/consumer/end_of_topic_test.exs
@@ -61,8 +61,6 @@ defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
     assert_receive {:consumer_end_of_topic, ^worker}, 10_000
 
     assert_receive {:DOWN, ^ref, :process, ^consumer, :shutdown}, 10_000
-
-    refute_receive {:consumer_end_of_topic, _worker}, 5_000
     refute consumer in Pulsar.Client.consumers(@client)
   end
 
@@ -76,15 +74,22 @@ defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
         init_args: [stop_at_end_of_topic: true]
       )
 
-    assert [_first, _second] = workers = Topology.workers(consumer)
+    groups = Map.new(Topology.groups(consumer))
+    [ending] = partition_workers(groups, 0)
+    [surviving] = partition_workers(groups, 1)
 
     drain()
 
-    refs = Map.new(workers, &{Process.monitor(&1), &1})
-    consumer_ref = Process.monitor(consumer)
-    :ok = System.terminate_topic(topic, partitioned?: true)
+    ending_ref = Process.monitor(ending)
+    :ok = System.terminate_topic(topic <> "-partition-0")
+    assert_receive {:DOWN, ^ending_ref, :process, ^ending, :normal}, 10_000
 
-    for {ref, worker} <- refs, do: assert_receive({:DOWN, ^ref, :process, ^worker, :normal}, 10_000)
+    assert Process.alive?(consumer)
+    Utils.seed_topic(topic <> "-partition-1", ["after-the-other-ended"], client: @client)
+    assert_receive {:consumer, ^surviving, %Pulsar.Message{payload: "after-the-other-ended"}}, 10_000
+
+    consumer_ref = Process.monitor(consumer)
+    :ok = System.terminate_topic(topic <> "-partition-1")
 
     assert_receive {:DOWN, ^consumer_ref, :process, ^consumer, :shutdown}, 10_000
   end
@@ -142,6 +147,10 @@ defmodule Pulsar.Integration.Consumer.EndOfTopicTest do
     :ok = Pulsar.Consumer.await_ready(consumer, client: @client)
 
     consumer
+  end
+
+  defp partition_workers(groups, index) do
+    for {_id, worker, :worker, _modules} <- Supervisor.which_children(Map.fetch!(groups, index)), do: worker
   end
 
   defp drain do

--- a/test/integration/consumer/schema_test.exs
+++ b/test/integration/consumer/schema_test.exs
@@ -32,7 +32,7 @@ defmodule Pulsar.Integration.Consumer.SchemaTest do
     assert_receive {:consumer, ^consumer_pid, %{payload: "test message"}}
   end
 
-  test "a consumer whose schema the topic will not accept never becomes ready" do
+  test "a consumer whose schema the topic will not accept stops instead of becoming ready" do
     topic = "persistent://public/default/consumer-schema-compat-test-#{:erlang.unique_integer([:positive])}"
 
     start_producer(topic, schema: [type: :String])
@@ -46,20 +46,11 @@ defmodule Pulsar.Integration.Consumer.SchemaTest do
         schema: [type: :Int32]
       )
 
-    :ok = Topology.await_ready(consumer_group, 1_000)
-
-    # The topology comes up, but its worker cannot subscribe under a schema the topic refuses,
-    # so it gives up rather than ever becoming ready.
-    assert Pulsar.Consumer.await_ready(consumer_group, timeout: 2_000) == {:error, :timeout}
-    assert Topology.workers(consumer_group) == []
-
-    assert Process.alive?(consumer_group)
-    assert consumer_group in Pulsar.Client.consumers(@client)
-    assert {:error, :no_consumers_available} = Pulsar.Consumer.send_flow(consumer_group, 1)
-
     ref = Process.monitor(consumer_group)
-    assert :ok = Pulsar.Consumer.stop(consumer_group, client: @client)
-    assert_receive {:DOWN, ^ref, :process, ^consumer_group, _reason}
+
+    assert_receive {:DOWN, ^ref, :process, ^consumer_group, _reason}, 5_000
+
+    assert Pulsar.Consumer.await_ready(consumer_group, timeout: 1_000) == {:error, :not_found}
     refute consumer_group in Pulsar.Client.consumers(@client)
   end
 

--- a/test/integration/consumer/schema_test.exs
+++ b/test/integration/consumer/schema_test.exs
@@ -48,7 +48,7 @@ defmodule Pulsar.Integration.Consumer.SchemaTest do
 
     ref = Process.monitor(consumer_group)
 
-    assert_receive {:DOWN, ^ref, :process, ^consumer_group, _reason}, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^consumer_group, :shutdown}, 5_000
 
     assert Pulsar.Consumer.await_ready(consumer_group, timeout: 1_000) == {:error, :not_found}
     refute consumer_group in Pulsar.Client.consumers(@client)

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -241,7 +241,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
 
     ref = Process.monitor(no_force_create_group)
 
-    assert_receive {:DOWN, ^ref, :process, ^no_force_create_group, _reason}, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^no_force_create_group, :shutdown}, 5_000
 
     assert Pulsar.Consumer.await_ready(no_force_create_group, timeout: 1_000) == {:error, :not_found}
     refute no_force_create_group in Pulsar.Client.consumers(@client)

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -228,7 +228,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
     refute "non-durable" in subscriptions
   end
 
-  test "force_create_topic: false leaves the consumer running with no workers" do
+  test "force_create_topic: false stops the consumer instead of leaving it running" do
     non_existent_topic = "persistent://public/default/subscription-options-non-existent"
 
     {:ok, no_force_create_group} =
@@ -239,20 +239,11 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
         subscription_options(:earliest, force_create_topic: false)
       )
 
-    :ok = Topology.await_ready(no_force_create_group, 1_000)
-
-    # The topic does not exist and this consumer will not create one, so its worker gives up
-    # rather than ever becoming ready.
-    assert Pulsar.Consumer.await_ready(no_force_create_group, timeout: 2_000) == {:error, :timeout}
-    assert Topology.workers(no_force_create_group) == []
-
-    assert Process.alive?(no_force_create_group)
-    assert no_force_create_group in Pulsar.Client.consumers(@client)
-    assert {:error, :no_consumers_available} = Pulsar.Consumer.send_flow(no_force_create_group, 1)
-
     ref = Process.monitor(no_force_create_group)
-    assert :ok = Pulsar.Consumer.stop(no_force_create_group, client: @client)
-    assert_receive {:DOWN, ^ref, :process, ^no_force_create_group, _reason}
+
+    assert_receive {:DOWN, ^ref, :process, ^no_force_create_group, _reason}, 5_000
+
+    assert Pulsar.Consumer.await_ready(no_force_create_group, timeout: 1_000) == {:error, :not_found}
     refute no_force_create_group in Pulsar.Client.consumers(@client)
   end
 

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -120,24 +120,33 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
     refute_receive {:consumer, ^consumer, _message}
   end
 
-  # An :exclusive subscription admits one consumer, so the workers past the first are refused
-  # and stop instead of restarting against a slot that will not free up. The one that got the
-  # subscription keeps running. Use :failover if the others should stand by.
-  test "exclusive subscription keeps only the consumer that got the subscription" do
-    {:ok, exclusive_multi_group} =
+  # An :exclusive subscription admits one consumer; :failover is the way to keep standbys.
+  test "exclusive subscription refuses a consumer count above one" do
+    assert_raise ArgumentError, ~r/admits a single consumer/, fn ->
+      Pulsar.Consumer.start(@topic, "exclusive-multi", @consumer_callback, subscription_options(:exclusive, 2))
+    end
+  end
+
+  test "a second consumer of an exclusive subscription stops rather than waiting for it" do
+    subscription = "exclusive-contended"
+
+    {:ok, holder} = Pulsar.Consumer.start(@topic, subscription, @consumer_callback, subscription_options(:exclusive, 1))
+    :ok = Pulsar.Consumer.await_ready(holder, client: @client)
+
+    {:ok, contender} =
       Pulsar.Consumer.start(
         @topic,
-        "exclusive-multi",
+        subscription,
         @consumer_callback,
-        subscription_options(:exclusive, 2)
+        [name: "exclusive-contender"] ++ subscription_options(:exclusive, 1)
       )
 
-    assert Process.alive?(exclusive_multi_group)
+    ref = Process.monitor(contender)
 
-    assert [_worker] =
-             Utils.wait_for(fn -> Topology.workers(exclusive_multi_group) end,
-               until: &match?([_worker], &1)
-             )
+    assert_receive {:DOWN, ^ref, :process, ^contender, _reason}, 10_000
+    refute contender in Pulsar.Client.consumers(@client)
+
+    assert Process.alive?(holder)
   end
 
   # Deliveries from the consumers of one subscription arrive interleaved, so they are grouped

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -120,7 +120,6 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
     refute_receive {:consumer, ^consumer, _message}
   end
 
-  # An :exclusive subscription admits one consumer; :failover is the way to keep standbys.
   test "exclusive subscription refuses a consumer count above one" do
     assert_raise ArgumentError, ~r/admits a single consumer/, fn ->
       Pulsar.Consumer.start(@topic, "exclusive-multi", @consumer_callback, subscription_options(:exclusive, 2))

--- a/test/integration/consumer/subscription_types_test.exs
+++ b/test/integration/consumer/subscription_types_test.exs
@@ -142,7 +142,7 @@ defmodule Pulsar.Integration.Consumer.SubscriptionTypesTest do
 
     ref = Process.monitor(contender)
 
-    assert_receive {:DOWN, ^ref, :process, ^contender, _reason}, 10_000
+    assert_receive {:DOWN, ^ref, :process, ^contender, :shutdown}, 10_000
     refute contender in Pulsar.Client.consumers(@client)
 
     assert Process.alive?(holder)

--- a/test/integration/producer/access_modes_test.exs
+++ b/test/integration/producer/access_modes_test.exs
@@ -60,7 +60,7 @@ defmodule Pulsar.Integration.AccessModesTest do
                       metadata: %{success: false, error: :producer_fenced, producer_name: "exclusive-2" <> _}
                     }}
 
-    assert_receive {:DOWN, ^ref, :process, ^group_pid_2, _reason}, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^group_pid_2, :shutdown}, 5_000
 
     assert Pulsar.Producer.await_ready(group_pid_2, timeout: 1_000) == {:error, :not_found}
     refute group_pid_2 in Pulsar.Client.producers(@client)

--- a/test/integration/producer/access_modes_test.exs
+++ b/test/integration/producer/access_modes_test.exs
@@ -52,16 +52,7 @@ defmodule Pulsar.Integration.AccessModesTest do
                client: @client
              )
 
-    :ok = Topology.await_ready(group_pid_2, 1_000)
-
-    # Fenced by the producer already holding the topic, so it gives up rather than ever
-    # becoming ready.
-    assert Pulsar.Producer.await_ready(group_pid_2, timeout: 2_000) == {:error, :timeout}
-    assert Topology.workers(group_pid_2) == []
-
-    assert Process.alive?(group_pid_2)
-    assert group_pid_2 in Pulsar.Client.producers(@client)
-    assert {:error, :no_producers_available} = Pulsar.Producer.send(group_pid_2, "Rejected message")
+    ref = Process.monitor(group_pid_2)
 
     assert_receive {:telemetry_event,
                     %{
@@ -69,9 +60,9 @@ defmodule Pulsar.Integration.AccessModesTest do
                       metadata: %{success: false, error: :producer_fenced, producer_name: "exclusive-2" <> _}
                     }}
 
-    ref = Process.monitor(group_pid_2)
-    assert :ok = Pulsar.Producer.stop(group_pid_2, client: @client)
-    assert_receive {:DOWN, ^ref, :process, ^group_pid_2, _reason}
+    assert_receive {:DOWN, ^ref, :process, ^group_pid_2, _reason}, 5_000
+
+    assert Pulsar.Producer.await_ready(group_pid_2, timeout: 1_000) == {:error, :not_found}
     refute group_pid_2 in Pulsar.Client.producers(@client)
 
     ref = Process.monitor(producer_1)

--- a/test/integration/producer/schema_test.exs
+++ b/test/integration/producer/schema_test.exs
@@ -118,7 +118,7 @@ defmodule Pulsar.Integration.Producer.SchemaTest do
     assert message.raw.metadata.schema_version
   end
 
-  test "a producer whose schema the topic will not accept never becomes ready" do
+  test "a producer whose schema the topic will not accept stops instead of becoming ready" do
     topic = "persistent://public/default/producer-schema-compat-test"
     :ok = System.create_topic(topic)
 
@@ -131,20 +131,11 @@ defmodule Pulsar.Integration.Producer.SchemaTest do
         name: "compat-test-producer-2"
       )
 
-    :ok = Topology.await_ready(producer_group, 1_000)
-
-    # The topology comes up, but its worker cannot register under a schema the topic refuses,
-    # so it gives up rather than ever becoming ready.
-    assert Pulsar.Producer.await_ready(producer_group, timeout: 2_000) == {:error, :timeout}
-    assert Topology.workers(producer_group) == []
-
-    assert Process.alive?(producer_group)
-    assert producer_group in Pulsar.Client.producers(@client)
-    assert {:error, :no_producers_available} = Pulsar.Producer.send(producer_group, "message")
-
     ref = Process.monitor(producer_group)
-    assert :ok = Pulsar.Producer.stop(producer_group, client: @client)
-    assert_receive {:DOWN, ^ref, :process, ^producer_group, _reason}
+
+    assert_receive {:DOWN, ^ref, :process, ^producer_group, _reason}, 5_000
+
+    assert Pulsar.Producer.await_ready(producer_group, timeout: 1_000) == {:error, :not_found}
     refute producer_group in Pulsar.Client.producers(@client)
   end
 

--- a/test/integration/producer/schema_test.exs
+++ b/test/integration/producer/schema_test.exs
@@ -133,7 +133,7 @@ defmodule Pulsar.Integration.Producer.SchemaTest do
 
     ref = Process.monitor(producer_group)
 
-    assert_receive {:DOWN, ^ref, :process, ^producer_group, _reason}, 5_000
+    assert_receive {:DOWN, ^ref, :process, ^producer_group, :shutdown}, 5_000
 
     assert Pulsar.Producer.await_ready(producer_group, timeout: 1_000) == {:error, :not_found}
     refute producer_group in Pulsar.Client.producers(@client)

--- a/test/unit/backoff_test.exs
+++ b/test/unit/backoff_test.exs
@@ -36,7 +36,7 @@ defmodule Pulsar.BackoffTest do
 
   describe "run/1" do
     test "retries the standard transient broker errors" do
-      for reason <- [:disconnected, {:ServiceNotReady, "try again"}] do
+      for reason <- [:disconnected, :no_broker_available, {:ServiceNotReady, "try again"}] do
         counter = :counters.new(1, [])
 
         assert Backoff.run(fn ->

--- a/test/unit/child_spec_test.exs
+++ b/test/unit/child_spec_test.exs
@@ -34,7 +34,7 @@ defmodule Pulsar.ChildSpecTest do
         )
 
       assert spec.type == :supervisor
-      assert spec.restart == :permanent
+      assert spec.restart == :transient
       assert spec.id == {Pulsar.Consumer, "persistent://public/default/orders-svc"}
     end
 
@@ -81,7 +81,7 @@ defmodule Pulsar.ChildSpecTest do
       spec = Pulsar.Producer.child_spec(topic: "persistent://public/default/audit")
 
       assert spec.type == :supervisor
-      assert spec.restart == :permanent
+      assert spec.restart == :transient
       assert spec.id == {Pulsar.Producer, "persistent://public/default/audit-producer"}
     end
 

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -338,6 +338,24 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert state.acks.acked == %{}
     end
 
+    test "reports the messages of an entry that could not be diverted" do
+      test_pid = self()
+      handler = "dead-letter-failed-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:pulsar, :consumer, :dead_letter, :failed],
+        fn _event, measurements, metadata, _config -> send(test_pid, {:failed, measurements, metadata}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      deliver(diverting_state(refuse: ["b"]), ["a", "b", "c"], redelivery_count: 1)
+
+      assert_receive {:failed, %{count: 1}, %{dead_letter_topic: "dlq", reason: :message_too_large}}
+    end
+
     test "acknowledges the entry once every message of it has been diverted" do
       state = diverting_state(refuse: [])
 

--- a/test/unit/consumer_dead_letter_test.exs
+++ b/test/unit/consumer_dead_letter_test.exs
@@ -153,6 +153,17 @@ defmodule Pulsar.Consumer.DeadLetterTest do
       assert Topology.resource?(restarted, :producers)
     end
 
+    test "leaves a dead letter producer that stopped cleanly stopped" do
+      root = root()
+      dlq = dead_letter_producer(root)
+      ref = Process.monitor(dlq)
+
+      :ok = Supervisor.stop(dlq)
+      assert_receive {:DOWN, ^ref, :process, ^dlq, :normal}
+
+      assert dead_letter_producer(root) == nil
+    end
+
     test "goes down with the consumer that owns it" do
       root = root()
       dlq = dead_letter_producer(root)

--- a/test/unit/consumer_options_test.exs
+++ b/test/unit/consumer_options_test.exs
@@ -75,6 +75,15 @@ defmodule Pulsar.Consumer.OptionsTest do
       end
     end
 
+    test "rejects more than one consumer on an exclusive subscription" do
+      assert_raise ArgumentError, ~r/admits a single consumer/, fn ->
+        validate!(subscription_type: :exclusive, consumer_count: 2)
+      end
+
+      assert validate!(subscription_type: :exclusive, consumer_count: 1)[:consumer_count] == 1
+      assert validate!(subscription_type: :failover, consumer_count: 2)[:consumer_count] == 2
+    end
+
     test "accepts a start_message_id as a ledger and entry pair" do
       assert validate!(start_message_id: {1, 2})[:start_message_id] == {1, 2}
 

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -261,13 +261,10 @@ defmodule Pulsar.TopologyTest do
              end)
     end
 
-    @tag telemetry_listen: [
-           [:pulsar, :topology, :discovery, :stop],
-           [:pulsar, :topology, :reconciliation, :stop]
-         ]
-    test "stops metadata polling for a non-partitioned topic while local reconciliation continues" do
+    @tag telemetry_listen: [[:pulsar, :topology, :discovery, :stop]]
+    test "stops metadata polling for a non-partitioned topic" do
       test_pid = self()
-      topic = "#{@topic}-local-reconciliation"
+      topic = "#{@topic}-non-partitioned-polling"
 
       resolver = fn resolved_topic, _opts ->
         send(test_pid, {:resolved, resolved_topic})
@@ -277,8 +274,9 @@ defmodule Pulsar.TopologyTest do
       {root, _registry} =
         start_async_topology(
           resolver,
-          [topic: topic, name: "#{topic}-producer", partition_discovery_interval_ms: 10],
-          reconciliation_interval_ms: 250
+          topic: topic,
+          name: "#{topic}-producer",
+          partition_discovery_interval_ms: 10
         )
 
       :ok = Topology.await_ready(root, 1_000)
@@ -292,38 +290,6 @@ defmodule Pulsar.TopologyTest do
                           client: :test,
                           success: true,
                           partition_count: 0
-                        }
-                      }}
-
-      [{0, old_group}] = Topology.groups(root)
-      [{_id, worker, :worker, _modules}] = Supervisor.which_children(old_group)
-      ref = Process.monitor(old_group)
-
-      :ok = Agent.stop(worker)
-      assert_receive {:DOWN, ^ref, :process, ^old_group, _reason}
-      assert Topology.groups(root) == [{0, :undefined}]
-
-      Utils.wait_for(
-        fn ->
-          case Topology.groups(root) do
-            [{0, new_group}] when is_pid(new_group) -> new_group != old_group
-            _not_running -> false
-          end
-        end,
-        timeout: 1_000,
-        interval: 10
-      )
-
-      assert_receive {:telemetry_event,
-                      %{
-                        event: [:pulsar, :topology, :reconciliation, :stop],
-                        metadata: %{
-                          topic: ^topic,
-                          source: :local,
-                          success: true,
-                          desired_partition_count: 0,
-                          partition_count: 0,
-                          revived_groups: [0]
                         }
                       }}
 
@@ -432,67 +398,40 @@ defmodule Pulsar.TopologyTest do
       end
     end
 
-    test "periodically revives every partition group after they stop normally" do
-      test_pid = self()
-      resolutions = start_supervised!({Agent, fn -> 0 end})
-
-      resolver = fn _topic, _opts ->
-        case Agent.get_and_update(resolutions, &{&1, &1 + 1}) do
-          0 ->
-            {:ok, 2}
-
-          _later ->
-            send(test_pid, {:resolution_started, self()})
-
-            receive do
-              :resolve -> {:ok, 2}
-            end
-        end
-      end
-
-      {root, _registry} = start_async_topology(resolver, partition_discovery_interval_ms: 100)
+    test "leaves a stopped partition group down while its siblings keep running" do
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 2} end, partition_discovery_interval_ms: 10)
 
       :ok = Topology.await_ready(root, 1_000)
-      assert_receive {:resolution_started, discovery}, 1_000
 
-      old_groups = Map.new(Topology.groups(root))
+      groups = Map.new(Topology.groups(root))
+      stopped = Map.fetch!(groups, 0)
+      surviving = Map.fetch!(groups, 1)
 
-      refs =
-        Enum.map(old_groups, fn {_index, group} ->
-          [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
-          ref = Process.monitor(group)
-          :ok = Agent.stop(worker)
-          {ref, group}
-        end)
+      [{_id, worker, :worker, _modules}] = Supervisor.which_children(stopped)
+      ref = Process.monitor(stopped)
+      :ok = Agent.stop(worker)
+      assert_receive {:DOWN, ^ref, :process, ^stopped, _reason}
 
-      for {ref, group} <- refs do
-        assert_receive {:DOWN, ^ref, :process, ^group, _reason}
-      end
+      # Several rounds of metadata polling.
+      Process.sleep(100)
 
       assert Process.alive?(root)
-      assert Enum.all?(Topology.groups(root), &match?({_index, :undefined}, &1))
+      assert Topology.groups(root) == [{0, :undefined}, {1, surviving}]
+    end
 
-      send(discovery, :resolve)
+    test "stops the topology once its last group has stopped" do
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 2} end, partition_discovery_interval_ms: 10)
 
-      Utils.wait_for(
-        fn ->
-          groups = Map.new(Topology.groups(root))
+      :ok = Topology.await_ready(root, 1_000)
 
-          Enum.all?(old_groups, fn {index, old_group} ->
-            case Map.fetch(groups, index) do
-              {:ok, new_group} when is_pid(new_group) -> new_group != old_group
-              _not_running -> false
-            end
-          end)
-        end,
-        timeout: 1_000,
-        interval: 10
-      )
+      root_ref = Process.monitor(root)
 
-      for {index, new_group} <- Topology.groups(root) do
-        assert [{_id, new_worker, :worker, _modules}] = Supervisor.which_children(new_group)
-        assert Agent.get(new_worker, & &1) == Pulsar.Topic.partition(@topic, index)
+      for {_index, group} <- Topology.groups(root) do
+        [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
+        :ok = Agent.stop(worker)
       end
+
+      assert_receive {:DOWN, ^root_ref, :process, ^root, :shutdown}, 1_000
     end
   end
 

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -88,6 +88,12 @@ defmodule Pulsar.TopologyTest do
     end
   end
 
+  defmodule CrashingWorker do
+    @moduledoc false
+
+    def start_link(_opts), do: {:ok, spawn_link(fn -> exit(:crashed) end)}
+  end
+
   defmodule OptsWorker do
     @moduledoc false
     use Agent
@@ -434,6 +440,73 @@ defmodule Pulsar.TopologyTest do
     end
   end
 
+  describe "restarts and propagation" do
+    test "restarts a worker that crashes, leaving its group and root alone" do
+      {root, _registry} = start_topology(0)
+
+      [{0, group}] = Topology.groups(root)
+      [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
+
+      worker_ref = Process.monitor(worker)
+      group_ref = Process.monitor(group)
+      root_ref = Process.monitor(root)
+
+      Process.exit(worker, :kill)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+
+      # A crash is what :transient exists to restart, so nothing above the worker reacts to it.
+      refute_receive {:DOWN, ^group_ref, :process, _pid, _reason}, 200
+      refute_receive {:DOWN, ^root_ref, :process, _pid, _reason}, 0
+
+      assert [{_id, restarted, :worker, _modules}] = Supervisor.which_children(group)
+      assert restarted != worker
+      assert Topology.groups(root) == [{0, group}]
+    end
+
+    test "a resource that shuts itself down is not started over by its client" do
+      client = start_dynamic_supervisor()
+      {:ok, root} = DynamicSupervisor.start_child(client, topology_spec(StubWorker))
+
+      :ok = Topology.await_ready(root, 1_000)
+      [{0, group}] = Topology.groups(root)
+      [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
+
+      ref = Process.monitor(root)
+      :ok = Agent.stop(worker)
+
+      assert_receive {:DOWN, ^ref, :process, ^root, :shutdown}, 1_000
+      assert DynamicSupervisor.which_children(client) == []
+    end
+
+    test "a group that exhausts its restart budget takes the resource with it" do
+      client = start_dynamic_supervisor()
+      {:ok, root} = DynamicSupervisor.start_child(client, topology_spec(CrashingWorker))
+
+      ref = Process.monitor(root)
+
+      # Exhaustion exits :shutdown, exactly like a group that stopped on purpose, so the root
+      # follows and the client removes it. The resource is gone, and nothing distinguishes this
+      # from a consumer that finished: worth pinning, since it is the one case the tree cannot
+      # tell apart.
+      assert_receive {:DOWN, ^ref, :process, ^root, :shutdown}, 5_000
+      assert DynamicSupervisor.which_children(client) == []
+    end
+
+    test "stops a producer topology once its last group has stopped" do
+      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 2} end, [], kind: :producers)
+
+      :ok = Topology.await_ready(root, 1_000)
+      root_ref = Process.monitor(root)
+
+      for {_index, group} <- Topology.groups(root) do
+        [{_id, worker, :worker, _modules}] = Supervisor.which_children(group)
+        :ok = Agent.stop(worker)
+      end
+
+      assert_receive {:DOWN, ^root_ref, :process, ^root, :shutdown}, 1_000
+    end
+  end
+
   describe "worker options" do
     test "gives a partition worker its own topic alongside the configured one" do
       {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 3} end, [], worker: OptsWorker)
@@ -503,6 +576,21 @@ defmodule Pulsar.TopologyTest do
   defp discovery(root) do
     [pid] = for {{Discovery, _kind, _topic, _scheme}, pid, _type, _modules} <- Supervisor.which_children(root), do: pid
     pid
+  end
+
+  defp topology_spec(worker) do
+    registry = :"registry-#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :unique, name: registry})
+
+    opts = [topic: @topic, name: @name, client: :test, partition_discovery_interval_ms: false, consumer_count: 1]
+    controller_opts = [resolver: fn _topic, _opts -> {:ok, 0} end]
+
+    %{
+      id: {:root, System.unique_integer([:positive])},
+      start: {Topology, :start_link, [worker, registry, :consumers, opts, controller_opts]},
+      restart: :transient,
+      type: :supervisor
+    }
   end
 
   defp worker_opts(root) do

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -399,9 +399,7 @@ defmodule Pulsar.TopologyTest do
     end
 
     test "leaves a stopped partition group down while its siblings keep running" do
-      {root, _registry} = start_async_topology(fn _topic, _opts -> {:ok, 2} end, partition_discovery_interval_ms: 10)
-
-      :ok = Topology.await_ready(root, 1_000)
+      {root, _registry} = start_topology(2)
 
       groups = Map.new(Topology.groups(root))
       stopped = Map.fetch!(groups, 0)
@@ -412,11 +410,12 @@ defmodule Pulsar.TopologyTest do
       :ok = Agent.stop(worker)
       assert_receive {:DOWN, ^ref, :process, ^stopped, _reason}
 
-      # Several rounds of metadata polling.
-      Process.sleep(100)
+      discovery = discovery(root)
+      for _poll <- 1..3, do: send(discovery, :discover)
+      assert GenServer.call(discovery, :status) == {:ready, {:partitioned, 2}}
 
       assert Process.alive?(root)
-      assert Topology.groups(root) == [{0, :undefined}, {1, surviving}]
+      assert Map.new(Topology.groups(root)) == %{0 => :undefined, 1 => surviving}
     end
 
     test "stops the topology once its last group has stopped" do
@@ -499,6 +498,11 @@ defmodule Pulsar.TopologyTest do
         refute Keyword.has_key?(opts, :companions)
       end
     end
+  end
+
+  defp discovery(root) do
+    [pid] = for {{Discovery, _kind, _topic, _scheme}, pid, _type, _modules} <- Supervisor.which_children(root), do: pid
+    pid
   end
 
   defp worker_opts(root) do


### PR DESCRIPTION
### Summary

Fixes #198

Reconciliation restarted every group child sitting at `:undefined`, which it could not tell apart from a group that had stopped on purpose. A one-shot consumer draining a terminated topic answered `{:stop, :normal, state}` and was resubscribed a minute later, indefinitely. The same loop applied to every terminal error: bad credentials were retried forever on a 60s timer.

### Why it can't be fixed by inspecting the tree

The reason a group stopped is not recoverable from the supervision tree. `restart: :transient` treats `:normal`, `:shutdown` and `{:shutdown, term}` alike, and a supervisor exits `:shutdown` both when `auto_shutdown` fires and when it exhausts its restart budget. All three of these look identical to `which_children`:

| what happened | group supervisor exit | root sees |
| --- | --- | --- |
| drained, callback said stop | `:shutdown` | `:undefined` |
| terminal error (auth, bad topic, `ConsumerBusy`) | `:shutdown` | `:undefined` |
| restart budget exhausted | `:shutdown` | `:undefined` |

So rather than discriminate after the fact, the tree is arranged to make the distinction structural.

### Changes

- Groups are `significant: true` under a root with `auto_shutdown: :all_significant`. A group whose workers all stopped takes no further part, and once the last group is gone the resource stops too instead of lingering with nothing consuming or producing.
- `:all_significant` and not `:any_significant`: partitions of a terminated topic reach their end at their own pace, and the ones still draining have to be allowed to finish.
- The root's own spec becomes `restart: :transient`, so a resource that stopped is not started over by the client's `DynamicSupervisor`.
- Unexpected errors are untouched: they still crash, and `:transient` still restarts them.
- The local reconciliation pass is removed. Partition growth is driven by metadata polling, so the pass had no remaining job once the revival it existed to perform was gone. That takes its timer, its backoff state and the `revived_groups` telemetry field with it.
- `ConsumerBusy` stays terminal. A consumer refused an `:exclusive` subscription held elsewhere stops rather than standing by for it.
- `subscription_type: :exclusive` with `consumer_count > 1` is now rejected. The workers past the first are refused the subscription and stop on arrival, which worked but only ever left one running.

Net `-100` lines of library code.

### Breaking changes

1. A consumer or producer that hits an error nothing can retry now stops instead of lingering with no workers. `await_ready/2` answers `{:error, :not_found}` rather than `{:error, :timeout}`, and the resource is no longer listed by `Pulsar.Client.consumers/1` or `Pulsar.Client.producers/1`.
2. `subscription_type: :exclusive` with `consumer_count > 1` now raises instead of starting workers that stop on arrival. Use `:failover` for standbys.
3. The `[:pulsar, :topology, :reconciliation, :*]` telemetry metadata loses `:source` and `:revived_groups`. Both described the local pass this PR removes, so neither has a meaningful value left to report. A handler that pattern-matches either key in its `metadata` argument now raises `FunctionClauseError`, and `:telemetry` detaches it after the first failure, so the break is silent from the handler's side. Match on `%{topic: topic}` or on the map loosely instead.

### OTP assumptions, verified

These were checked against OTP directly before the change was written, since the whole design rests on them:

- A `:one_for_one` supervisor with `auto_shutdown: :all_significant` and **zero** significant children at `init` stays up. This matters because the root starts with only `Discovery` and its companions, and groups are added later via `start_child`.
- The first significant child stopping leaves the root up with that child at `:undefined`; the last one stopping brings the root down with `:shutdown`.
- A significant child that *crashes* is still restarted by `:transient`, and the root stays up.
- A `:permanent` root under a `DynamicSupervisor` **is** restarted after a clean shutdown (a new pid appears); `:transient` is removed cleanly. This is why the root spec had to change.

### Known trade-off

`auto_shutdown` cannot tell a retired group from a failed one, so if a group exhausts its restart budget while siblings are alive, it stays `:undefined` beside them rather than taking the resource down. This is left to an external health probe: `Topology.groups/1` already reports `:undefined` for a stranded partition, distinctly from having no such partition, so the check is `every group is a pid and the count matches the discovered partition width`.

Note for such a probe: a one-shot consumer that drains a terminated topic *correctly* disappears. A naive "am I consuming?" liveness check reads that as broken and restarts the pod, which resubscribes and re-drains — the original bug, relocated. The probe has to distinguish "gone because finished" from "gone because broken".

### Tests

- Regression test for #198: a consumer that stops at the end of a terminated topic stays stopped, is not resubscribed, and deregisters.
- A partitioned consumer keeps draining its other partitions when one of them stops at its end, and goes away once the last one has.
- A stopped partition group stays down across several rounds of metadata polling while its siblings keep running.
- A second consumer of an `:exclusive` subscription stops rather than waiting, leaving the holder alive.
- The four tests that asserted the old husk behaviour (`{:error, :timeout}`, still registered) now assert the resource goes away.

`mix test` 569/570, `mix credo --strict` and `mix dialyzer` clean. The one failure is a pre-existing load flake in `test/integration/reader/common_test.exs` — it moves between tests across runs and the file passes 3/3 in isolation on both this branch and `main`.

### Action Log

- [ ] DLQ Producer down should bring down consumer without data loss