### PR TITLE
fix(reader): fail when a non-durable worker is lost

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,7 +237,12 @@ to `false` disables later metadata checks; initial discovery still runs.
 `Pulsar.Reader` builds on this lifecycle. Each enumeration creates a temporary non-durable
 consumer below the selected client, waits internally for the expected workers to become
 ready, and then exposes their messages as a stream. Halting the stream or failing startup
-removes that temporary consumer; the client remains running.
+removes that temporary consumer; the client remains running. The enumeration monitors the
+workers that establish its position. If one exits, Reader raises instead of accepting its
+replacement: a new non-durable subscription would apply the original start position and could
+replay or skip messages. The same rule applies per partition, while a newly discovered partition
+can join because it has no previous cursor to recover. The failure removes the whole temporary
+consumer through the public facade and does not change the worker's supervision policy.
 
 ## Declared and Runtime Resources
 

--- a/docs/reader.md
+++ b/docs/reader.md
@@ -150,6 +150,16 @@ topic
 end
 ```
 
+Once initialized, a Reader cannot recover its exact position if one of its consumer workers
+exits. Its subscription is non-durable, so a replacement would subscribe from the original
+`:start_position`, `:start_message_id`, or `:start_timestamp`, potentially replaying or skipping
+messages. The enumeration therefore raises a `RuntimeError` and removes its temporary consumer.
+
+This applies if any worker of a partitioned Reader exits. A partition discovered for the first
+time can still join a running Reader because it has no earlier cursor to recover. Use
+`Pulsar.Consumer` with a durable subscription when consumption must recover automatically from
+broker disconnects or worker failures.
+
 ## Flow Control
 
 The Reader manages flow control internally. You can configure the number of permits (messages requested from the broker) using `:flow_permits`:

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -396,9 +396,7 @@ defmodule Pulsar.Reader do
   # a pid that disappeared in the gap immediately produces :DOWN, so the stream cannot miss the
   # lookup/use race here.
   defp collect_initial_workers(state, expected, deadline) do
-    tracked = state.workers_by_topic |> Map.values() |> MapSet.new(fn {pid, _monitor_ref} -> pid end)
-
-    if MapSet.subset?(expected, tracked) do
+    if MapSet.size(expected) == 0 do
       {:ok, state}
     else
       reader_ref = state.reader_ref
@@ -407,7 +405,7 @@ defmodule Pulsar.Reader do
         {:pulsar_reader_ready, ^reader_ref, consumer_pid, topic} ->
           case track_worker(state, consumer_pid, topic) do
             {:ok, new_state} ->
-              collect_initial_workers(new_state, expected, deadline)
+              collect_initial_workers(new_state, MapSet.delete(expected, consumer_pid), deadline)
 
             {:error, reason} ->
               demonitor_workers(state)
@@ -427,10 +425,10 @@ defmodule Pulsar.Reader do
   # cursor reached by the old worker.
   defp track_worker(state, consumer_pid, topic) do
     case state.workers_by_topic do
-      %{^topic => {^consumer_pid, _monitor_ref}} ->
+      %{^topic => ^consumer_pid} ->
         {:ok, state}
 
-      %{^topic => {_previous_pid, _monitor_ref}} ->
+      %{^topic => _previous_pid} ->
         {:error, :worker_replaced}
 
       _new_topic ->
@@ -439,7 +437,7 @@ defmodule Pulsar.Reader do
         {:ok,
          %{
            state
-           | workers_by_topic: Map.put(state.workers_by_topic, topic, {consumer_pid, monitor_ref}),
+           | workers_by_topic: Map.put(state.workers_by_topic, topic, consumer_pid),
              topics_by_monitor: Map.put(state.topics_by_monitor, monitor_ref, topic),
              permits_by_consumer: Map.put_new(state.permits_by_consumer, consumer_pid, state.flow_permits)
          }}
@@ -448,12 +446,14 @@ defmodule Pulsar.Reader do
 
   defp worker_topic(state, consumer_pid) do
     Enum.find_value(state.workers_by_topic, fn
-      {topic, {^consumer_pid, _monitor_ref}} -> topic
-      {_topic, {_other_pid, _monitor_ref}} -> nil
+      {topic, ^consumer_pid} -> topic
+      {_topic, _other_pid} -> nil
     end)
   end
 
   defp raise_interrupted(state, topic, reason) do
+    # Recursive receives may have tracked workers in a newer state than Stream.resource/3
+    # retains for its cleanup callback, so those monitors have to be removed here as well.
     demonitor_workers(state)
 
     raise "reader worker for #{inspect(topic)} was lost (#{inspect(reason)}); " <>

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -297,12 +297,12 @@ defmodule Pulsar.Reader do
           {:pulsar_reader_ready, ^reader_ref, consumer_pid, topic} ->
             case track_worker(state, consumer_pid, topic) do
               {:ok, new_state} -> next_message(new_state, deadline)
-              {:error, reason} -> raise_interrupted(topic, reason)
+              {:error, reason} -> raise_interrupted(state, topic, reason)
             end
 
           {:DOWN, monitor_ref, :process, _consumer_pid, reason}
           when is_map_key(topics_by_monitor, monitor_ref) ->
-            raise_interrupted(Map.fetch!(topics_by_monitor, monitor_ref), reason)
+            raise_interrupted(state, Map.fetch!(topics_by_monitor, monitor_ref), reason)
         after
           time_left(deadline) ->
             {:halt, state}
@@ -371,7 +371,7 @@ defmodule Pulsar.Reader do
           maybe_refill_flow(%{state | permits_by_consumer: new_permits}, consumer_pid)
 
         {:error, reason} ->
-          raise_interrupted(worker_topic(state, consumer_pid), {:flow_failed, reason})
+          raise_interrupted(state, worker_topic(state, consumer_pid), {:flow_failed, reason})
       end
     else
       state
@@ -453,7 +453,9 @@ defmodule Pulsar.Reader do
     end)
   end
 
-  defp raise_interrupted(topic, reason) do
+  defp raise_interrupted(state, topic, reason) do
+    demonitor_workers(state)
+
     raise "reader worker for #{inspect(topic)} was lost (#{inspect(reason)}); " <>
             "the non-durable stream cannot continue from a known position"
   end

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -285,6 +285,7 @@ defmodule Pulsar.Reader do
 
       {:empty, _buffer} ->
         reader_ref = state.reader_ref
+        topics_by_monitor = state.topics_by_monitor
 
         receive do
           {:pulsar_message, ^reader_ref, _consumer_pid, message} ->
@@ -299,14 +300,9 @@ defmodule Pulsar.Reader do
               {:error, reason} -> raise_interrupted(topic, reason)
             end
 
-          {:DOWN, monitor_ref, :process, _consumer_pid, reason} ->
-            case state.topics_by_monitor do
-              %{^monitor_ref => topic} ->
-                raise_interrupted(topic, reason)
-
-              _unknown_monitor ->
-                next_message(state, deadline)
-            end
+          {:DOWN, monitor_ref, :process, _consumer_pid, reason}
+          when is_map_key(topics_by_monitor, monitor_ref) ->
+            raise_interrupted(Map.fetch!(topics_by_monitor, monitor_ref), reason)
         after
           time_left(deadline) ->
             {:halt, state}

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -66,6 +66,11 @@ defmodule Pulsar.Reader do
   - The consumer receives all requested messages (e.g., via `Enum.take/2`)
   - The inactivity timeout is reached (default: 60 seconds)
   - The stream is halted by downstream processing
+
+  A Reader cannot recover a known position after one of its non-durable consumer workers
+  exits. It raises a `RuntimeError` and removes its temporary consumer rather than silently
+  resubscribing from the original start position. Use `Pulsar.Consumer` with a durable
+  subscription when consumption must survive a broker disconnect or worker failure.
   """
 
   alias Pulsar.Consumer
@@ -129,7 +134,9 @@ defmodule Pulsar.Reader do
   Creates a stream of messages from a Pulsar topic.
 
   Returns a `Stream` that yields `Pulsar.Message` structs. If initialization
-  fails, the stream emits `{:error, reason}` as the first (and only) element.
+  fails, the stream emits `{:error, reason}` as the first (and only) element. If a
+  consumer worker exits after initialization, enumeration raises a `RuntimeError` because the
+  non-durable subscription cannot resume from a known position.
 
   ## Options
 
@@ -226,21 +233,25 @@ defmodule Pulsar.Reader do
   end
 
   defp build_reader_state(consumer, client_name, reader_ref, flow_permits, timeout, startup_timeout) do
-    case wait_for_consumers_ready(consumer, startup_timeout) do
+    startup_deadline = deadline(startup_timeout)
+
+    case wait_for_consumers_ready(consumer, startup_deadline) do
       {:ok, consumer_pids} ->
         permits_by_consumer = Map.new(consumer_pids, fn pid -> {pid, flow_permits} end)
 
-        {:ok,
-         %{
-           client: client_name,
-           consumer_pids: consumer_pids,
-           consumer_root: consumer,
-           flow_permits: flow_permits,
-           permits_by_consumer: permits_by_consumer,
-           timeout: timeout,
-           reader_ref: reader_ref,
-           buffer: :queue.new()
-         }}
+        state = %{
+          client: client_name,
+          consumer_root: consumer,
+          flow_permits: flow_permits,
+          permits_by_consumer: permits_by_consumer,
+          timeout: timeout,
+          reader_ref: reader_ref,
+          buffer: :queue.new(),
+          workers_by_topic: %{},
+          topics_by_monitor: %{}
+        }
+
+        collect_initial_workers(state, MapSet.new(consumer_pids), startup_deadline)
 
       {:error, _reason} = error ->
         error
@@ -281,6 +292,21 @@ defmodule Pulsar.Reader do
 
           {:pulsar_permits, ^reader_ref, consumer_pid, consumed} ->
             next_message(%{state | buffer: :queue.in({:permits, consumer_pid, consumed}, state.buffer)}, deadline)
+
+          {:pulsar_reader_ready, ^reader_ref, consumer_pid, topic} ->
+            case track_worker(state, consumer_pid, topic) do
+              {:ok, new_state} -> next_message(new_state, deadline)
+              {:error, reason} -> raise_interrupted(topic, reason)
+            end
+
+          {:DOWN, monitor_ref, :process, _consumer_pid, reason} ->
+            case state.topics_by_monitor do
+              %{^monitor_ref => topic} ->
+                raise_interrupted(topic, reason)
+
+              _unknown_monitor ->
+                next_message(state, deadline)
+            end
         after
           time_left(deadline) ->
             {:halt, state}
@@ -297,10 +323,18 @@ defmodule Pulsar.Reader do
   defp stop_reader(:halted), do: :ok
 
   defp stop_reader(state) do
+    demonitor_workers(state)
+
     case Consumer.stop(state.consumer_root, client: state.client) do
       :ok -> :ok
       {:error, _reason} -> :ok
     end
+  end
+
+  defp demonitor_workers(state) do
+    Enum.each(state.topics_by_monitor, fn {monitor_ref, _topic} ->
+      Process.demonitor(monitor_ref, [:flush])
+    end)
   end
 
   @doc false
@@ -333,25 +367,99 @@ defmodule Pulsar.Reader do
     threshold = div(state.flow_permits, 2)
 
     if current_permits <= threshold do
-      :ok = Consumer.send_flow(consumer_pid, state.flow_permits)
-      new_permits = Map.put(state.permits_by_consumer, consumer_pid, current_permits + state.flow_permits)
+      case Consumer.send_flow(consumer_pid, state.flow_permits) do
+        :ok ->
+          new_permits =
+            Map.put(state.permits_by_consumer, consumer_pid, current_permits + state.flow_permits)
 
-      maybe_refill_flow(%{state | permits_by_consumer: new_permits}, consumer_pid)
+          maybe_refill_flow(%{state | permits_by_consumer: new_permits}, consumer_pid)
+
+        {:error, reason} ->
+          raise_interrupted(worker_topic(state, consumer_pid), {:flow_failed, reason})
+      end
     else
       state
     end
   end
 
   # Each worker grants :flow_initial for itself when it subscribes, so a partition discovered
-  # later, or a worker that restarts, starts with a window instead of waiting to be given one.
-  defp wait_for_consumers_ready(consumer, startup_timeout) do
-    with :ok <- Consumer.await_ready(consumer, timeout: startup_timeout),
+  # later starts with a window instead of waiting to be given one. A replacement worker does
+  # too, but its subscription has lost the non-durable cursor and is rejected above.
+  defp wait_for_consumers_ready(consumer, startup_deadline) do
+    with :ok <- Consumer.await_ready(consumer, timeout: time_left(startup_deadline)),
          [_ | _] = consumer_pids <- Topology.workers(consumer) do
       {:ok, consumer_pids}
     else
       [] -> {:error, :reader_start_timeout}
       {:error, _reason} -> {:error, :reader_start_timeout}
     end
+  end
+
+  # Callback.init/2 has sent a ready signal before await_ready/2 can observe a worker as ready.
+  # Keep receiving until every pid from that readiness snapshot has been identified. Monitoring
+  # a pid that disappeared in the gap immediately produces :DOWN, so the stream cannot miss the
+  # lookup/use race here.
+  defp collect_initial_workers(state, expected, deadline) do
+    tracked = state.workers_by_topic |> Map.values() |> MapSet.new(fn {pid, _monitor_ref} -> pid end)
+
+    if MapSet.subset?(expected, tracked) do
+      {:ok, state}
+    else
+      reader_ref = state.reader_ref
+
+      receive do
+        {:pulsar_reader_ready, ^reader_ref, consumer_pid, topic} ->
+          case track_worker(state, consumer_pid, topic) do
+            {:ok, new_state} ->
+              collect_initial_workers(new_state, expected, deadline)
+
+            {:error, reason} ->
+              demonitor_workers(state)
+              {:error, {:reader_interrupted, topic, reason}}
+          end
+      after
+        time_left(deadline) ->
+          demonitor_workers(state)
+          {:error, :reader_start_timeout}
+      end
+    end
+  end
+
+  # A topic not seen before is a partition discovered after the enumeration began and is safe
+  # to add: this is its first subscription. A different pid for a known topic is a replacement,
+  # whose new non-durable subscription starts from the original Reader options rather than the
+  # cursor reached by the old worker.
+  defp track_worker(state, consumer_pid, topic) do
+    case state.workers_by_topic do
+      %{^topic => {^consumer_pid, _monitor_ref}} ->
+        {:ok, state}
+
+      %{^topic => {_previous_pid, _monitor_ref}} ->
+        {:error, :worker_replaced}
+
+      _new_topic ->
+        monitor_ref = Process.monitor(consumer_pid)
+
+        {:ok,
+         %{
+           state
+           | workers_by_topic: Map.put(state.workers_by_topic, topic, {consumer_pid, monitor_ref}),
+             topics_by_monitor: Map.put(state.topics_by_monitor, monitor_ref, topic),
+             permits_by_consumer: Map.put_new(state.permits_by_consumer, consumer_pid, state.flow_permits)
+         }}
+    end
+  end
+
+  defp worker_topic(state, consumer_pid) do
+    Enum.find_value(state.workers_by_topic, fn
+      {topic, {^consumer_pid, _monitor_ref}} -> topic
+      {_topic, {_other_pid, _monitor_ref}} -> nil
+    end)
+  end
+
+  defp raise_interrupted(topic, reason) do
+    raise "reader worker for #{inspect(topic)} was lost (#{inspect(reason)}); " <>
+            "the non-durable stream cannot continue from a known position"
   end
 
   defp stop_consumer(consumer, client_name) do

--- a/lib/pulsar/reader/callback.ex
+++ b/lib/pulsar/reader/callback.ex
@@ -9,7 +9,8 @@ defmodule Pulsar.Reader.Callback do
   use Pulsar.Consumer.Callback
 
   @impl true
-  def init([stream_pid, reader_ref], _context) do
+  def init([stream_pid, reader_ref], context) do
+    send(stream_pid, {:pulsar_reader_ready, reader_ref, self(), context.topic})
     {:ok, %{stream_pid: stream_pid, reader_ref: reader_ref}}
   end
 

--- a/test/integration/reader/interruption_test.exs
+++ b/test/integration/reader/interruption_test.exs
@@ -90,11 +90,7 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
 
     {reader, reader_ref} =
       start_paused_reader(@topic, fn ->
-        send(test_pid, {:reader_waiting, self()})
-
-        receive do
-          :finish -> :ok
-        end
+        send(test_pid, {:reader_monitors, self(), Process.info(self(), :monitors)})
       end)
 
     assert_receive {:reader_message, ^reader, %{payload: "message"}}, 5_000
@@ -103,37 +99,15 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
     [worker] = Topology.workers(root)
     %{callback_state: %{reader_ref: callback_ref}} = :sys.get_state(worker)
 
-    late_worker =
-      spawn(fn ->
-        receive do
-          :stop -> :ok
-        end
-      end)
-
-    replacement =
-      spawn(fn ->
-        receive do
-          :stop -> :ok
-        end
-      end)
-
     late_topic = "#{@topic}-partition-late"
 
-    on_exit(fn ->
-      if Process.alive?(late_worker), do: send(late_worker, :stop)
-      if Process.alive?(replacement), do: send(replacement, :stop)
-    end)
-
-    send(reader, {:pulsar_reader_ready, callback_ref, late_worker, late_topic})
-    send(reader, {:pulsar_reader_ready, callback_ref, replacement, late_topic})
+    send(reader, {:pulsar_reader_ready, callback_ref, test_pid, late_topic})
+    send(reader, {:pulsar_reader_ready, callback_ref, worker, late_topic})
     send(reader, :continue)
 
     assert_interrupted(reader, late_topic)
-    assert_receive {:reader_waiting, ^reader}, 5_000
-    assert {:monitors, monitors} = Process.info(reader, :monitors)
-    refute {:process, late_worker} in monitors
-
-    send(reader, :finish)
+    assert_receive {:reader_monitors, ^reader, {:monitors, monitors}}, 5_000
+    refute {:process, test_pid} in monitors
     assert_receive {:DOWN, ^reader_ref, :process, ^reader, :normal}, 5_000
   end
 

--- a/test/integration/reader/interruption_test.exs
+++ b/test/integration/reader/interruption_test.exs
@@ -2,10 +2,12 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
   use Pulsar.Test.Case, async: true
 
   @topic "persistent://public/default/reader-interruption-test"
+  @idle_topic "persistent://public/default/idle-reader-interruption-test"
   @partitioned_topic "persistent://public/default/partitioned-reader-interruption-test"
   @partitions 3
 
   setup_all do
+    :ok = System.create_topic(@idle_topic)
     :ok = System.create_topic(@partitioned_topic, @partitions)
     Utils.seed_topic(@topic, ["message"], client: @client)
     Utils.seed_topic(@partitioned_topic, ["message"], client: @client)
@@ -43,6 +45,44 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
     assert_interrupted(reader, partition_topic)
     assert_receive {:DOWN, ^reader_ref, :process, ^reader, :normal}, 5_000
     assert Pulsar.Client.consumers(@client) == []
+  end
+
+  test "leaves unrelated DOWN messages in the enumerating process mailbox" do
+    test_pid = self()
+
+    unrelated =
+      spawn(fn ->
+        receive do
+          :stop -> exit(:unrelated_failure)
+        end
+      end)
+
+    unrelated_ref = Process.monitor(unrelated)
+
+    trigger =
+      spawn(fn ->
+        [root] =
+          Utils.wait_for(fn -> Pulsar.Client.consumers(@client) end,
+            until: &match?([_root], &1),
+            description: "Reader consumer root to start"
+          )
+
+        :ok = Pulsar.Consumer.await_ready(root)
+        send(unrelated, :stop)
+        send(test_pid, :unrelated_stopped)
+      end)
+
+    on_exit(fn ->
+      if Process.alive?(trigger), do: Process.exit(trigger, :kill)
+      if Process.alive?(unrelated), do: Process.exit(unrelated, :kill)
+    end)
+
+    assert @idle_topic
+           |> Pulsar.Reader.stream(client: @client, timeout: 500)
+           |> Enum.to_list() == []
+
+    assert_receive :unrelated_stopped
+    assert_receive {:DOWN, ^unrelated_ref, :process, ^unrelated, :unrelated_failure}
   end
 
   defp start_paused_reader(topic) do

--- a/test/integration/reader/interruption_test.exs
+++ b/test/integration/reader/interruption_test.exs
@@ -85,7 +85,59 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
     assert_receive {:DOWN, ^unrelated_ref, :process, ^unrelated, :unrelated_failure}
   end
 
-  defp start_paused_reader(topic) do
+  test "flushes monitors added while recursively awaiting a message" do
+    test_pid = self()
+
+    {reader, reader_ref} =
+      start_paused_reader(@topic, fn ->
+        send(test_pid, {:reader_waiting, self()})
+
+        receive do
+          :finish -> :ok
+        end
+      end)
+
+    assert_receive {:reader_message, ^reader, %{payload: "message"}}, 5_000
+
+    [root] = Pulsar.Client.consumers(@client)
+    [worker] = Topology.workers(root)
+    %{callback_state: %{reader_ref: callback_ref}} = :sys.get_state(worker)
+
+    late_worker =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    replacement =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    late_topic = "#{@topic}-partition-late"
+
+    on_exit(fn ->
+      if Process.alive?(late_worker), do: send(late_worker, :stop)
+      if Process.alive?(replacement), do: send(replacement, :stop)
+    end)
+
+    send(reader, {:pulsar_reader_ready, callback_ref, late_worker, late_topic})
+    send(reader, {:pulsar_reader_ready, callback_ref, replacement, late_topic})
+    send(reader, :continue)
+
+    assert_interrupted(reader, late_topic)
+    assert_receive {:reader_waiting, ^reader}, 5_000
+    assert {:monitors, monitors} = Process.info(reader, :monitors)
+    refute {:process, late_worker} in monitors
+
+    send(reader, :finish)
+    assert_receive {:DOWN, ^reader_ref, :process, ^reader, :normal}, 5_000
+  end
+
+  defp start_paused_reader(topic, after_interruption \\ fn -> :ok end) do
     test_pid = self()
 
     {reader, reader_ref} =
@@ -101,7 +153,9 @@ defmodule Pulsar.Integration.Reader.InterruptionTest do
             end
           end)
         rescue
-          error in RuntimeError -> send(test_pid, {:reader_interrupted, self(), error})
+          error in RuntimeError ->
+            send(test_pid, {:reader_interrupted, self(), error})
+            after_interruption.()
         end
       end)
 

--- a/test/integration/reader/interruption_test.exs
+++ b/test/integration/reader/interruption_test.exs
@@ -1,0 +1,80 @@
+defmodule Pulsar.Integration.Reader.InterruptionTest do
+  use Pulsar.Test.Case, async: true
+
+  @topic "persistent://public/default/reader-interruption-test"
+  @partitioned_topic "persistent://public/default/partitioned-reader-interruption-test"
+  @partitions 3
+
+  setup_all do
+    :ok = System.create_topic(@partitioned_topic, @partitions)
+    Utils.seed_topic(@topic, ["message"], client: @client)
+    Utils.seed_topic(@partitioned_topic, ["message"], client: @client)
+
+    :ok
+  end
+
+  test "raises and removes its temporary consumer when its worker exits" do
+    {reader, reader_ref} = start_paused_reader(@topic)
+    assert_receive {:reader_message, ^reader, %{payload: "message"}}, 5_000
+
+    [root] = Pulsar.Client.consumers(@client)
+    [worker] = Topology.workers(root)
+    assert Pulsar.Consumer.topic(worker) == @topic
+
+    Process.exit(worker, :kill)
+    send(reader, :continue)
+
+    assert_interrupted(reader, @topic)
+    assert_receive {:DOWN, ^reader_ref, :process, ^reader, :normal}, 5_000
+    assert Pulsar.Client.consumers(@client) == []
+  end
+
+  test "losing one partition interrupts the whole Reader" do
+    {reader, reader_ref} = start_paused_reader(@partitioned_topic)
+    assert_receive {:reader_message, ^reader, %{payload: "message"}}, 5_000
+
+    [root] = Pulsar.Client.consumers(@client)
+    [worker | _other_workers] = Topology.workers(root)
+    partition_topic = Pulsar.Consumer.topic(worker)
+
+    Process.exit(worker, :kill)
+    send(reader, :continue)
+
+    assert_interrupted(reader, partition_topic)
+    assert_receive {:DOWN, ^reader_ref, :process, ^reader, :normal}, 5_000
+    assert Pulsar.Client.consumers(@client) == []
+  end
+
+  defp start_paused_reader(topic) do
+    test_pid = self()
+
+    {reader, reader_ref} =
+      spawn_monitor(fn ->
+        try do
+          topic
+          |> Pulsar.Reader.stream(client: @client, timeout: :infinity)
+          |> Enum.each(fn message ->
+            send(test_pid, {:reader_message, self(), message})
+
+            receive do
+              :continue -> :ok
+            end
+          end)
+        rescue
+          error in RuntimeError -> send(test_pid, {:reader_interrupted, self(), error})
+        end
+      end)
+
+    on_exit(fn ->
+      if Process.alive?(reader), do: Process.exit(reader, :kill)
+    end)
+
+    {reader, reader_ref}
+  end
+
+  defp assert_interrupted(reader, topic) do
+    assert_receive {:reader_interrupted, ^reader, %RuntimeError{message: message}}, 5_000
+    assert message =~ "reader worker for #{inspect(topic)} was lost"
+    assert message =~ "the non-durable stream cannot continue from a known position"
+  end
+end


### PR DESCRIPTION
Reader streams now fail explicitly when an underlying non-durable consumer worker is lost, preventing silent replay or skipped messages after resubscription. The temporary consumer is removed on failure, including when any partition worker is lost.

Closes #168.