### PR TITLE
fix(consumer): charge chunk permits on arrival

### DIFF
--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -182,11 +182,11 @@ logical message.
 
 ## Flow Control and Permits
 
-Flow control permits are only decremented when messages are assembled and delivered to your callback:
+Flow control tracks chunks as the broker delivers them, before a complete application message exists:
 
-- **Individual chunks arriving**: No permits are decremented yet
-- **Chunked message completed**: Decrements N permits (where N = number of chunks)
-- **Chunked message expired/evicted**: Decrements M permits (where M = number of chunks received)
+- **Individual chunks arriving**: Decrements one permit immediately
+- **Chunked message completed**: Adds no further cost; its chunks were already counted
+- **Chunked message expired/evicted**: Adds no further cost; every received chunk was already counted
 - **Non-chunked message**: Decrements 1 permit
 
 The `Pulsar.Message.num_broker_messages/1` helper returns the correct permit count:
@@ -202,7 +202,10 @@ Pulsar.Message.num_broker_messages(message) # => 3
 Pulsar.Message.num_broker_messages(message) # => 2
 ```
 
-This ensures that flow control accurately reflects the number of broker messages consumed, regardless of whether messages are chunked or not.
+The helper remains useful to application code that needs the total broker cost represented by
+one callback-visible message. The consumer does not wait for that message to exist before updating
+its own window: accounting on arrival lets it refill a window smaller than the number of chunks
+needed to assemble the message.
 
 ## Helper Functions
 

--- a/lib/pulsar/consumer/worker.ex
+++ b/lib/pulsar/consumer/worker.ex
@@ -372,21 +372,25 @@ defmodule Pulsar.Consumer.Worker do
   end
 
   def handle_info({:broker_message, message_data}, state) do
-    {messages, skipped_ids, new_state} =
+    {messages, skipped_ids, new_state, permits_consumed} =
       case message_data do
         {:invalid, command, bytes, validation_error} ->
           report_invalid_message(state, validation_error)
-          {[build_invalid_message(command, bytes, validation_error)], [], state}
+          message = build_invalid_message(command, bytes, validation_error)
+          {[message], [], state, Pulsar.Message.num_broker_messages(message)}
 
         {command, metadata, payload, broker_metadata} ->
           if chunked_message?(metadata) do
             # A chunk is a slice of the compressed message, so it cannot be decompressed
             # before the rest of the slices are back around it.
             {state_after, msgs} = maybe_assemble_chunked_message(state, command, metadata, payload, broker_metadata)
-            {msgs, [], state_after}
+            # Each chunk is one broker delivery, whether or not it completes the message.
+            {msgs, [], state_after, 1}
           else
             {msgs, skipped_ids} = build_messages_from_entry(command, metadata, payload, broker_metadata, state)
-            {msgs, skipped_ids, state}
+            # A skipped message was still sent, and still charged a permit.
+            permits = length(skipped_ids) + Enum.sum(Enum.map(msgs, &Pulsar.Message.num_broker_messages/1))
+            {msgs, skipped_ids, state, permits}
           end
 
         {commands, metadatas, payload, broker_metadatas, %{error: detail} = chunk_metadata} ->
@@ -404,11 +408,9 @@ defmodule Pulsar.Consumer.Worker do
             })
 
           message = build_message_from_chunk(chunk_metadata_full, payload, :incomplete_chunked_message)
-          {[message], [], state}
+          # The received chunks spent their permits on arrival; this delivery is synthetic.
+          {[message], [], state, 0}
       end
-
-    # A skipped message was still sent, and still charged a permit.
-    permits_consumed = length(skipped_ids) + Enum.sum(Enum.map(messages, &Pulsar.Message.num_broker_messages/1))
 
     # Individual acknowledgement counts skipped messages off so the local batch tally can
     # complete. A cumulative acknowledgement follows Java's more conservative rule: filtering
@@ -874,6 +876,8 @@ defmodule Pulsar.Consumer.Worker do
     new_permits = max(state.flow_outstanding_permits - count, 0)
     %{state | flow_outstanding_permits: new_permits}
   end
+
+  defp apply_flow_policy(state, 0), do: state
 
   defp apply_flow_policy(state, consumed) do
     case decide_flow(state, consumed) do

--- a/lib/pulsar/message.ex
+++ b/lib/pulsar/message.ex
@@ -274,7 +274,9 @@ defmodule Pulsar.Message do
   batch count when its payload failed validation after the metadata was decoded.
   For chunked messages, this is the number of chunks actually received.
 
-  This is used for flow control permit accounting.
+  This lets callers relate an application message to the broker deliveries that produced it.
+  The consumer itself charges chunk permits as each chunk arrives, before the application
+  message exists.
 
   ## Examples
 

--- a/lib/pulsar/reader.ex
+++ b/lib/pulsar/reader.ex
@@ -268,9 +268,11 @@ defmodule Pulsar.Reader do
 
   defp next_message(state), do: next_message(state, deadline(state.timeout))
 
-  # A delivery's permits arrive after its messages and are charged once the stream has read past
-  # them, so the window tracks what has been consumed rather than what the broker has sent. They
-  # keep their own deadline: :timeout measures time without a message, and a delivery that
+  # A delivery's permits normally arrive after its messages and are charged once the stream has
+  # read past them, so the window tracks what has been consumed rather than what the broker has
+  # sent. An incomplete chunk has no message to precede its permit report; charging it immediately
+  # lets a window smaller than the chunk count refill until the message can be assembled. Permit
+  # reports keep their own deadline: :timeout measures time without a message, and a delivery that
   # yielded none must not extend it.
   defp next_message(state, deadline) do
     case :queue.out(state.buffer) do

--- a/test/integration/reader/flow_control_test.exs
+++ b/test/integration/reader/flow_control_test.exs
@@ -59,6 +59,29 @@ defmodule Pulsar.Integration.Reader.FlowControlTest do
     refute_granted(consumer_id)
   end
 
+  test "refills while assembling a chunked message wider than its window" do
+    topic = @topic <> "-chunked"
+    payload = String.duplicate("chunked-reader-", 10)
+
+    {:ok, producer} =
+      Pulsar.Producer.start(
+        topic,
+        client: @client,
+        name: :reader_flow_chunked_producer,
+        chunking_enabled: true,
+        max_message_size: 8
+      )
+
+    :ok = Pulsar.Producer.await_ready(producer)
+    assert {:ok, %{num_chunks: num_chunks}} = Pulsar.Producer.send(producer, payload)
+    assert num_chunks > 5
+
+    assert [%{payload: ^payload}] =
+             topic
+             |> Pulsar.Reader.stream(client: @client, flow_permits: 5, timeout: 2_000)
+             |> Enum.take(1)
+  end
+
   # Every test listening for this event is sent every consumer's, so the id picks out ours.
   defp assert_granted(consumer_id, permits) do
     assert_receive {:telemetry_event,

--- a/test/unit/consumer_worker_test.exs
+++ b/test/unit/consumer_worker_test.exs
@@ -543,6 +543,47 @@ defmodule Pulsar.Consumer.WorkerTest do
     end)
   end
 
+  test "charges each chunk as it arrives without charging the assembled message again" do
+    compressed = :zlib.compress(@chunked)
+    half = div(byte_size(compressed), 2)
+    <<first::binary-size(^half), second::binary>> = compressed
+    opts = [uncompressed_size: byte_size(@chunked), total_chunk_msg_size: byte_size(compressed)]
+    state = struct(reporting_state(), max_pending_chunked_messages: 10)
+
+    assert {:noreply, state} = Worker.handle_info(chunk_delivery(0, first, opts), state)
+    assert state.flow_outstanding_permits == 99
+    refute_received {:handled, _message}
+
+    assert {:noreply, state} = Worker.handle_info(chunk_delivery(1, second, opts), state)
+    assert state.flow_outstanding_permits == 98
+    assert_received {:handled, %{payload: @chunked}}
+  end
+
+  test "does not charge an evicted incomplete message after charging its chunks" do
+    state = struct(reporting_state(), max_pending_chunked_messages: 1)
+
+    assert {:noreply, state} =
+             Worker.handle_info(
+               chunk_delivery(0, "first", uuid: "first", num_chunks_from_msg: 3),
+               state
+             )
+
+    assert state.flow_outstanding_permits == 99
+
+    assert {:noreply, state} =
+             Worker.handle_info(
+               chunk_delivery(0, "second", uuid: "second", num_chunks_from_msg: 3),
+               state
+             )
+
+    assert state.flow_outstanding_permits == 98
+    assert_receive {:broker_message, incomplete_delivery}
+
+    assert {:noreply, state} = Worker.handle_info({:broker_message, incomplete_delivery}, state)
+    assert state.flow_outstanding_permits == 98
+    assert_received {:invalid, %{chunk_metadata: %{error: :queue_full, uuid: "first"}}}
+  end
+
   describe "a chunked message that never completes" do
     setup do
       handler = {__MODULE__, :chunk_expired, self()}
@@ -597,6 +638,19 @@ defmodule Pulsar.Consumer.WorkerTest do
       assert_received {:"$gen_cast", {:send_command, %Binary.CommandAck{} = ack}}
       assert ack.validation_error == nil
       assert length(ack.message_id) == 2
+    end
+
+    test "does not charge or refill for an expired incomplete message after charging its chunks", ctx do
+      assert ctx.state.flow_outstanding_permits == 98
+      state = %{ctx.state | flow_threshold: 98, flow_refill: 1}
+
+      assert {:noreply, state} = Worker.handle_info(:cleanup_expired_chunks, age(state, 200))
+      assert state.flow_outstanding_permits == 98
+      assert_receive {:broker_message, incomplete_delivery}
+
+      assert {:noreply, state} = Worker.handle_info({:broker_message, incomplete_delivery}, state)
+      assert state.flow_outstanding_permits == 98
+      refute_received {:"$gen_cast", {:send_command, %Binary.CommandFlow{}}}
     end
 
     test "is left alone while it still has time", ctx do


### PR DESCRIPTION
### Description

Charge each chunk's flow permit when it arrives, preventing messages with more chunks than the consumer window from stalling until expiry.

This bug was not introduced in 3.x; it was already present in 2.x.

Closes #192.