### PR TITLE
refactor(test): stop using Utils.wait_for/2

### DIFF
--- a/test/integration/client/escalation_test.exs
+++ b/test/integration/client/escalation_test.exs
@@ -4,7 +4,6 @@ defmodule Pulsar.Integration.Client.EscalationTest do
   alias Pulsar.Client
   alias Pulsar.Test.Support.DummyConsumer
   alias Pulsar.Test.Support.System
-  alias Pulsar.Test.Support.Utils
   alias Pulsar.Topology
 
   @moduletag :integration
@@ -64,12 +63,10 @@ defmodule Pulsar.Integration.Client.EscalationTest do
         startup_delay_ms: 30_000
       )
 
-    # Its worker exists but has not subscribed: await_ready/2 would sit out the whole delay.
-    [worker] =
-      Utils.wait_for(fn -> Topology.workers(consumer) end,
-        until: &match?([_worker], &1),
-        description: "the delayed worker to be started"
-      )
+    # The topology-only barrier returns once the worker exists, without waiting for its delayed
+    # subscription to become ready.
+    :ok = Topology.await_ready(consumer, 10_000)
+    [worker] = Topology.workers(consumer)
 
     ref = Process.monitor(worker)
 

--- a/test/integration/client/reliability_test.exs
+++ b/test/integration/client/reliability_test.exs
@@ -90,11 +90,8 @@ defmodule Pulsar.Integration.Client.ReliabilityTest do
     restart.(before)
     assert_receive {:DOWN, ^ref, :process, ^before, _reason}
 
-    [after_restart] =
-      Utils.wait_for(fn -> Topology.workers(group) end,
-        until: &match?([worker] when worker != before, &1),
-        description: "replacement topology worker to start"
-      )
+    :ok = facade.await_ready(group)
+    [after_restart] = Topology.workers(group)
 
     refute Process.alive?(before)
     assert Process.alive?(group)

--- a/test/integration/consumer/chunking_test.exs
+++ b/test/integration/consumer/chunking_test.exs
@@ -162,12 +162,9 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
       )
 
     assert byte_size(very_large_message) == 6_291_456
+    :ok = Pulsar.Producer.await_ready(producer)
 
-    Utils.wait_for(
-      fn -> Pulsar.Producer.send(producer, very_large_message) end,
-      until: &(&1 == {:error, :message_too_large}),
-      description: "the producer to refuse the oversized message"
-    )
+    assert Pulsar.Producer.send(producer, very_large_message) == {:error, :message_too_large}
 
     # Reaching the broker with this would have closed the connection.
     assert {:ok, _msg_id} = Pulsar.Producer.send(producer, "still connected")
@@ -383,11 +380,10 @@ defmodule Pulsar.Integration.Consumer.ChunkingTest do
         chunking_enabled: true
       )
 
-    Utils.wait_for(
-      fn -> Pulsar.Producer.send(producer, "small payload", properties: oversized_properties) end,
-      until: &(&1 == {:error, :metadata_too_large}),
-      description: "the producer to refuse the oversized metadata"
-    )
+    :ok = Pulsar.Producer.await_ready(producer)
+
+    assert Pulsar.Producer.send(producer, "small payload", properties: oversized_properties) ==
+             {:error, :metadata_too_large}
   end
 
   @tag telemetry_listen: [[:pulsar, :consumer, :chunk, :discarded]]

--- a/test/integration/consumer/subscription_options_test.exs
+++ b/test/integration/consumer/subscription_options_test.exs
@@ -251,8 +251,6 @@ defmodule Pulsar.Integration.Consumer.SubscriptionOptionsTest do
   test "read_compacted reads the last message per key, not every message", %{expected_count: expected_count} do
     :ok = System.compact_topic(@topic)
 
-    Utils.wait_for(fn -> System.compacted_topic?(@topic) end)
-
     {:ok, compacted_group} =
       Pulsar.Consumer.start(
         @topic,

--- a/test/integration/producer/access_modes_test.exs
+++ b/test/integration/producer/access_modes_test.exs
@@ -109,15 +109,14 @@ defmodule Pulsar.Integration.AccessModesTest do
         client: @client
       )
 
-    # await_ready/2 would wait out its whole timeout here: this producer is queued behind the
-    # exclusive one and stays unready until that one goes.
-    [producer_2] = Utils.wait_for(fn -> Topology.workers(group_pid_2) end, until: &match?([_], &1))
+    # The topology-only barrier returns once the queued worker exists, without waiting for the
+    # exclusive producer to release the topic.
+    :ok = Topology.await_ready(group_pid_2, 10_000)
+    [producer_2] = Topology.workers(group_pid_2)
+    producer_2_state = :sys.get_state(producer_2)
 
-    Utils.wait_for(fn ->
-      String.starts_with?(:sys.get_state(producer_2).producer_name || "", "waiting-producer-2")
-    end)
-
-    refute :sys.get_state(producer_2).ready
+    assert String.starts_with?(producer_2_state.producer_name, "waiting-producer-2")
+    refute producer_2_state.ready
 
     assert {:ok, _} = Pulsar.Producer.send(group_pid_1, "Message from first producer", client: @client)
 

--- a/test/integration/producer/batch_test.exs
+++ b/test/integration/producer/batch_test.exs
@@ -208,15 +208,17 @@ defmodule Pulsar.Integration.Producer.BatchTest do
       # Neither fills the batch, so both wait for a flush that nothing has scheduled yet.
       pending =
         Enum.map(["batched-1", "batched-2"], fn payload ->
-          Task.async(fn -> Pulsar.Producer.send(producer_pid, payload) end)
+          {:ok, ref} = Pulsar.Producer.send_async(producer_pid, payload)
+          ref
         end)
 
-      # Both are queued before the delayed one arrives, so it is what flushes them.
-      Utils.wait_for(fn -> :sys.get_state(producer).batched == 2 end)
+      # Sent from this process, so the state call is handled after both casts. Both are queued
+      # before the delayed one arrives, making it the send that flushes them.
+      assert :sys.get_state(producer).batched == 2
 
       assert {:ok, _message_id} = Pulsar.Producer.send(producer_pid, "delayed-1", deliver_at_time: deliver_at)
 
-      assert Enum.all?(Task.await_many(pending, 10_000), &match?({:ok, _}, &1))
+      assert Enum.all?(Enum.map(pending, &Pulsar.Producer.await(&1, 10_000)), &match?({:ok, _}, &1))
 
       messages = assert_messages_received(consumer_pid, ["batched-1", "batched-2", "delayed-1"])
       delayed = Enum.find(messages, &(&1.payload == "delayed-1"))

--- a/test/support/system.ex
+++ b/test/support/system.ex
@@ -1,6 +1,5 @@
 defmodule Pulsar.Test.Support.System do
   @moduledoc false
-  alias Pulsar.Test.Support.Utils
 
   require Logger
 
@@ -40,9 +39,10 @@ defmodule Pulsar.Test.Support.System do
 
   def start_pulsar do
     Logger.info("Starting Pulsar ...")
-    {_output, 0} = System.cmd("docker", ["compose", "up", "-d"], stderr_to_stdout: true)
 
-    Utils.wait_for(&brokers_up?/0)
+    {_output, 0} =
+      System.cmd("docker", ["compose", "up", "-d", "--wait", "--wait-timeout", "120"], stderr_to_stdout: true)
+
     :ok
   end
 
@@ -221,13 +221,33 @@ defmodule Pulsar.Test.Support.System do
   end
 
   def compact_topic(topic, broker \\ broker()) do
-    command = [
+    compact = [
       "bin/pulsar-admin",
       "--admin-url",
       broker.admin_url,
       "topics",
       "compact",
       topic
+    ]
+
+    case docker_exec(broker.container, compact) do
+      {_output, 0} ->
+        await_compaction(topic, broker)
+
+      {error_output, exit_code} ->
+        {:error, %{exit_code: exit_code, message: error_output}}
+    end
+  end
+
+  defp await_compaction(topic, broker) do
+    command = [
+      "bin/pulsar-admin",
+      "--admin-url",
+      broker.admin_url,
+      "topics",
+      "compaction-status",
+      topic,
+      "--wait-complete"
     ]
 
     case docker_exec(broker.container, command) do
@@ -239,25 +259,6 @@ defmodule Pulsar.Test.Support.System do
     end
   end
 
-  def compacted_topic?(topic, broker \\ broker()) do
-    command = [
-      "bin/pulsar-admin",
-      "--admin-url",
-      broker.admin_url,
-      "topics",
-      "compaction-status",
-      topic
-    ]
-
-    case docker_exec(broker.container, command) do
-      {"Compaction was a success\n", 0} ->
-        true
-
-      _ ->
-        false
-    end
-  end
-
   defp docker_exec(command) do
     broker = broker()
 
@@ -266,13 +267,5 @@ defmodule Pulsar.Test.Support.System do
 
   defp docker_exec(container, command) do
     System.cmd("docker", ["exec", container | command], stderr_to_stdout: true)
-  end
-
-  defp brokers_up? do
-    Enum.all?(@brokers, &broker_up?(&1))
-  end
-
-  defp broker_up?(broker) do
-    {"ok", 0} == System.cmd("curl", ["-s", broker.health_url])
   end
 end

--- a/test/unit/topology_test.exs
+++ b/test/unit/topology_test.exs
@@ -5,7 +5,6 @@ defmodule Pulsar.TopologyTest do
 
   alias Pulsar.Backoff
   alias Pulsar.Client
-  alias Pulsar.Test.Support.Utils
   alias Pulsar.Topology
   alias Pulsar.Topology.Controller
   alias Pulsar.Topology.Group
@@ -408,8 +407,27 @@ defmodule Pulsar.TopologyTest do
 
       assert_receive {:resolved, 2}
       :ok = Topology.await_ready(root, 1_000)
+
+      assert_receive {:telemetry_event,
+                      %{
+                        metadata: %{
+                          desired_partition_count: 2,
+                          partition_count: 2,
+                          success: true
+                        }
+                      }}
+
       assert_receive {:resolved, 4}
-      Utils.wait_for(fn -> length(Topology.groups(root)) == 4 end, timeout: 1_000, interval: 10)
+
+      assert_receive {:telemetry_event,
+                      %{
+                        metadata: %{
+                          desired_partition_count: 4,
+                          partition_count: 4,
+                          success: true
+                        }
+                      }}
+
       assert_receive {:resolved, 2}
 
       assert_receive {:telemetry_event,


### PR DESCRIPTION
### Summary

Continue the work we started in #207 and migrate more tests away from `Utils.wait_for/2` to a simpler and more idiomatic implementation. The mid-term goal is to fully remove [Utils.wait_for/2](https://github.com/efcasado/pulsar-elixir/blob/a8d8bb0e684a3855af861848b44d430ffacaa22f/test/support/utils.ex#L79-L86).