### PR TITLE
feat: route invalid messages through callback

### DIFF
--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -30,7 +30,24 @@ message:
 | `{:stop, reason, state}` | Acknowledge | Finish with `reason` |
 
 The same outcomes apply to `handle_invalid_message/2`. Its default implementation acknowledges
-the invalid message so corrupt data is not redelivered forever.
+the invalid message so corrupt or incomplete data is not redelivered forever. Override it and
+return `{:error, reason, state}` when an invalid-message class should deliberately be retried and,
+with a dead letter policy, eventually diverted:
+
+```elixir
+def handle_invalid_message(
+      %Pulsar.Message{validation_error: :decompression_failed},
+      state
+    ) do
+  {:error, :unreadable_payload, state}
+end
+
+def handle_invalid_message(_message, state), do: {:ok, state}
+```
+
+This needs `:redelivery_interval`; without one the NACK remains outstanding as described below.
+Use individual acknowledgement when a failed message must reach the DLQ: a later cumulative ACK
+can pass it and acknowledge it before it is redelivered.
 
 Most consumers only need automatic acknowledgement:
 

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -68,9 +68,14 @@ def handle_message(%Pulsar.Message{chunk_metadata: %{num_chunks: n}} = message, 
   process(message.payload)
   {:ok, state}
 end
+
+def handle_message(%Pulsar.Message{} = message, state) do
+  process(message.payload)
+  {:ok, state}
+end
 ```
 
-An incomplete chunked message has no application payload and goes to
+An incomplete chunked message has no complete application payload and goes to
 `handle_invalid_message/2`, as described below.
 
 ## Chunked Message Metadata

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -63,24 +63,15 @@ The consumer automatically handles chunk assembly:
 4. **Delivery**: The complete message is delivered to your `handle_message/2` callback
 
 ```elixir
-def handle_message(%Pulsar.Message{} = message, state) do
-  # message.payload contains the complete, reassembled payload
-  # message.chunk_metadata indicates if this was a chunked message
-
-  case message.chunk_metadata do
-    %{chunked: true, complete: true, num_chunks: n} ->
-      IO.puts("Received complete chunked message with #{n} chunks")
-
-    %{chunked: true, complete: false, error: reason} ->
-      IO.puts("Received incomplete chunked message: #{reason}")
-
-    nil ->
-      IO.puts("Received non-chunked message")
-  end
-
+def handle_message(%Pulsar.Message{chunk_metadata: %{num_chunks: n}} = message, state) do
+  IO.puts("Received complete chunked message with #{n} chunks")
+  process(message.payload)
   {:ok, state}
 end
 ```
+
+An incomplete chunked message has no application payload and goes to
+`handle_invalid_message/2`, as described below.
 
 ## Chunked Message Metadata
 
@@ -94,8 +85,8 @@ The `Pulsar.Message` struct provides information about chunked messages:
   - `received_chunks` - Number of chunks received (for incomplete messages)
   - `error` - Reason for incompleteness (if incomplete)
 
-A chunked message is assembled before the callback sees it, so `payload` is the complete
-payload and `message_id` covers every chunk: acknowledging it acknowledges them all.
+A complete chunked message is assembled before `handle_message/2` sees it, so `payload` is the
+complete payload and `message_id` covers every chunk: acknowledging it acknowledges them all.
 
 `Pulsar.Message`'s accessors — `producer_name/1`, `key/1`, `properties/1` and the rest — answer
 the same way for a chunked message as for any other. Only the `raw` field reflects the split,
@@ -157,19 +148,32 @@ Chunks may not complete for several reasons:
 1. **Expiration**: Not all chunks arrived within the timeout period
 2. **Queue overflow**: Too many concurrent chunked messages
 
-Incomplete chunks are delivered to your callback with `complete: false`. Their `payload` is
-whatever chunks did arrive, concatenated, and under `:compression` those are still compressed:
-a message only decompresses once all of its chunks are back together, so a partial one cannot
-be decompressed at all. Treat the payload of an incomplete message as opaque.
+Incomplete chunks are delivered to `handle_invalid_message/2` with
+`validation_error: :incomplete_chunked_message` and `complete: false`. Their `payload` is whatever
+chunks did arrive, concatenated, and under `:compression` those are still compressed: a message
+only decompresses once all of its chunks are back together, so a partial one cannot be decompressed
+at all. Treat the payload of an incomplete message as opaque.
 
 ```elixir
-def handle_message(%Pulsar.Message{chunk_metadata: %{complete: false, error: reason, received_chunks: n}}, state) do
+def handle_invalid_message(
+      %Pulsar.Message{
+        validation_error: :incomplete_chunked_message,
+        chunk_metadata: %{error: reason, received_chunks: n}
+      },
+      state
+    ) do
   Logger.warning("Incomplete chunk: #{reason}, received #{n} chunks")
 
-  # Return error to trigger redelivery
+  # Retry the received chunks. With the default {:ok, state}, they are acknowledged.
   {:error, :incomplete_chunk, state}
 end
 ```
+
+Acknowledging an incomplete message acknowledges only the chunks that arrived and carries no
+wire validation error, because those individual chunks were intact. NACKing may recover the
+logical message if redelivery supplies all chunks. If it eventually reaches a DLQ, however, the
+republished payload is still only the partial bytes held by that delivery, not the original
+logical message.
 
 ## Flow Control and Permits
 
@@ -242,7 +246,7 @@ defmodule MyConsumer do
       process_file(message.payload)
       {:ok, state}
     else
-      # Regular non-chunked message or incomplete chunked message
+      # Regular non-chunked message
       {:ok, state}
     end
   end

--- a/docs/dead_letter_policies.md
+++ b/docs/dead_letter_policies.md
@@ -33,8 +33,8 @@ is diverted to the dead letter topic instead of being handed to your callback:
 With `max_redelivery: 3`, a message your callback keeps rejecting is delivered three times. The fourth
 delivery is diverted, and the callback never sees it:
 
-1. **Deliveries 1 to 3**: `handle_message/2` runs and returns `{:error, reason, state}`, so the message is
-   negatively acknowledged and redelivered
+1. **Deliveries 1 to 3**: `handle_message/2` or `handle_invalid_message/2` runs and returns
+   `{:error, reason, state}`, so the message is negatively acknowledged and redelivered
 2. **Delivery 4**: the count has reached the threshold, so the message is published to the dead letter topic
 3. **Acknowledged**: once the publish succeeds, the message is acknowledged and leaves the subscription
 
@@ -118,6 +118,11 @@ it is carried across:
 
 The two property names are the ones the Java client uses, so a dead letter topic can be consumed by either
 client and read the same way.
+
+For an invalid message, “unchanged” means the bytes the consumer was able to retain, not necessarily
+the payload originally published. A decompression failure carries compressed bytes, a malformed batch
+carries its decoded entry framing, and an incomplete chunked message carries only the chunks that arrived.
+These are useful for inspection but must not be treated as the original application payload.
 
 Reading them back:
 

--- a/lib/pulsar/consumer/callback.ex
+++ b/lib/pulsar/consumer/callback.ex
@@ -44,11 +44,12 @@ defmodule Pulsar.Consumer.Callback do
   - `became_active/1` - Called when this consumer becomes the active consumer of a `:failover` subscription (default: `{:ok, state}`)
   - `became_passive/1` - Called when this consumer becomes a passive (standby) consumer of a `:failover` subscription (default: `{:ok, state}`)
   - `reached_end_of_topic/1` - Called when this consumer has drained a terminated topic (default: `{:ok, state}`)
-  - `handle_invalid_message/2` - Called instead of `handle_message/2` for a message whose
-    bytes could not be trusted (default: log a warning and acknowledge it, so it is not
-    redelivered). Override it to record or divert such messages; see `Pulsar.Message.valid?/1`
-    for what they contain. Because they are routed here, `handle_message/2` only ever
-    receives messages that arrived intact.
+  - `handle_invalid_message/2` - Called instead of `handle_message/2` when no complete
+    application payload could be built: for example, after framing, decompression or batch
+    decoding fails, or when a chunked message expires incomplete (default: log a warning and
+    acknowledge it, so it is not redelivered). Override it to record, retry or divert such
+    messages; see `Pulsar.Message.valid?/1` for what they contain. Because they are routed
+    here, `handle_message/2` only ever receives complete payloads that can be treated as data.
 
   ## Message Format
 
@@ -145,8 +146,11 @@ defmodule Pulsar.Consumer.Callback do
   processed message is acknowledged before the worker stops.
 
   `handle_invalid_message/2` accepts the same results. Its `{:ok, ...}` and `{:stop, ...}`
-  results acknowledge the invalid message with its validation error; `{:noreply, ...}` leaves
-  acknowledgement to the callback, and `{:error, ...}` tracks it for redelivery.
+  results acknowledge the invalid message, including Pulsar's wire validation error when one
+  applies; an incomplete chunk is acknowledged normally because its received bytes were intact.
+  `{:noreply, ...}` leaves acknowledgement to the callback, and `{:error, ...}` tracks the
+  message for redelivery. With a redelivery interval and dead letter policy, repeatedly returning
+  `{:error, ...}` intentionally sends an invalid message through normal DLQ processing.
 
   ### Notification callbacks
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -378,6 +378,12 @@ defmodule Pulsar.Consumer.Worker do
           end
 
         {commands, metadatas, payload, broker_metadatas, chunk_metadata} ->
+          report_invalid_message(
+            state,
+            :incomplete_chunked_message,
+            Map.get(chunk_metadata, :error)
+          )
+
           chunk_metadata_full =
             Map.merge(chunk_metadata, %{
               commands: commands,
@@ -385,7 +391,7 @@ defmodule Pulsar.Consumer.Worker do
               broker_metadatas: broker_metadatas
             })
 
-          message = build_message_from_chunk(chunk_metadata_full, payload)
+          message = build_message_from_chunk(chunk_metadata_full, payload, :incomplete_chunked_message)
           {[message], [], state}
       end
 
@@ -648,8 +654,8 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   defp process_single_message(state, %Pulsar.Message{} = message, nacked_acc) do
-    # Call callback for ALL messages (including incomplete chunks). An invalid one
-    # goes to its own callback, so handle_message/2 can trust what it is given.
+    # Every unusable delivery, including an incomplete chunked message, goes to its own
+    # callback so handle_message/2 can trust what it is given.
     result =
       if Pulsar.Message.valid?(message) do
         state.callback_module.handle_message(message, state.callback_state)
@@ -1091,8 +1097,10 @@ defmodule Pulsar.Consumer.Worker do
   defp compacted_out?(_single_metadata), do: false
 
   defp validation_error(%Pulsar.Message{validation_error: nil}), do: nil
+  defp validation_error(%Pulsar.Message{validation_error: :incomplete_chunked_message}), do: nil
   defp validation_error(%Pulsar.Message{validation_error: :decompression_failed}), do: :DecompressionError
   defp validation_error(%Pulsar.Message{validation_error: :uncompressed_size_corruption}), do: :UncompressedSizeCorruption
+  defp validation_error(%Pulsar.Message{validation_error: :batch_deserialization_failed}), do: :BatchDeSerializeError
   defp validation_error(%Pulsar.Message{}), do: :ChecksumMismatch
 
   # A chunk's uuid lives in the metadata that failed validation, so a corrupt chunk
@@ -1110,8 +1118,23 @@ defmodule Pulsar.Consumer.Worker do
   defp build_messages_from_entry(command, metadata, payload, broker_metadata, state) do
     case maybe_uncompress(metadata, payload) do
       {:ok, uncompressed} ->
-        unwrapped = unwrap_messages(metadata, uncompressed)
-        build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+        case unwrap_messages(metadata, uncompressed) do
+          {:ok, unwrapped} ->
+            build_messages_from_unwrapped(command, metadata, broker_metadata, unwrapped)
+
+          {:error, :batch_deserialization_failed} ->
+            report_invalid_message(state, :batch_deserialization_failed)
+
+            {[
+               build_invalid_message(
+                 command,
+                 uncompressed,
+                 :batch_deserialization_failed,
+                 metadata,
+                 broker_metadata
+               )
+             ], []}
+        end
 
       {:error, reason} ->
         validation_error = report_unreadable_payload(state, reason)
@@ -1161,17 +1184,17 @@ defmodule Pulsar.Consumer.Worker do
     validation_error
   end
 
-  defp report_invalid_message(state, reason) do
+  defp report_invalid_message(state, reason, detail \\ nil) do
     :telemetry.execute(
       [:pulsar, :consumer, :message, :invalid],
       %{count: 1},
       state
       |> consumer_metadata()
-      |> Map.merge(%{reason: reason, decompression_reason: nil, detail: nil})
+      |> Map.merge(%{reason: reason, decompression_reason: nil, detail: detail})
     )
   end
 
-  defp build_message_from_chunk(chunk_metadata, payload, validation_error \\ nil) do
+  defp build_message_from_chunk(chunk_metadata, payload, validation_error) do
     %Pulsar.Message{
       payload: payload,
       message_id: Map.get(chunk_metadata, :message_ids, []),
@@ -1188,20 +1211,25 @@ defmodule Pulsar.Consumer.Worker do
 
   defp unwrap_messages(metadata, payload) do
     if metadata.num_messages_in_batch > 0 do
-      parse_batch_messages(payload, metadata.num_messages_in_batch, [])
+      case parse_batch_messages(payload, metadata.num_messages_in_batch, []) do
+        # `num_messages_in_batch` is an optional proto2 scalar whose default is one. Protox
+        # cannot tell an absent field on a plain message from an explicitly encoded one-message
+        # batch, so failed batch framing is conclusive only when the entry advertises > 1.
+        {:error, :batch_deserialization_failed} when metadata.num_messages_in_batch == 1 ->
+          {:ok, [{nil, payload}]}
+
+        result ->
+          result
+      end
     else
-      [{nil, payload}]
+      {:ok, [{nil, payload}]}
     end
   end
 
-  defp parse_batch_messages(<<>>, 0, acc), do: Enum.reverse(acc)
-  defp parse_batch_messages(_, 0, acc), do: Enum.reverse(acc)
+  defp parse_batch_messages(<<>>, 0, acc), do: {:ok, Enum.reverse(acc)}
+  defp parse_batch_messages(_trailing, 0, _acc), do: {:error, :batch_deserialization_failed}
 
-  defp parse_batch_messages(
-         <<metadata_size::32, metadata::bytes-size(metadata_size), data::binary>> = payload,
-         count,
-         acc
-       ) do
+  defp parse_batch_messages(<<metadata_size::32, metadata::bytes-size(metadata_size), data::binary>>, count, acc) do
     single_metadata = Binary.SingleMessageMetadata.decode(metadata)
 
     payload_size = single_metadata.payload_size
@@ -1212,12 +1240,10 @@ defmodule Pulsar.Consumer.Worker do
 
     parse_batch_messages(rest, count - 1, [message | acc])
   rescue
-    _ -> [{nil, payload}]
+    _ -> {:error, :batch_deserialization_failed}
   end
 
-  defp parse_batch_messages(payload, _, _) do
-    [{nil, payload}]
-  end
+  defp parse_batch_messages(_payload, _count, _acc), do: {:error, :batch_deserialization_failed}
 
   defp chunked_message?(%Binary.MessageMetadata{uuid: uuid, chunk_id: chunk_id})
        when is_binary(uuid) and is_integer(chunk_id) do

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -22,6 +22,18 @@ defmodule Pulsar.Consumer.Worker do
   @zstd_min_buffer_size 64 * 1024
   @zstd_max_buffer_size 1024 * 1024
 
+  # Message.validation_error is client-level. CommandAck accepts Pulsar's narrower enum,
+  # so only reasons with a deliberate mapping are sent over the wire.
+  @wire_validation_errors %{
+    checksum_mismatch: :ChecksumMismatch,
+    malformed_frame: :ChecksumMismatch,
+    malformed_message_metadata: :ChecksumMismatch,
+    malformed_broker_entry_metadata: :ChecksumMismatch,
+    decompression_failed: :DecompressionError,
+    uncompressed_size_corruption: :UncompressedSizeCorruption,
+    batch_deserialization_failed: :BatchDeSerializeError
+  }
+
   defstruct [
     :client,
     :topic,
@@ -377,11 +389,11 @@ defmodule Pulsar.Consumer.Worker do
             {msgs, skipped_ids, state}
           end
 
-        {commands, metadatas, payload, broker_metadatas, chunk_metadata} ->
+        {commands, metadatas, payload, broker_metadatas, %{error: detail} = chunk_metadata} ->
           report_invalid_message(
             state,
             :incomplete_chunked_message,
-            Map.get(chunk_metadata, :error)
+            detail
           )
 
           chunk_metadata_full =
@@ -540,7 +552,7 @@ defmodule Pulsar.Consumer.Worker do
     state =
       Enum.reduce(messages, state, fn %Pulsar.Message{} = message, acc_state ->
         :ok = DeadLetter.divert(producer, message, acc_state.topic)
-        ack_message_ids(acc_state, List.wrap(message.message_id), validation_error(message))
+        ack_message_ids(acc_state, List.wrap(message.message_id), wire_validation_error(message))
       end)
 
     :telemetry.execute(
@@ -667,7 +679,7 @@ defmodule Pulsar.Consumer.Worker do
 
     case result do
       {:ok, new_callback_state} ->
-        state = ack_message_ids(state, message_ids_list, validation_error(message))
+        state = ack_message_ids(state, message_ids_list, wire_validation_error(message))
         {:continue, %{state | callback_state: new_callback_state}, nacked_acc}
 
       {:noreply, new_callback_state} ->
@@ -685,7 +697,7 @@ defmodule Pulsar.Consumer.Worker do
       {:stop, reason, new_callback_state} ->
         # Do not force an entry-level ack for a partial batch: that would also acknowledge the
         # unread suffix. The normal ledger sends the prefix only when batch-index acks are enabled.
-        state = ack_message_ids(state, message_ids_list, validation_error(message))
+        state = ack_message_ids(state, message_ids_list, wire_validation_error(message))
         {:stop, reason, %{state | callback_state: new_callback_state}, nacked_acc}
     end
   end
@@ -1096,12 +1108,7 @@ defmodule Pulsar.Consumer.Worker do
   defp compacted_out?(%Binary.SingleMessageMetadata{compacted_out: true}), do: true
   defp compacted_out?(_single_metadata), do: false
 
-  defp validation_error(%Pulsar.Message{validation_error: nil}), do: nil
-  defp validation_error(%Pulsar.Message{validation_error: :incomplete_chunked_message}), do: nil
-  defp validation_error(%Pulsar.Message{validation_error: :decompression_failed}), do: :DecompressionError
-  defp validation_error(%Pulsar.Message{validation_error: :uncompressed_size_corruption}), do: :UncompressedSizeCorruption
-  defp validation_error(%Pulsar.Message{validation_error: :batch_deserialization_failed}), do: :BatchDeSerializeError
-  defp validation_error(%Pulsar.Message{}), do: :ChecksumMismatch
+  defp wire_validation_error(%Pulsar.Message{validation_error: error}), do: @wire_validation_errors[error]
 
   # A chunk's uuid lives in the metadata that failed validation, so a corrupt chunk
   # cannot be tied back to its siblings; those expire as an incomplete message.
@@ -1212,9 +1219,9 @@ defmodule Pulsar.Consumer.Worker do
   defp unwrap_messages(metadata, payload) do
     if metadata.num_messages_in_batch > 0 do
       case parse_batch_messages(payload, metadata.num_messages_in_batch, []) do
-        # `num_messages_in_batch` is an optional proto2 scalar whose default is one. Protox
-        # cannot tell an absent field on a plain message from an explicitly encoded one-message
-        # batch, so failed batch framing is conclusive only when the entry advertises > 1.
+        # `num_messages_in_batch` is an optional proto2 scalar whose default is one. The generated
+        # struct cannot tell an absent field on a plain message from an explicitly encoded
+        # one-message batch, so failed batch framing is conclusive only when the entry advertises > 1.
         {:error, :batch_deserialization_failed} when metadata.num_messages_in_batch == 1 ->
           {:ok, [{nil, payload}]}
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -1216,22 +1216,10 @@ defmodule Pulsar.Consumer.Worker do
     }
   end
 
-  defp unwrap_messages(metadata, payload) do
-    if metadata.num_messages_in_batch > 0 do
-      case parse_batch_messages(payload, metadata.num_messages_in_batch, []) do
-        # `num_messages_in_batch` is an optional proto2 scalar whose default is one. The generated
-        # struct cannot tell an absent field on a plain message from an explicitly encoded
-        # one-message batch, so failed batch framing is conclusive only when the entry advertises > 1.
-        {:error, :batch_deserialization_failed} when metadata.num_messages_in_batch == 1 ->
-          {:ok, [{nil, payload}]}
+  defp unwrap_messages(%Binary.MessageMetadata{num_messages_in_batch: count}, payload)
+       when is_integer(count) and count > 0, do: parse_batch_messages(payload, count, [])
 
-        result ->
-          result
-      end
-    else
-      {:ok, [{nil, payload}]}
-    end
-  end
+  defp unwrap_messages(%Binary.MessageMetadata{}, payload), do: {:ok, [{nil, payload}]}
 
   defp parse_batch_messages(<<>>, 0, acc), do: {:ok, Enum.reverse(acc)}
   defp parse_batch_messages(_trailing, 0, _acc), do: {:error, :batch_deserialization_failed}

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -305,8 +305,7 @@ defmodule Pulsar.Message do
 
   # A payload that failed after its metadata was decoded keeps its batch count.
   def num_broker_messages(%__MODULE__{validation_error: error, raw: %{metadata: %{num_messages_in_batch: count}}})
-      when error in [:decompression_failed, :uncompressed_size_corruption, :batch_deserialization_failed] and
-             is_integer(count) and count > 0 do
+      when not is_nil(error) and is_integer(count) and count > 0 do
     count
   end
 

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -17,9 +17,9 @@ defmodule Pulsar.Message do
     For complete chunked messages: `%{chunked: true, complete: true, uuid: "...", num_chunks: N}`
     For incomplete chunked messages: `%{chunked: true, complete: false, error: :reason, uuid: "..."}`
 
-  - `validation_error` - `nil` for messages that arrived intact. Otherwise why `payload` cannot
-    be treated as data: the frame could not be read, or it could and its payload did not
-    decompress. See `valid?/1`.
+  - `validation_error` - `nil` when `payload` is a complete message that can be treated as
+    data. Otherwise why it cannot: the frame could not be read, its payload could not be
+    decompressed or unbatched, or some chunks never arrived. See `valid?/1`.
 
   - `raw` - The underlying protocol structs, as a map of `:command`, `:metadata`,
     `:single_metadata` and `:broker_metadata`. **Unstable**: its shape follows the wire
@@ -305,7 +305,8 @@ defmodule Pulsar.Message do
 
   # A payload that failed after its metadata was decoded keeps its batch count.
   def num_broker_messages(%__MODULE__{validation_error: error, raw: %{metadata: %{num_messages_in_batch: count}}})
-      when error in [:decompression_failed, :uncompressed_size_corruption] and is_integer(count) and count > 0 do
+      when error in [:decompression_failed, :uncompressed_size_corruption, :batch_deserialization_failed] and
+             is_integer(count) and count > 0 do
     count
   end
 
@@ -359,9 +360,9 @@ defmodule Pulsar.Message do
   def complete?(%__MODULE__{}), do: true
 
   @doc """
-  Returns `true` if the message arrived intact, `false` if it did not.
+  Returns `true` if the message is complete and its payload can be treated as data.
 
-  A message is invalid when its bytes could not be turned into a payload, and
+  A message is invalid when its bytes could not be turned into a complete payload, and
   `validation_error` says why:
 
   - The frame itself could not be read: `:checksum_mismatch` when it failed its CRC32C check,
@@ -374,6 +375,12 @@ defmodule Pulsar.Message do
   - `:uncompressed_size_corruption` - the decoded or reassembled payload did not match the
     size advertised by the producer. `metadata` is kept and `payload` holds the bytes as they
     arrived, still compressed when compression was enabled.
+  - `:batch_deserialization_failed` - the entry advertised a batch, but its individual message
+    frames could not be read. `metadata` is kept and `payload` holds the decompressed batch
+    bytes rather than an individual application message.
+  - `:incomplete_chunked_message` - the client gave up waiting for every chunk. Match
+    `chunk_metadata.error` to distinguish `:expired` from `:queue_full`; `payload` is the
+    concatenation of only the chunks that arrived and may still be compressed.
 
   Any of them is delivered so the callback can record or divert it, but no such payload may be
   treated as data. Match `validation_error` with a catch-all: more reasons may be added.
@@ -389,12 +396,14 @@ defmodule Pulsar.Message do
       iex> Pulsar.Message.valid?(%Pulsar.Message{validation_error: :checksum_mismatch})
       false
 
-  Validity is independent of chunk completeness — an incomplete chunked message is
-  still made of bytes that arrived intact:
+  An incomplete chunked message is invalid even though each chunk it contains arrived intact:
 
-      iex> expired = %Pulsar.Message{chunk_metadata: %{chunked: true, complete: false}}
+      iex> expired = %Pulsar.Message{
+      ...>   validation_error: :incomplete_chunked_message,
+      ...>   chunk_metadata: %{chunked: true, complete: false, error: :expired}
+      ...> }
       iex> {Pulsar.Message.valid?(expired), Pulsar.Message.complete?(expired)}
-      {true, false}
+      {false, false}
 
       def handle_invalid_message(%Pulsar.Message{} = message, state) do
         Logger.error("dropping corrupt message: \#{message.validation_error}")
@@ -402,6 +411,6 @@ defmodule Pulsar.Message do
       end
   """
   @spec valid?(t()) :: boolean()
-  def valid?(%__MODULE__{validation_error: nil}), do: true
+  def valid?(%__MODULE__{validation_error: nil} = message), do: complete?(message)
   def valid?(%__MODULE__{}), do: false
 end

--- a/lib/pulsar/producer/worker.ex
+++ b/lib/pulsar/producer/worker.ex
@@ -583,7 +583,7 @@ defmodule Pulsar.Producer.Worker do
 
     compressed_payload = maybe_compress(message_metadata, single_messages_payload)
 
-    encoded_frame = Protocol.encode(command_send, message_metadata, compressed_payload)
+    encoded_frame = Protocol.encode_batch(command_send, message_metadata, compressed_payload)
 
     case Pulsar.Broker.publish_message(state.broker_pid, encoded_frame) do
       :ok ->

--- a/lib/pulsar/protocol.ex
+++ b/lib/pulsar/protocol.ex
@@ -2,6 +2,7 @@ defmodule Pulsar.Protocol do
   # https://pulsar.apache.org/docs/next/developing-binary-protocol/#framing
   @moduledoc false
 
+  alias Google.Protobuf.Empty
   alias Pulsar.Protocol.Binary.Pulsar.Proto, as: Binary
 
   # A command's field in the BaseCommand oneof carries the same protobuf tag as
@@ -44,6 +45,11 @@ defmodule Pulsar.Protocol do
 
   @magic_crc32c 0x0E01
   @magic_broker_entry_metadata 0x0E02
+
+  @num_messages_in_batch_field 11
+  # protobuf-elixir omits optional proto2 scalars set to their declared default. A one-message
+  # batch still needs field 11 on the wire so consumers can distinguish it from a plain message.
+  @one_message_batch_marker <<0x58, 0x01>>
 
   # Protobuf does not enforce proto2 required fields when decoding, so an absent
   # one arrives as nil rather than an error. The structs decoded from a frame, and
@@ -90,8 +96,15 @@ defmodule Pulsar.Protocol do
   def encode(command), do: frame(encode_base_command(command), <<>>)
 
   @spec encode(struct(), struct(), binary()) :: binary()
-  def encode(command_send, message_metadata, payload) do
-    frame(encode_base_command(command_send), message_part(message_metadata, payload))
+  def encode(command_send, message_metadata, payload), do: encode_message(command_send, message_metadata, payload, false)
+
+  @doc false
+  @spec encode_batch(struct(), struct(), binary()) :: binary()
+  def encode_batch(command_send, message_metadata, payload),
+    do: encode_message(command_send, message_metadata, payload, true)
+
+  defp encode_message(command_send, message_metadata, payload, batch?) do
+    frame(encode_base_command(command_send), message_part(message_metadata, payload, batch?))
   end
 
   defp encode_base_command(command) do
@@ -105,12 +118,18 @@ defmodule Pulsar.Protocol do
 
   # The counterpart of decode_message/3: the checksum covers the metadata size,
   # metadata and payload, and nothing else.
-  defp message_part(message_metadata, payload) do
-    metadata = Binary.MessageMetadata.encode(message_metadata)
+  defp message_part(message_metadata, payload, batch?) do
+    metadata = encode_message_metadata(message_metadata, batch?)
     checksummed = <<byte_size(metadata)::32, metadata::binary, payload::binary>>
 
     <<@magic_crc32c::16, :crc32cer.nif(checksummed)::32, checksummed::binary>>
   end
+
+  defp encode_message_metadata(%Binary.MessageMetadata{num_messages_in_batch: 1} = metadata, true) do
+    Binary.MessageMetadata.encode(metadata) <> @one_message_batch_marker
+  end
+
+  defp encode_message_metadata(metadata, _batch?), do: Binary.MessageMetadata.encode(metadata)
 
   defp frame(command, rest) do
     command_size = byte_size(command)
@@ -296,7 +315,24 @@ defmodule Pulsar.Protocol do
   defp decode_broker_entry_metadata(binary),
     do: decode_protobuf(Binary.BrokerEntryMetadata, binary, :malformed_broker_entry_metadata)
 
-  defp decode_message_metadata(binary), do: decode_protobuf(Binary.MessageMetadata, binary, :malformed_message_metadata)
+  defp decode_message_metadata(binary) do
+    with {:ok, metadata} <- decode_protobuf(Binary.MessageMetadata, binary, :malformed_message_metadata) do
+      count = if batch_count_present?(binary), do: metadata.num_messages_in_batch, else: 0
+      {:ok, %{metadata | num_messages_in_batch: count}}
+    end
+  end
+
+  defp batch_count_present?(binary) do
+    # Decode against an empty schema so every raw field is retained as unknown. This recovers
+    # presence without teaching the client how to parse protobuf wire types itself.
+    binary
+    |> Empty.decode()
+    |> Protobuf.get_unknown_fields()
+    |> Enum.any?(fn
+      {@num_messages_in_batch_field, _wire_type, _value} -> true
+      _other -> false
+    end)
+  end
 
   defp decode_protobuf(module, binary, reason) do
     decoded = module.decode(binary)

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -451,6 +451,12 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
     assert metadata.partition == nil
     assert metadata.subscription_name == "chunking-evict"
 
+    assert_receive {:consumer, ^consumer,
+                    %{
+                      validation_error: :incomplete_chunked_message,
+                      chunk_metadata: %{complete: false, error: :queue_full, uuid: "fake-uuid-oldest"}
+                    }}
+
     assert_receive {:consumer, ^consumer, %{payload: ^large_message} = received_msg}
     assert received_msg.chunk_metadata.chunked
     assert received_msg.chunk_metadata.complete

--- a/test/support/dummy_consumer.ex
+++ b/test/support/dummy_consumer.ex
@@ -44,10 +44,6 @@ defmodule Pulsar.Test.Support.DummyConsumer do
   """
   def register(consumer_pid, pid), do: GenServer.call(consumer_pid, {:forward_to, pid})
 
-  def handle_message(%Pulsar.Message{chunk_metadata: %{chunked: true, complete: false}}, state) do
-    {:error, :incomplete_chunk, state}
-  end
-
   def handle_message(%Pulsar.Message{} = message, state) do
     notify(state.forward_to, {:consumer, self(), message})
 

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -695,7 +695,7 @@ defmodule Pulsar.Consumer.BatchAckTest do
       sequence_id: 0,
       publish_time: 0,
       compression: :NONE,
-      num_messages_in_batch: 1
+      num_messages_in_batch: 0
     }
 
     {:noreply, new_state} = Worker.handle_info({:broker_message, {command, metadata, payload, nil}}, state)

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -29,8 +29,10 @@ defmodule Pulsar.Consumer.BatchAckTest do
       send(self(), {:delivered, message.payload})
 
       case Map.get(answers, message.payload, :ack) do
+        :ack -> {:ok, answers}
+        :defer -> {:noreply, answers}
+        :nack -> {:error, :rejected_invalid_message, answers}
         {:stop, reason} -> {:stop, reason, answers}
-        _other -> {:ok, answers}
       end
     end
   end
@@ -93,6 +95,18 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert_received {:delivered, "invalid"}
       assert [ack] = acks()
       assert ack.validation_error == :ChecksumMismatch
+    end
+
+    test "an invalid-message callback can opt into redelivery" do
+      state = worker_state(%{"invalid" => :nack}, redelivery_interval: 100)
+      command = %Binary.CommandMessage{consumer_id: 1, message_id: message_id()}
+      delivery = {:broker_message, {:invalid, command, "invalid", :checksum_mismatch}}
+
+      assert {:noreply, state} = Worker.handle_info(delivery, state)
+      assert_received {:delivered, "invalid"}
+      assert acks() == []
+      assert [%{batch_index: -1} = id] = MapSet.to_list(state.acks.nacked)
+      assert {id.ledgerId, id.entryId} == {@ledger, @entry}
     end
 
     test "acknowledges the entry once, after the last message in it is acked" do

--- a/test/unit/consumer_batch_ack_test.exs
+++ b/test/unit/consumer_batch_ack_test.exs
@@ -109,6 +109,17 @@ defmodule Pulsar.Consumer.BatchAckTest do
       assert {id.ledgerId, id.entryId} == {@ledger, @entry}
     end
 
+    test "does not invent a wire validation error for an unknown high-level reason" do
+      state = worker_state(%{})
+      command = %Binary.CommandMessage{consumer_id: 1, message_id: message_id()}
+      delivery = {:broker_message, {:invalid, command, "invalid", :future_validation_error}}
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, state)
+      assert_received {:delivered, "invalid"}
+      assert [ack] = acks()
+      assert ack.validation_error == nil
+    end
+
     test "acknowledges the entry once, after the last message in it is acked" do
       deliver(worker_state(%{}), ["a", "b", "c"])
 

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -216,6 +216,32 @@ defmodule Pulsar.Consumer.WorkerTest do
     assert invalid.message_id == command.message_id
   end
 
+  describe "a batch whose framing cannot be read" do
+    setup do
+      payload = <<"not two framed messages">>
+      delivery = delivery(:NONE, payload, num_messages_in_batch: 2)
+
+      {:ok, delivery: delivery, payload: payload}
+    end
+
+    test "reaches handle_invalid_message/2 with the decompressed entry bytes", ctx do
+      assert {:noreply, _state} = Worker.handle_info(ctx.delivery, reporting_state())
+
+      assert_received {:invalid, invalid}
+      refute_received {:handled, _message}
+      assert invalid.validation_error == :batch_deserialization_failed
+      assert invalid.payload == ctx.payload
+      assert Pulsar.Message.num_broker_messages(invalid) == 2
+    end
+
+    test "acknowledges it with the protocol's batch deserialization error", ctx do
+      Worker.handle_info(ctx.delivery, reporting_state())
+
+      assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
+      assert ack.validation_error == :BatchDeSerializeError
+    end
+  end
+
   describe "a payload that cannot be decompressed" do
     for compression <- [:ZLIB, :LZ4, :ZSTD, :SNAPPY] do
       test "reaches handle_invalid_message/2 under #{compression}" do
@@ -309,8 +335,7 @@ defmodule Pulsar.Consumer.WorkerTest do
 
       Worker.handle_info(delivery(:ZSTD, <<"garbage">>, uncompressed_size: 64), reporting_state())
 
-      assert_received {:telemetry, %{count: 1}, metadata}
-      assert metadata.reason == :decompression_failed
+      assert_received {:telemetry, %{count: 1}, %{reason: :decompression_failed} = metadata}
       assert metadata.decompression_reason == :decompression_error
       assert metadata.topic == "persistent://public/default/orders-partition-2"
     end
@@ -505,6 +530,23 @@ defmodule Pulsar.Consumer.WorkerTest do
       assert_received {:telemetry, measurements, metadata}
       assert measurements.received_chunks == 2
       assert metadata.uuid == "orders-producer-1"
+    end
+
+    test "reaches handle_invalid_message/2 and acknowledges its intact chunks normally", ctx do
+      {:noreply, _state} = Worker.handle_info(:cleanup_expired_chunks, age(ctx.state, 200))
+      assert_receive {:broker_message, incomplete_delivery}
+
+      assert {:noreply, _state} =
+               Worker.handle_info({:broker_message, incomplete_delivery}, ctx.state)
+
+      assert_received {:invalid, invalid}
+      refute_received {:handled, _message}
+      assert invalid.validation_error == :incomplete_chunked_message
+      assert invalid.chunk_metadata.error == :expired
+
+      assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
+      assert ack.validation_error == nil
+      assert length(ack.message_id) == 2
     end
 
     test "is left alone while it still has time", ctx do

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -101,6 +101,15 @@ defmodule Pulsar.Consumer.WorkerTest do
     {:broker_message, {command, metadata, payload, nil}}
   end
 
+  defp batch_payload(payloads) do
+    payloads
+    |> Enum.map(fn payload ->
+      metadata = Binary.SingleMessageMetadata.encode(%Binary.SingleMessageMetadata{payload_size: byte_size(payload)})
+      <<byte_size(metadata)::32, metadata::binary, payload::binary>>
+    end)
+    |> IO.iodata_to_binary()
+  end
+
   defp chunk_delivery(chunk_id, payload, opts) do
     delivery(
       :ZLIB,
@@ -239,6 +248,33 @@ defmodule Pulsar.Consumer.WorkerTest do
 
       assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
       assert ack.validation_error == :BatchDeSerializeError
+    end
+
+    test "rejects a batch that ends before its advertised message count" do
+      payload = batch_payload(["only one"])
+      delivery = delivery(:NONE, payload, num_messages_in_batch: 2)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+      assert_received {:invalid, %{validation_error: :batch_deserialization_failed}}
+      refute_received {:handled, _message}
+    end
+
+    test "rejects trailing bytes after the advertised batch" do
+      payload = batch_payload(["first", "second"]) <> "trailing"
+      delivery = delivery(:NONE, payload, num_messages_in_batch: 2)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+      assert_received {:invalid, %{validation_error: :batch_deserialization_failed}}
+      refute_received {:handled, _message}
+    end
+
+    test "treats failed one-message batch framing as an ordinary message" do
+      payload = "ordinary payload"
+      delivery = delivery(:NONE, payload, num_messages_in_batch: 1)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+      assert_received {:handled, %{payload: ^payload}}
+      refute_received {:invalid, _message}
     end
   end
 

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -95,7 +95,12 @@ defmodule Pulsar.Consumer.WorkerTest do
   end
 
   defp delivery(compression, payload, opts) do
-    metadata = struct(Binary.MessageMetadata, [producer_name: "orders-producer", compression: compression] ++ opts)
+    metadata =
+      struct(
+        Binary.MessageMetadata,
+        [producer_name: "orders-producer", compression: compression, num_messages_in_batch: 0] ++ opts
+      )
+
     command = %Binary.CommandMessage{message_id: %Binary.MessageIdData{ledgerId: 1, entryId: 1}}
 
     {:broker_message, {command, metadata, payload, nil}}
@@ -268,9 +273,18 @@ defmodule Pulsar.Consumer.WorkerTest do
       refute_received {:handled, _message}
     end
 
-    test "treats failed one-message batch framing as an ordinary message" do
-      payload = "ordinary payload"
+    test "rejects malformed framing in an explicitly marked one-message batch" do
+      payload = "malformed batch"
       delivery = delivery(:NONE, payload, num_messages_in_batch: 1)
+
+      assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
+      assert_received {:invalid, %{validation_error: :batch_deserialization_failed}}
+      refute_received {:handled, _message}
+    end
+
+    test "does not batch-parse an ordinary message" do
+      payload = "ordinary payload"
+      delivery = delivery(:NONE, payload, [])
 
       assert {:noreply, _state} = Worker.handle_info(delivery, reporting_state())
       assert_received {:handled, %{payload: ^payload}}

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -24,6 +24,32 @@ defmodule Pulsar.MessageTest do
     assert Message.num_broker_messages(message) == 3
   end
 
+  test "num_broker_messages/1 preserves a batch count when its framing is unreadable" do
+    message = %Message{
+      validation_error: :batch_deserialization_failed,
+      raw: %{metadata: %{num_messages_in_batch: 3}}
+    }
+
+    assert Message.num_broker_messages(message) == 3
+  end
+
+  test "an incomplete chunked message is invalid with its cause kept in chunk metadata" do
+    message = %Message{
+      validation_error: :incomplete_chunked_message,
+      chunk_metadata: %{chunked: true, complete: false, error: :expired}
+    }
+
+    refute Message.valid?(message)
+    refute Message.complete?(message)
+    assert message.chunk_metadata.error == :expired
+  end
+
+  test "valid?/1 rejects an incomplete chunk even if a caller omitted its validation error" do
+    message = %Message{chunk_metadata: %{chunked: true, complete: false, error: :expired}}
+
+    refute Message.valid?(message)
+  end
+
   # The point of the accessors: the same question has one answer whether the broker delivered
   # the message on its own, inside a batch, or split across chunks.
   describe "accessors across delivery shapes" do

--- a/test/unit/message_test.exs
+++ b/test/unit/message_test.exs
@@ -33,6 +33,15 @@ defmodule Pulsar.MessageTest do
     assert Message.num_broker_messages(message) == 3
   end
 
+  test "num_broker_messages/1 preserves decoded batch counts for future validation reasons" do
+    message = %Message{
+      validation_error: :future_validation_error,
+      raw: %{metadata: %{num_messages_in_batch: 3}}
+    }
+
+    assert Message.num_broker_messages(message) == 3
+  end
+
   test "an incomplete chunked message is invalid with its cause kept in chunk metadata" do
     message = %Message{
       validation_error: :incomplete_chunked_message,

--- a/test/unit/protocol_test.exs
+++ b/test/unit/protocol_test.exs
@@ -140,8 +140,15 @@ defmodule Pulsar.ProtocolTest do
 
       assert {:ok, {command, metadata, payload, nil}} = Protocol.decode(frame)
       assert command == ctx.command
-      assert metadata == ctx.metadata
+      assert metadata == %{ctx.metadata | num_messages_in_batch: 0}
       assert payload == ctx.payload
+    end
+
+    test "preserves an explicit one-message batch marker", ctx do
+      frame = Protocol.encode_batch(ctx.command, ctx.metadata, ctx.payload)
+
+      assert {:ok, {_command, metadata, _payload, nil}} = Protocol.decode(frame)
+      assert metadata.num_messages_in_batch == 1
     end
 
     test "handles an empty payload", ctx do
@@ -302,7 +309,7 @@ defmodule Pulsar.ProtocolTest do
       frame = message_frame(command, metadata, "payload")
 
       assert {:ok, {^command, decoded_metadata, "payload", nil}} = Protocol.decode(frame)
-      assert decoded_metadata == metadata
+      assert decoded_metadata == %{metadata | num_messages_in_batch: 0}
     end
 
     test "decodes a MESSAGE frame with broker entry metadata" do
@@ -313,7 +320,7 @@ defmodule Pulsar.ProtocolTest do
       frame = message_frame(command, metadata, "payload", broker_entry_metadata: broker_entry)
 
       assert {:ok, {^command, decoded_metadata, "payload", decoded_broker_entry}} = Protocol.decode(frame)
-      assert decoded_metadata == metadata
+      assert decoded_metadata == %{metadata | num_messages_in_batch: 0}
       assert decoded_broker_entry == broker_entry
     end
 
@@ -335,7 +342,7 @@ defmodule Pulsar.ProtocolTest do
         assert {:ok, {^command, decoded_metadata, "payload", decoded_broker_entry}} = Protocol.decode(frame),
                "failed to decode a frame with #{label}"
 
-        assert decoded_metadata == metadata
+        assert decoded_metadata == %{metadata | num_messages_in_batch: 0}
         assert decoded_broker_entry == expected_broker_entry
       end
     end


### PR DESCRIPTION
### Summary

- Route malformed batches and incomplete chunked messages through `handle_invalid_message/2`.
- Reuse `Pulsar.Message.validation_error`, while retaining the specific incomplete-chunk cause in `chunk_metadata.error`.
- Keep invalid messages ACKed by default, while allowing callbacks to NACK them for redelivery and eventual DLQ routing.

[elixir-protobuf](https://github.com/elixir-protobuf/protobuf) "Skip encoding for fields if they match their user-defined default in proto2." (see [here](https://github.com/elixir-protobuf/protobuf/blob/main/CHANGELOG.md?utm_source=chatgpt.com#bug-fixes-8)). Thus, we need to implement a small, bespoke solution (see [here](https://github.com/efcasado/pulsar-elixir/pull/214#discussion_r3838151166)). This may be a bug in `elixir-protobuf`, but needs further investigation. More context [here](https://github.com/elixir-protobuf/protobuf/commit/3f077f8d12a66fb57fee41ae1c2334b349c9cfe6) and [here](https://github.com/elixir-protobuf/protobuf/pull/219). `Proto2` optional fields have presence semantics (see [here](https://protobuf.dev/programming-guides/field_presence/)).

Closes #206.
